### PR TITLE
feat(404): adopt shared ecosystem 404 redesign

### DIFF
--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -1,39 +1,150 @@
 ---
-import '@omnisgm-app/brand/tokens.css';
-import '@omnisgm-app/brand/base.css'; // фон body + reset (иначе середина 404 белая)
+// Общий 404 экосистемы OmnisGM (дизайн из DS / @omnisgm-app/brand dist/404.html).
+// Самодостаточный: токены/шрифты инлайн, отдаётся и без CSS приложения.
+// Rules-специфика: home-ссылка учитывает язык в пути (/en/ · /ru/); favicon/manifest.
 const FONTS =
-  'https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,600&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap';
+  'https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,600;0,700;0,800;1,500&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap';
 ---
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>404 — Page not found · OmnisGM</title>
     <meta name="description" content="Page not found. Looks like the Search check came up a natural 1." />
     <meta name="robots" content="noindex" />
+    <meta name="theme-color" content="#0F1117" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href={FONTS} />
-    <meta name="theme-color" content="#0F1016" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="manifest" href="/manifest.webmanifest" />
+    <style is:global>
+      :root {
+        --og-bg:#0F1117; --og-bg-2:#15171F; --og-bg-3:#1C1F29; --og-bg-4:#252935; --og-bg-5:#2E3340;
+        --og-text:#E6E6E9; --og-text-2:#A6A9B8; --og-text-3:#71748A; --og-text-4:#4E5165;
+        --og-blue:#4C7CFF; --og-purple:#8B5CF6;
+        --og-accent:var(--og-purple); --og-accent-hover:#9D74F8;
+        --og-accent-soft:color-mix(in oklab, var(--og-purple) 16%, transparent);
+        --og-accent-line:color-mix(in oklab, var(--og-purple) 34%, transparent);
+        --og-accent-text:#c3adfb; --og-on-accent:#fff;
+        --og-border:#262A36; --og-border-strong:#363B4A; --og-border-soft:#1D202A;
+        --og-danger:#E5484D; --og-danger-text:#f0787c;
+        --og-grad:linear-gradient(135deg, var(--og-blue), var(--og-purple));
+        --og-glow:0 0 40px -6px color-mix(in oklab, var(--og-purple) 55%, transparent);
+        --og-font-display:'Spectral',Georgia,'Times New Roman',serif;
+        --og-font-body:'Inter',system-ui,-apple-system,sans-serif;
+        --og-font-mono:'JetBrains Mono',ui-monospace,'SF Mono',monospace;
+        --og-fast:.14s; --og-med:.24s; --og-ease:cubic-bezier(.2,.7,.2,1);
+        --og-r-xs:6px; --og-r-sm:9px; --og-r-md:12px; --og-r-lg:16px; --og-r-pill:999px;
+      }
+      * { box-sizing:border-box; margin:0; padding:0; }
+      a { color:inherit; text-decoration:none; }
+      button { font-family:inherit; }
+      ::selection { background:color-mix(in oklab, var(--og-purple) 45%, var(--og-bg)); color:var(--og-on-accent); }
+      body {
+        display:flex; flex-direction:column; min-height:100dvh;
+        background:var(--og-bg); color:var(--og-text);
+        font-family:var(--og-font-body); -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
+      }
+      .grain::after {
+        content:''; position:fixed; inset:0; pointer-events:none; mix-blend-mode:overlay; opacity:0.5; z-index:1;
+        background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence baseFrequency='0.85' numOctaves='2' seed='5'/><feColorMatrix values='0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 0.04 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.6'/></svg>");
+      }
+      .nf-header {
+        position:sticky; top:0; z-index:20;
+        padding:22px clamp(22px,6vw,80px);
+        border-bottom:1px solid var(--og-border);
+        display:flex; align-items:center; justify-content:space-between;
+        background:rgba(21,23,31,.72); backdrop-filter:blur(8px);
+      }
+      .nf-brand-link { display:inline-flex; align-items:center; gap:11px; }
+      .nf-brand-link .mark { width:26px; height:26px; flex-shrink:0; }
+      .nf-brand-link .word { font-family:var(--og-font-display); font-size:19px; font-weight:700; letter-spacing:-.3px; color:var(--og-text); transition:color var(--og-fast); }
+      .nf-brand-link:hover .word { color:var(--og-accent-text); }
+      .nf-lang { display:inline-flex; align-items:center; border:1px solid var(--og-border); border-radius:var(--og-r-xs); overflow:hidden; }
+      .nf-lang button { appearance:none; background:transparent; border:0; cursor:pointer; font-family:var(--og-font-mono); font-size:11px; letter-spacing:1px; color:var(--og-text-4); padding:6px 10px; transition:color var(--og-fast), background var(--og-fast); }
+      .nf-lang button:hover { color:var(--og-text-2); }
+      .nf-lang button.active { color:var(--og-accent-text); background:var(--og-accent-soft); }
+
+      .nf-stage { position:relative; flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; padding:64px 24px; text-align:center; overflow:hidden; }
+      .nf-constellation { position:absolute; inset:0; width:100%; height:100%; pointer-events:none; z-index:0;
+        -webkit-mask-image:radial-gradient(120% 100% at 50% 42%, #000 30%, transparent 78%);
+        mask-image:radial-gradient(120% 100% at 50% 42%, #000 30%, transparent 78%); }
+      .nf-inner { position:relative; z-index:2; max-width:600px; width:100%; }
+      .nf-tag { font-family:var(--og-font-mono); font-size:11px; letter-spacing:2px; text-transform:uppercase; color:var(--og-text-3); margin-bottom:30px; }
+
+      .nf-die-wrap { position:relative; width:170px; height:170px; margin:0 auto 34px; display:flex; align-items:center; justify-content:center; }
+      .nf-orbit { position:absolute; inset:0; border-radius:50%; border:1px solid var(--og-accent-line); opacity:.5; }
+      .nf-orbit.o2 { inset:-26px; border-color:color-mix(in oklab, var(--og-purple) 20%, transparent); opacity:.4; }
+      .nf-die { width:128px; height:128px; position:relative; transform:rotate(-8deg); z-index:1; }
+      .nf-die svg { display:block; width:100%; height:100%; overflow:visible; }
+      .nf-die .face { fill:var(--og-bg-3); stroke:var(--og-border-strong); stroke-width:1.5; stroke-linejoin:round; }
+      .nf-die .front { fill:var(--og-bg-4); stroke:var(--og-border-strong); stroke-width:1.2; stroke-linejoin:round; }
+      .nf-die .edge { fill:none; stroke:var(--og-border); stroke-width:1; stroke-linecap:round; }
+      .nf-num { font-family:var(--og-font-display); font-weight:800; font-size:34px; fill:var(--og-danger); text-anchor:middle; dominant-baseline:central; }
+
+      .nf-code {
+        font-family:var(--og-font-display); font-weight:800; font-size:clamp(76px,18vw,150px);
+        line-height:0.9; letter-spacing:-0.02em; margin:0 0 10px;
+        background:linear-gradient(180deg,var(--og-text) 0%,var(--og-text-3) 132%);
+        -webkit-background-clip:text; background-clip:text; -webkit-text-fill-color:transparent;
+      }
+      .nf-title { font-family:var(--og-font-display); font-weight:600; font-size:clamp(23px,4vw,32px); margin:0 0 16px; color:var(--og-text); text-wrap:balance; }
+      .nf-body { font-size:16px; line-height:1.65; color:var(--og-text-2); margin:0 auto 14px; max-width:460px; text-wrap:pretty; }
+      .nf-roll { display:inline-flex; align-items:center; gap:8px; font-family:var(--og-font-mono); font-size:12px; color:var(--og-text-3); margin:0 auto 36px; padding:6px 12px; border:1px solid var(--og-border); border-radius:var(--og-r-pill); background:var(--og-bg-2); }
+      .nf-roll .dot { width:6px; height:6px; border-radius:50%; background:var(--og-danger); flex-shrink:0; }
+      .nf-roll b { color:var(--og-danger-text); font-weight:500; }
+
+      .nf-actions { display:flex; gap:12px; justify-content:center; flex-wrap:wrap; }
+      .og-btn { display:inline-flex; align-items:center; justify-content:center; gap:8px; min-height:44px; height:44px; padding:0 22px; font-family:var(--og-font-body); font-size:14px; font-weight:600; letter-spacing:-.1px; line-height:1; border:1px solid transparent; border-radius:var(--og-r-sm); cursor:pointer; white-space:nowrap; transition:background var(--og-fast) var(--og-ease), border-color var(--og-fast), filter var(--og-fast), box-shadow var(--og-med), transform var(--og-fast); }
+      .og-btn:active { transform:translateY(1px); }
+      .og-btn--hero { background:var(--og-grad); color:var(--og-on-accent); }
+      .og-btn--hero:hover { box-shadow:var(--og-glow); filter:brightness(1.06); }
+
+      .nf-footer { position:relative; z-index:2; padding:24px clamp(22px,6vw,80px); border-top:1px solid var(--og-border); background:var(--og-bg-2); display:flex; justify-content:space-between; align-items:center; gap:12px; font-family:var(--og-font-mono); font-size:11.5px; color:var(--og-text-4); letter-spacing:0.3px; }
+
+      @keyframes nf-tumble { 0%{transform:rotate(-8deg) translateY(0);} 50%{transform:rotate(-3deg) translateY(-6px);} 100%{transform:rotate(-8deg) translateY(0);} }
+      @keyframes nf-spin { to { transform:rotate(360deg); } }
+      @keyframes nf-tw { 0%,100%{ opacity:var(--o,.6); } 50%{ opacity:.08; } }
+      @media (prefers-reduced-motion:no-preference) {
+        .nf-die { animation:nf-tumble 4.5s ease-in-out infinite; }
+        .nf-orbit-spin { transform-origin:400px 300px; animation:nf-spin 180s linear infinite; }
+        .nf-tw { animation:nf-tw var(--d,4s) ease-in-out var(--dl,0s) infinite; }
+      }
+      @media (max-width:720px) { .nf-footer { flex-direction:column; gap:6px; text-align:center; } }
+    </style>
   </head>
   <body class="grain">
+
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <linearGradient id="og-grad" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" stop-color="#4C7CFF"/><stop offset="1" stop-color="#8B5CF6"/>
+        </linearGradient>
+        <radialGradient id="og-star-glow" cx="0.5" cy="0.5" r="0.5">
+          <stop offset="0" stop-color="#EDE7FF" stop-opacity="0.95"/>
+          <stop offset="0.4" stop-color="#A98BFF" stop-opacity="0.5"/>
+          <stop offset="1" stop-color="#8B5CF6" stop-opacity="0"/>
+        </radialGradient>
+        <symbol id="mark" viewBox="0 0 120 120">
+          <circle cx="60" cy="60" r="37" fill="none" stroke="url(#og-grad)" stroke-width="2.4"/>
+          <path d="M60 12 L66 23 L60 34 L54 23 Z" fill="url(#og-grad)"/>
+          <path d="M60 86 L66 97 L60 108 L54 97 Z" fill="url(#og-grad)"/>
+          <path d="M108 60 L97 66 L86 60 L97 54 Z" fill="url(#og-grad)"/>
+          <path d="M12 60 L23 54 L34 60 L23 66 Z" fill="url(#og-grad)"/>
+          <circle cx="60" cy="60" r="15" fill="url(#og-star-glow)"/>
+          <path d="M60 38 Q63.5 56.5 82 60 Q63.5 63.5 60 82 Q56.5 63.5 38 60 Q56.5 56.5 60 38 Z" fill="url(#og-grad)"/>
+        </symbol>
+      </defs>
+    </svg>
+
     <header class="nf-header">
-      <div class="nf-brand">
-        <a href="https://omnisgm.com" class="nf-brand-link" aria-label="OmnisGM">
-          <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
-            <circle cx="12" cy="12" r="9.5" stroke="var(--og-accent)" stroke-width="1.2" fill="none" />
-            <circle cx="12" cy="12" r="6" stroke="var(--og-accent)" stroke-width="0.8" fill="none" opacity="0.5" />
-            <circle cx="12" cy="12" r="2" fill="var(--og-accent)" />
-            <path d="M12 2.5v3M12 18.5v3M2.5 12h3M18.5 12h3" stroke="var(--og-accent)" stroke-width="1" stroke-linecap="round" />
-          </svg>
-          <span class="word">OmnisGM</span>
-        </a>
-        <span class="sub">/ rules</span>
-      </div>
-      <nav class="nf-nav">
+      <a href="https://omnisgm.com" class="nf-brand-link" aria-label="OmnisGM">
+        <svg class="mark"><use href="#mark"/></svg>
+        <span class="word">OmnisGM</span>
+      </a>
+      <nav>
         <div class="nf-lang" role="group" aria-label="Language">
           <button data-lang="en">EN</button>
           <button data-lang="ru">RU</button>
@@ -42,105 +153,106 @@ const FONTS =
     </header>
 
     <main class="nf-stage">
+      <svg class="nf-constellation" id="nf-constellation" viewBox="0 0 800 600" preserveAspectRatio="xMidYMid slice" aria-hidden="true"></svg>
+
       <div class="nf-inner">
         <div class="nf-tag" data-ru="OmnisGM · Ошибка 404" data-en="OmnisGM · Error 404">OmnisGM · Error 404</div>
 
-        <div class="nf-die" aria-hidden="true">
-          <svg viewBox="0 0 120 120">
-            <polygon class="face" points="60,6 106.8,33 106.8,87 60,114 13.2,87 13.2,33" />
-            <path class="edge" d="M60,42 L60,6 M60,42 L13.2,33 M60,42 L106.8,33 M37,81 L13.2,33 M37,81 L13.2,87 M37,81 L60,114 M83,81 L106.8,33 M83,81 L106.8,87 M83,81 L60,114" />
-            <polygon class="front" points="60,42 37,81 83,81" />
-            <text class="nf-num" x="60" y="69">1</text>
-          </svg>
+        <div class="nf-die-wrap" aria-hidden="true">
+          <span class="nf-orbit"></span>
+          <span class="nf-orbit o2"></span>
+          <div class="nf-die">
+            <svg viewBox="0 0 120 120">
+              <polygon class="face" points="60,6 106.8,33 106.8,87 60,114 13.2,87 13.2,33" />
+              <path class="edge" d="M60,42 L60,6 M60,42 L13.2,33 M60,42 L106.8,33 M37,81 L13.2,33 M37,81 L13.2,87 M37,81 L60,114 M83,81 L106.8,33 M83,81 L106.8,87 M83,81 L60,114" />
+              <polygon class="front" points="60,42 37,81 83,81" />
+              <text class="nf-num" x="60" y="69">1</text>
+            </svg>
+          </div>
         </div>
 
         <h1 class="nf-code">404</h1>
         <h2 class="nf-title" data-ru="Эта страница потерялась в подземелье" data-en="This page got lost in the dungeon">This page got lost in the dungeon</h2>
         <p class="nf-body" data-ru="Свиток, который вы искали, рассыпался в прах — или его здесь никогда и не было. Проверьте адрес или вернитесь к началу приключения." data-en="The scroll you were looking for crumbled to dust — or was never here at all. Check the address or return to the start of the adventure.">The scroll you were looking for crumbled to dust — or was never here at all. Check the address or return to the start of the adventure.</p>
-        <p class="nf-roll" data-ru="Бросок на Поиск: |натуральная 1| — критический провал." data-en="Search check: |natural 1| — critical failure.">Search check: <b>natural 1</b> — critical failure.</p>
+        <p class="nf-roll" data-ru="Бросок на Поиск: |натуральная 1| — критический провал." data-en="Search check: |natural 1| — critical failure."><span class="dot"></span><span class="nf-roll-txt">Search check: <b>natural 1</b> — critical failure.</span></p>
 
         <div class="nf-actions">
-          <a class="nf-btn primary nf-home" href="/en/" data-href-ru="/ru/" data-href-en="/en/" data-ru="← На главную" data-en="← Home">← Home</a>
+          <a class="og-btn og-btn--hero nf-home" href="/en/" data-href-ru="/ru/" data-href-en="/en/" data-ru="← На главную" data-en="← Home">← Home</a>
         </div>
       </div>
     </main>
 
     <footer class="nf-footer">
       <span data-ru="© 2026 OmnisGM. Сделано в одиночку, медленно, осознанно." data-en="© 2026 OmnisGM. Built solo, slowly, deliberately.">© 2026 OmnisGM. Built solo, slowly, deliberately.</span>
-      <span>rules.omnisgm.com</span>
+      <span id="nf-host">rules.omnisgm.com</span>
     </footer>
 
-    <style>
-      body { display: flex; flex-direction: column; min-height: 100vh; font-family: var(--font-body); }
-      .grain { position: relative; }
-      .grain::after {
-        content: ''; position: absolute; inset: 0; pointer-events: none;
-        background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence baseFrequency='0.85' numOctaves='2' seed='5'/><feColorMatrix values='0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 0.04 0'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.6'/></svg>");
-        mix-blend-mode: overlay; opacity: 0.5;
-      }
-      .nf-header {
-        padding: 22px clamp(22px, 6vw, 80px); border-bottom: 1px solid var(--og-border);
-        display: flex; align-items: center; justify-content: space-between;
-        background: rgba(15,14,19,0.85); backdrop-filter: blur(8px); position: sticky; top: 0; z-index: 20;
-      }
-      .nf-brand { display: flex; align-items: center; gap: 9px; }
-      .nf-brand-link { display: inline-flex; align-items: center; gap: 10px; }
-      .nf-brand-link:hover .word { color: var(--og-accent); }
-      .nf-brand svg { flex-shrink: 0; }
-      .nf-brand .word { font-family: var(--font-display); font-size: 18px; font-weight: 700; letter-spacing: -0.4px; color: var(--og-text); }
-      .nf-brand .sub { font-family: var(--font-mono); font-size: 11.5px; color: var(--og-decor); letter-spacing: 1px; }
-      .nf-nav { display: flex; align-items: center; gap: 28px; }
-      .nf-lang { display: inline-flex; align-items: center; border: 1px solid var(--og-border); border-radius: 6px; overflow: hidden; }
-      .nf-lang button {
-        appearance: none; background: transparent; border: 0; cursor: pointer;
-        font-family: var(--font-mono); font-size: 11px; letter-spacing: 1px; color: var(--og-decor);
-        padding: 5px 9px; transition: color .15s, background .15s;
-      }
-      .nf-lang button:hover { color: var(--og-text-2); }
-      .nf-lang button.active { color: var(--og-accent); background: var(--og-bg-3); }
-
-      .nf-stage { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 64px 24px; text-align: center; }
-      .nf-inner { max-width: 560px; width: 100%; }
-      .nf-tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: 2px; text-transform: uppercase; color: var(--og-decor); margin-bottom: 32px; }
-      .nf-die { width: 132px; height: 132px; margin: 0 auto 32px; position: relative; transform: rotate(-8deg); }
-      .nf-die svg { display: block; width: 100%; height: 100%; overflow: visible; }
-      .nf-die .face { fill: var(--og-bg-3); stroke: var(--og-border-strong); stroke-width: 1.5; stroke-linejoin: round; }
-      .nf-die .front { fill: var(--og-bg-4); stroke: var(--og-border-strong); stroke-width: 1.2; stroke-linejoin: round; }
-      .nf-die .edge { fill: none; stroke: var(--og-border); stroke-width: 1; stroke-linecap: round; }
-      .nf-num { font-family: var(--font-display); font-weight: 700; font-size: 32px; fill: var(--og-danger); text-anchor: middle; dominant-baseline: central; }
-      .nf-code {
-        font-family: var(--font-display); font-weight: 800; font-size: clamp(72px, 18vw, 140px);
-        line-height: 0.9; letter-spacing: -0.02em; margin: 0 0 8px;
-        background: linear-gradient(180deg, var(--og-text) 0%, var(--og-icon) 130%);
-        -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
-      }
-      .nf-title { font-family: var(--font-display); font-weight: 600; font-size: clamp(22px, 4vw, 30px); margin: 0 0 16px; color: var(--og-text); }
-      .nf-body { font-size: 16px; line-height: 1.65; color: var(--og-text-2); margin: 0 auto 12px; max-width: 440px; }
-      .nf-roll { font-family: var(--font-mono); font-size: 12.5px; color: var(--og-icon); margin: 0 auto 36px; }
-      .nf-roll b { color: var(--og-danger); font-weight: 500; }
-      .nf-actions { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
-      .nf-btn { cursor: pointer; font-family: var(--font-body); font-size: 14px; font-weight: 600; padding: 12px 22px; border-radius: 10px; border: 1px solid var(--og-border-strong); background: var(--og-bg-3); color: var(--og-text); transition: border-color .15s ease, color .15s ease, background .15s ease; }
-      .nf-btn:hover { border-color: var(--og-accent); color: var(--og-accent); }
-      .nf-btn.primary { background: var(--og-accent); border-color: var(--og-accent); color: #0F1016; }
-      .nf-btn.primary:hover { background: var(--og-accent-2); border-color: var(--og-accent-2); color: #0F1016; }
-      .nf-footer { padding: 24px clamp(22px, 6vw, 80px); border-top: 1px solid var(--og-border); background: var(--og-bg-2); display: flex; justify-content: space-between; align-items: center; font-family: var(--font-mono); font-size: 11.5px; color: var(--og-decor); letter-spacing: 0.3px; }
-
-      @keyframes nf-tumble { 0% { transform: rotate(-8deg) translateY(0); } 50% { transform: rotate(-3deg) translateY(-6px); } 100% { transform: rotate(-8deg) translateY(0); } }
-      @media (prefers-reduced-motion: no-preference) { .nf-die { animation: nf-tumble 4.5s ease-in-out infinite; } }
-      @media (max-width: 720px) { .nf-footer { flex-direction: column; gap: 6px; text-align: center; } }
-    </style>
-
     <script is:inline>
+      /* ---------- Фирменный принт: орбиты + звёздное поле ---------- */
+      (function drawConstellation() {
+        var svg = document.getElementById('nf-constellation');
+        if (!svg) return;
+        var W = 800, H = 600, cx = 400, cy = 300;
+        var PUR = '#8B5CF6', BLU = '#6E97FF', WHT = '#C9CCF0';
+        var seed = 11;
+        function rnd() { seed = (seed * 9301 + 49297) % 233280; return seed / 233280; }
+        var orbits = [70, 128, 196, 274, 360];
+        var bg = '', beads = '';
+
+        bg += '<line x1="24" y1="' + cy + '" x2="' + (W - 24) + '" y2="' + cy + '" stroke="' + PUR + '" stroke-opacity=".10" stroke-width="1"/>';
+        bg += '<line x1="' + cx + '" y1="10" x2="' + cx + '" y2="' + (H - 10) + '" stroke="' + PUR + '" stroke-opacity=".10" stroke-width="1"/>';
+
+        orbits.forEach(function (r, i) {
+          var op = (0.26 - i * 0.04).toFixed(2);
+          bg += '<circle cx="' + cx + '" cy="' + cy + '" r="' + r + '" fill="none" stroke="' + PUR + '" stroke-opacity="' + op + '" stroke-width="1"/>';
+          [[cx, cy - r], [cx, cy + r], [cx - r, cy], [cx + r, cy]].forEach(function (p) {
+            bg += '<circle cx="' + p[0] + '" cy="' + p[1] + '" r="1.5" fill="' + PUR + '" fill-opacity="' + (+op + 0.22).toFixed(2) + '"/>';
+          });
+        });
+
+        orbits.forEach(function (r, i) {
+          var n = 4 + i;
+          for (var k = 0; k < n; k++) {
+            var a = rnd() * Math.PI * 2;
+            var x = cx + Math.cos(a) * r, y = cy + Math.sin(a) * r;
+            var rr = (rnd() * 1.3 + 1).toFixed(1);
+            var col = rnd() > 0.8 ? BLU : PUR;
+            beads += '<circle cx="' + x.toFixed(1) + '" cy="' + y.toFixed(1) + '" r="' + rr + '" fill="' + col + '" fill-opacity="' + (0.4 + rnd() * 0.35).toFixed(2) + '"/>';
+          }
+        });
+
+        for (var s = 0; s < 130; s++) {
+          var x = rnd() * W, y = rnd() * H;
+          if (Math.hypot(x - cx, y - cy) < 54) continue;
+          var r = (rnd() * 1.6 + 0.4).toFixed(1);
+          var o = (0.12 + rnd() * 0.5);
+          var col = rnd() > 0.85 ? BLU : (rnd() > 0.94 ? WHT : PUR);
+          var tw = rnd() > 0.6;
+          var attr = tw
+            ? ' class="nf-tw" style="--o:' + o.toFixed(2) + ';--d:' + (2.5 + rnd() * 4).toFixed(1) + 's;--dl:' + (rnd() * 4).toFixed(1) + 's"'
+            : ' fill-opacity="' + o.toFixed(2) + '"';
+          bg += '<circle cx="' + x.toFixed(1) + '" cy="' + y.toFixed(1) + '" r="' + r + '" fill="' + col + '"' + attr + '/>';
+        }
+
+        svg.innerHTML = bg + '<g class="nf-orbit-spin">' + beads + '</g>';
+      })();
+
+      /* ---------- Локализация RU / EN + host + lang-home ---------- */
       (function () {
         var STRINGS = { ru: { title: '404 — Страница не найдена · OmnisGM' }, en: { title: '404 — Page not found · OmnisGM' } };
+        var host = document.getElementById('nf-host'); if (host) host.textContent = location.host || 'rules.omnisgm.com';
         function applyLang(lang) {
           document.documentElement.lang = lang;
           document.title = STRINGS[lang].title;
           document.querySelectorAll('[data-ru]').forEach(function (el) {
             var txt = el.getAttribute('data-' + lang);
             if (txt == null) return;
-            if (txt.indexOf('|') !== -1) el.innerHTML = txt.replace(/\|([^|]+)\|/g, '<b>$1</b>');
-            else el.textContent = txt;
+            if (txt.indexOf('|') !== -1) {
+              var slot = el.querySelector('.nf-roll-txt') || el;
+              slot.innerHTML = txt.replace(/\|([^|]+)\|/g, '<b>$1</b>');
+            } else {
+              el.textContent = txt;
+            }
           });
           var home = document.querySelector('.nf-home');
           if (home) home.setAttribute('href', home.getAttribute('data-href-' + lang));
@@ -151,7 +263,7 @@ const FONTS =
         }
         var saved = 'en';
         try { saved = localStorage.getItem('omnis-lang') || 'en'; } catch (e) {}
-        if (saved !== 'ru' && saved !== 'en') saved = 'en';
+        if (saved !== 'ru' && saved !== 'en') saved = (navigator.language || '').toLowerCase().indexOf('ru') === 0 ? 'ru' : 'en';
         document.querySelectorAll('.nf-lang button').forEach(function (b) {
           b.addEventListener('click', function () { applyLang(b.getAttribute('data-lang')); });
         });


### PR DESCRIPTION
Раскатка нового общего 404 (DS) в Rules. SSG отдаёт статику — реальный прод-404 на rules.omnisgm.com.

## Что
- Заменён `src/pages/404.astro` на общий дизайн: компас-звезда, созвездие-принт, орбиты вокруг d20 «натуральная 1», фиолет+Spectral, hero-кнопка.
- Самодостаточный (инлайн токены/шрифты); Rules-специфика: home учитывает язык (/en/·/ru/), favicon/manifest, host из location.host.
- `<style is:global>` — созвездие инжектится JS, scoped-стили к нему бы не применились.

## Проверка
- astro check 0/0; build ок; **e2e 404.spec passed** (status 404, .nf-code=404, тёмный бренд-фон); рендер-скриншот чистый (созвездие 181, без JS-ошибок).

Мержится в `main` → прод.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BnZqPj9LYvNCSz8MiWxqLo