### PR TITLE
chore: убрать «TTRPG SRD» из имени манифеста и заголовка

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -24,7 +24,7 @@ export default defineConfig({
       includeAssets: ['favicon.svg', 'apple-touch-icon.png', 'icon.svg'],
       manifest: {
         id: '/',
-        name: 'OmnisGM Rules — TTRPG SRD',
+        name: 'OmnisGM Rules — tabletop RPG reference',
         short_name: 'OmnisGM Rules',
         description:
           'A fast, offline-ready reader for freely-licensed tabletop RPG System Reference Documents — D&D 5.2.1 / 5.1, Daggerheart, Basic Roleplaying.',

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -13,7 +13,7 @@ const r = (id: string) => {
   return n && !isGroup(n) ? routeOf(n.slug, 'en') : '/en/';
 };
 
-const title = 'OmnisGM Rules — TTRPG SRD reader (D&D, Daggerheart, Basic Roleplaying)';
+const title = 'OmnisGM Rules — tabletop RPG reference (D&D, Daggerheart, Basic Roleplaying)';
 const titleRu = 'OmnisGM Rules — ридер SRD настольных игр (D&D, Daggerheart, BRP)';
 const description =
   'Freely-licensed tabletop RPG System Reference Documents (D&D 5.2.1 / 5.1, Daggerheart, Basic Roleplaying) as Markdown. A project of the OmnisGM ecosystem.';


### PR DESCRIPTION
Проект называется OmnisGM Rules; h1 уже переименованы. Имя PWA и <title> главной → «tabletop RPG reference».

🤖 Generated with [Claude Code](https://claude.com/claude-code)