### PR TITLE
feat(brand): adopt v0.4.0 — text icon/decor rename (zero-diff)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/sitemap": "^3.3.0",
-        "@omnisgm-app/brand": "^0.3.0",
+        "@omnisgm-app/brand": "^0.4.0",
         "astro": "^5.7.0"
       },
       "devDependencies": {
@@ -2865,9 +2865,9 @@
       }
     },
     "node_modules/@omnisgm-app/brand": {
-      "version": "0.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.3.0/9c20b1d9f61ae2640076cc6f5ef3952e7416e08d",
-      "integrity": "sha512-ZTRpJcHxdqx6AnUpJdoC7AUcdh7MegF9874TXJcUfzxDd7xExQOHz3EMEIjMgwaP0E7bW056u0a14ByNbEk7Og=="
+      "version": "0.4.0",
+      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.4.0/ba864e5289832f8902b5083ad274e86d1bb7454b",
+      "integrity": "sha512-MjnvOaLIXHlRKM7/65SfnKxMUq0nhAh0ydfnHxri5TuWpd+9K/wdvKfdUMXzlHK9uSQYodYSFenukLwyTrcu5w=="
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.3.0",
-    "@omnisgm-app/brand": "^0.3.0",
+    "@omnisgm-app/brand": "^0.4.0",
     "astro": "^5.7.0"
   },
   "devDependencies": {

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -88,12 +88,12 @@ const FONTS =
       .nf-brand-link:hover .word { color: var(--og-accent); }
       .nf-brand svg { flex-shrink: 0; }
       .nf-brand .word { font-family: var(--font-display); font-size: 18px; font-weight: 700; letter-spacing: -0.4px; color: var(--og-text); }
-      .nf-brand .sub { font-family: var(--font-mono); font-size: 11.5px; color: var(--og-text-4); letter-spacing: 1px; }
+      .nf-brand .sub { font-family: var(--font-mono); font-size: 11.5px; color: var(--og-decor); letter-spacing: 1px; }
       .nf-nav { display: flex; align-items: center; gap: 28px; }
       .nf-lang { display: inline-flex; align-items: center; border: 1px solid var(--og-border); border-radius: 6px; overflow: hidden; }
       .nf-lang button {
         appearance: none; background: transparent; border: 0; cursor: pointer;
-        font-family: var(--font-mono); font-size: 11px; letter-spacing: 1px; color: var(--og-text-4);
+        font-family: var(--font-mono); font-size: 11px; letter-spacing: 1px; color: var(--og-decor);
         padding: 5px 9px; transition: color .15s, background .15s;
       }
       .nf-lang button:hover { color: var(--og-text-2); }
@@ -101,7 +101,7 @@ const FONTS =
 
       .nf-stage { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 64px 24px; text-align: center; }
       .nf-inner { max-width: 560px; width: 100%; }
-      .nf-tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: 2px; text-transform: uppercase; color: var(--og-text-4); margin-bottom: 32px; }
+      .nf-tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: 2px; text-transform: uppercase; color: var(--og-decor); margin-bottom: 32px; }
       .nf-die { width: 132px; height: 132px; margin: 0 auto 32px; position: relative; transform: rotate(-8deg); }
       .nf-die svg { display: block; width: 100%; height: 100%; overflow: visible; }
       .nf-die .face { fill: var(--og-bg-3); stroke: var(--og-border-strong); stroke-width: 1.5; stroke-linejoin: round; }
@@ -111,19 +111,19 @@ const FONTS =
       .nf-code {
         font-family: var(--font-display); font-weight: 800; font-size: clamp(72px, 18vw, 140px);
         line-height: 0.9; letter-spacing: -0.02em; margin: 0 0 8px;
-        background: linear-gradient(180deg, var(--og-text) 0%, var(--og-text-3) 130%);
+        background: linear-gradient(180deg, var(--og-text) 0%, var(--og-icon) 130%);
         -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
       }
       .nf-title { font-family: var(--font-display); font-weight: 600; font-size: clamp(22px, 4vw, 30px); margin: 0 0 16px; color: var(--og-text); }
       .nf-body { font-size: 16px; line-height: 1.65; color: var(--og-text-2); margin: 0 auto 12px; max-width: 440px; }
-      .nf-roll { font-family: var(--font-mono); font-size: 12.5px; color: var(--og-text-3); margin: 0 auto 36px; }
+      .nf-roll { font-family: var(--font-mono); font-size: 12.5px; color: var(--og-icon); margin: 0 auto 36px; }
       .nf-roll b { color: var(--og-danger); font-weight: 500; }
       .nf-actions { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
       .nf-btn { cursor: pointer; font-family: var(--font-body); font-size: 14px; font-weight: 600; padding: 12px 22px; border-radius: 10px; border: 1px solid var(--og-border-strong); background: var(--og-bg-3); color: var(--og-text); transition: border-color .15s ease, color .15s ease, background .15s ease; }
       .nf-btn:hover { border-color: var(--og-accent); color: var(--og-accent); }
       .nf-btn.primary { background: var(--og-accent); border-color: var(--og-accent); color: #0F1016; }
       .nf-btn.primary:hover { background: var(--og-accent-2); border-color: var(--og-accent-2); color: #0F1016; }
-      .nf-footer { padding: 24px clamp(22px, 6vw, 80px); border-top: 1px solid var(--og-border); background: var(--og-bg-2); display: flex; justify-content: space-between; align-items: center; font-family: var(--font-mono); font-size: 11.5px; color: var(--og-text-4); letter-spacing: 0.3px; }
+      .nf-footer { padding: 24px clamp(22px, 6vw, 80px); border-top: 1px solid var(--og-border); background: var(--og-bg-2); display: flex; justify-content: space-between; align-items: center; font-family: var(--font-mono); font-size: 11.5px; color: var(--og-decor); letter-spacing: 0.3px; }
 
       @keyframes nf-tumble { 0% { transform: rotate(-8deg) translateY(0); } 50% { transform: rotate(-3deg) translateY(-6px); } 100% { transform: rotate(-8deg) translateY(0); } }
       @media (prefers-reduced-motion: no-preference) { .nf-die { animation: nf-tumble 4.5s ease-in-out infinite; } }

--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -34,7 +34,7 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 .rd-brand-sub { font-family: var(--font-mono); font-size: 11px; color: var(--og-text-muted); letter-spacing: 1px; }
 
 .rd-search-wrap { position: relative; flex: 1 1 auto; max-width: 460px; }
-.rd-search-icon { position: absolute; left: 12px; top: 50%; transform: translateY(-50%); color: var(--og-text-4); pointer-events: none; display: flex; }
+.rd-search-icon { position: absolute; left: 12px; top: 50%; transform: translateY(-50%); color: var(--og-decor); pointer-events: none; display: flex; }
 .rd-search {
   width: 100%; appearance: none; background: var(--og-bg-2); color: var(--og-text);
   border: 1px solid var(--og-border); border-radius: 8px;
@@ -136,7 +136,7 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 /* Сворачивание через <details>: прячем нативный маркер, своя каретка вращается на [open] */
 .rd-nav-det > summary { list-style: none; cursor: pointer; }
 .rd-nav-det > summary::-webkit-details-marker { display: none; }
-.rd-nav-caret { display: inline-flex; color: var(--og-text-3); transition: transform .15s ease; flex-shrink: 0; }
+.rd-nav-caret { display: inline-flex; color: var(--og-icon); transition: transform .15s ease; flex-shrink: 0; }
 .rd-nav-det[open] > summary .rd-nav-caret { transform: rotate(90deg); }
 .rd-nav-page {
   width: 100%; display: block; text-align: left; background: none; border: none; text-decoration: none;
@@ -209,7 +209,7 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
   display: flex; gap: 10px; align-items: baseline; flex-wrap: wrap;
   font-family: var(--font-mono); font-size: 11.5px; color: var(--og-text-muted); letter-spacing: 0.3px;
 }
-.rd-source a { display: inline-flex; align-items: center; min-height: 44px; color: var(--og-text-2); border-bottom: 1px dotted var(--og-text-4); }
+.rd-source a { display: inline-flex; align-items: center; min-height: 44px; color: var(--og-text-2); border-bottom: 1px dotted var(--og-decor); }
 .rd-source a:hover { color: var(--og-warm); }
 
 .rd-prevnext { margin-top: 28px; display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
@@ -235,7 +235,7 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 .rd-toc-grp.has-subs > .rd-toc-h2 { position: relative; padding-left: 20px; }
 .rd-toc-grp.has-subs > .rd-toc-h2::before {
   content: ''; position: absolute; left: 7px; top: 50%; width: 6px; height: 6px; margin-top: -3px;
-  border-right: 1.4px solid var(--og-text-3); border-bottom: 1.4px solid var(--og-text-3);
+  border-right: 1.4px solid var(--og-icon); border-bottom: 1.4px solid var(--og-icon);
   transform: rotate(-45deg); transition: transform .15s ease;
 }
 .rd-toc-grp.open.has-subs > .rd-toc-h2::before { transform: rotate(45deg); }
@@ -317,7 +317,7 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 /* десктопная каретка-псевдоэлемент не нужна (h2 не прямой потомок группы) — рисуем кнопку-каретку */
 .rd-toc-caret {
   flex: 0 0 auto; width: 44px; height: 44px; background: none; border: none; cursor: pointer; padding: 0;
-  display: inline-flex; align-items: center; justify-content: center; color: var(--og-text-3);
+  display: inline-flex; align-items: center; justify-content: center; color: var(--og-icon);
 }
 .rd-toc-caret::before {
   content: ''; width: 7px; height: 7px;


### PR DESCRIPTION
Фаза 5b, миграция Rules на двухосевую текст-модель кита v0.4.0.

## Изменения
- brand `^0.3.0` → `^0.4.0`
- `--og-text-3` → `--og-icon` (каретки/аффордансы, значение #71748A без изменений)
- `--og-text-4` → `--og-decor` (иконка поиска, пунктир «Источник», mono-подписи 404; #4E5165 без изменений)
- `--og-text-muted` — без изменений (канон AA, ×16)

## Проверка
- astro check: 0 errors / 0 warnings
- e2e: **3/3 passed**
- **Zero visual diff** — все значения совпадают со старыми (чистое переименование семантики).

Мержится в `main` → прод (rules.omnisgm.com).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BnZqPj9LYvNCSz8MiWxqLo