### PR TITLE
feat(brand): adopt v0.3.0 redesign — purple accent + Spectral display

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/sitemap": "^3.3.0",
-        "@omnisgm-app/brand": "^0.2.0",
+        "@omnisgm-app/brand": "^0.3.0",
         "astro": "^5.7.0"
       },
       "devDependencies": {
@@ -2865,9 +2865,9 @@
       }
     },
     "node_modules/@omnisgm-app/brand": {
-      "version": "0.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.2.0/9f3b51170fbcf3965c1d080aa2194cb138b63492",
-      "integrity": "sha512-EqdVYB9zxr7x+NkpWVOMjgONtD9POghgwifT8mtdlHcjk2H5p+tdhiqMPMNsWLlViifOMMsLokooo7IINHnE4w=="
+      "version": "0.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.3.0/9c20b1d9f61ae2640076cc6f5ef3952e7416e08d",
+      "integrity": "sha512-ZTRpJcHxdqx6AnUpJdoC7AUcdh7MegF9874TXJcUfzxDd7xExQOHz3EMEIjMgwaP0E7bW056u0a14ByNbEk7Og=="
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.3.0",
-    "@omnisgm-app/brand": "^0.2.0",
+    "@omnisgm-app/brand": "^0.3.0",
     "astro": "^5.7.0"
   },
   "devDependencies": {

--- a/web/src/layouts/Reader.astro
+++ b/web/src/layouts/Reader.astro
@@ -22,9 +22,9 @@ const ogAltLocale = lang === 'ru' ? 'en_US' : 'ru_RU';
 
 // Шрифты грузим не блокируя рендер (урок из новостей): preconnect + media=print onload swap + noscript.
 // Запрашиваем только используемые веса: Inter без 700 (нигде не используется),
-// JetBrains 600 вместо 700 (моно-элементы в CSS — 600). Fraunces 700 нужен бренду «OmnisGM».
+// JetBrains 600 вместо 700 (моно-элементы в CSS — 600). Spectral 700 нужен бренду «OmnisGM».
 const FONTS =
-  'https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600&display=swap';
+  'https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600&display=swap';
 ---
 <!DOCTYPE html>
 <html lang={lang} data-title-ru={bilingual ? titleRu : undefined}>

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -2,7 +2,7 @@
 import '@omnisgm-app/brand/tokens.css';
 import '@omnisgm-app/brand/base.css'; // фон body + reset (иначе середина 404 белая)
 const FONTS =
-  'https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,600&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap';
+  'https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,600&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap';
 ---
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
Фаза 4 синка бренд-кита: раскатка **@omnisgm-app/brand v0.3.0** в Rules (намеренный редизайн).

## Что меняется
- **Акцент** синий → фиолетовый `#8B5CF6`
- **Дисплей-шрифт** Fraunces → **Spectral** (`--font-display` из кита; CSS не трогали — ридер использует `var(--font-display)`)
- **Знак/фавиконки** — новый «компас-звезда» из кита (копируются на prebuild)

## Изменения
- `web/package.json`: brand `^0.2.0` → `^0.3.0`
- `web/src/layouts/Reader.astro` + `web/src/pages/404.astro`: Google Fonts `Fraunces` → `Spectral`

## Проверка
- `astro check`: 0 errors / 0 warnings / 3 hints
- e2e (Playwright): **3/3 passed**
- Визуально: заголовки ридера на Spectral serif, CTA-карточка в фиолетовом градиенте

Мержится в `main` → деплой на **прод** (rules.omnisgm.com).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnZqPj9LYvNCSz8MiWxqLo