### PR TITLE
feat(seo): hreflang-пары на всех контентных страницах и хабах (#13)

### DIFF
--- a/web/e2e/lang.spec.ts
+++ b/web/e2e/lang.spec.ts
@@ -10,3 +10,44 @@ test('тумблер языка переключает EN → RU', async ({ page
   await expect(page).toHaveURL(/\/ru\//);
   await expect(page.locator('html')).toHaveAttribute('lang', 'ru');
 });
+
+// hreflang: три взаимных тега (en/ru/x-default) с абсолютными URL на каждой странице.
+// Собираем { hreflang → href } из <head>. Проверяем ровно три ключа и абсолютность URL.
+async function hreflangMap(page: import('@playwright/test').Page) {
+  return page.$$eval('head link[rel="alternate"][hreflang]', (ls) =>
+    Object.fromEntries(ls.map((l) => [l.getAttribute('hreflang'), l.getAttribute('href')])),
+  );
+}
+
+const EN_CONTENT = '/en/dnd/srd-5.2/legal/';
+const RU_CONTENT = '/ru/dnd/srd-5.2/legal/';
+
+test('hreflang: контентная EN-страница — 3 абсолютных тега, x-default → EN', async ({ page }) => {
+  await page.goto(EN_CONTENT);
+  const m = await hreflangMap(page);
+  expect(Object.keys(m).sort()).toEqual(['en', 'ru', 'x-default']);
+  for (const href of Object.values(m)) expect(href).toMatch(/^https?:\/\//);
+  expect(new URL(m.en!).pathname).toBe(EN_CONTENT);
+  expect(new URL(m.ru!).pathname).toBe(RU_CONTENT);
+  expect(m['x-default']).toBe(m.en); // на контентных x-default зеркалит EN-версию
+});
+
+test('hreflang: RU-пара выводит ту же тройку (взаимность)', async ({ page }) => {
+  await page.goto(EN_CONTENT);
+  const en = await hreflangMap(page);
+  await page.goto(RU_CONTENT);
+  const ru = await hreflangMap(page);
+  expect(ru).toEqual(en); // взаимность: односторонний hreflang Google игнорирует
+});
+
+test('hreflang: хаб /en/ и корень / дают согласованную тройку', async ({ page }) => {
+  await page.goto('/en/');
+  const hub = await hreflangMap(page);
+  expect(new URL(hub.en!).pathname).toBe('/en/');
+  expect(new URL(hub.ru!).pathname).toBe('/ru/');
+  expect(new URL(hub['x-default']!).pathname).toBe('/'); // хаб-кластер: x-default → корень
+
+  await page.goto('/');
+  const root = await hreflangMap(page);
+  expect(root).toEqual(hub); // корень и хабы — один кластер, тройка совпадает
+});

--- a/web/src/components/ReaderShell.astro
+++ b/web/src/components/ReaderShell.astro
@@ -48,6 +48,16 @@ const currentPath = Astro.url.pathname;
 const enUrl = lang === 'en' ? currentPath : counterpart;
 const ruUrl = lang === 'ru' ? currentPath : counterpart;
 
+// hreflang-пары (пути от корня) — та же парность slug'ов, что и у переключателя языка.
+// Корень (bilingual) выводит тройку сам; здесь — контентные страницы и хабы систем.
+//  • контентная (curSlug != null): en/ru — маршруты пары, x-default → EN.
+//  • хаб/вкладка (curSlug == null, не корень): /en/ ↔ /ru/, x-default → «/» (зеркало корня-кластера).
+const alternates = bilingual
+  ? undefined
+  : curSlug != null
+    ? { en: routeOf(curSlug, 'en'), ru: routeOf(curSlug, 'ru'), xDefault: routeOf(curSlug, 'en') }
+    : { en: '/en/', ru: '/ru/', xDefault: '/' };
+
 const idx = FLAT_PAGES.findIndex((p) => p.id === currentId);
 const prev = idx > 0 ? FLAT_PAGES[idx - 1] : null;
 const next = idx >= 0 && idx < FLAT_PAGES.length - 1 ? FLAT_PAGES[idx + 1] : null;
@@ -103,7 +113,7 @@ const searchUi = {
   },
 };
 ---
-<Reader title={title} description={description} lang={lang} bilingual={bilingual} titleRu={titleRu} jsonLd={jsonLd}>
+<Reader title={title} description={description} lang={lang} bilingual={bilingual} titleRu={titleRu} jsonLd={jsonLd} alternates={alternates}>
   <div class="rd-root">
     {/* Мобильные тогглы на CSS-радио (без JS): якоря первыми в .rd-root. Общий name="rd-panel"
         делает панели взаимоисключающими; rd-panel-none — закрытое состояние (по умолчанию).

--- a/web/src/layouts/Reader.astro
+++ b/web/src/layouts/Reader.astro
@@ -12,8 +12,9 @@ export interface Props {
   titleRu?: string;      // RU-заголовок для свопа document.title при bilingual
   image?: string;        // og:image (путь от корня); по умолчанию /og.png
   jsonLd?: object;       // граф schema.org (Organization/WebSite/BreadcrumbList/Article)
+  alternates?: { en: string; ru: string; xDefault: string }; // hreflang-пары (пути от корня) для не-корневых страниц
 }
-const { title, description = '', lang = 'en', canonical, bilingual = false, titleRu, image = '/og.png', jsonLd } = Astro.props;
+const { title, description = '', lang = 'en', canonical, bilingual = false, titleRu, image = '/og.png', jsonLd, alternates } = Astro.props;
 const canonicalURL = canonical ?? new URL(Astro.url.pathname, Astro.site).toString();
 const ORIGIN = Astro.site ? Astro.site.origin : 'https://rules.omnisgm.com';
 const imageURL = new URL(image, ORIGIN).toString();
@@ -47,11 +48,20 @@ const FONTS =
     <title>{title}</title>
     {description && <meta name="description" content={description} />}
     <link rel="canonical" href={canonicalURL} />
+    {/* hreflang-кластер. Взаимоисключающе: корень «/» — через bilingual; остальные страницы — через alternates.
+        Google требует взаимности (односторонний hreflang игнорируется) — RU/EN-пара выводит одинаковую тройку. */}
     {bilingual && (
       <>
         <link rel="alternate" hreflang="en" href={`${ORIGIN}/en/`} />
         <link rel="alternate" hreflang="ru" href={`${ORIGIN}/ru/`} />
         <link rel="alternate" hreflang="x-default" href={`${ORIGIN}/`} />
+      </>
+    )}
+    {!bilingual && alternates && (
+      <>
+        <link rel="alternate" hreflang="en" href={`${ORIGIN}${alternates.en}`} />
+        <link rel="alternate" hreflang="ru" href={`${ORIGIN}${alternates.ru}`} />
+        <link rel="alternate" hreflang="x-default" href={`${ORIGIN}${alternates.xDefault}`} />
       </>
     )}
 


### PR DESCRIPTION
Closes #13.

## Что сделано
hreflang-тройка (`en` / `ru` / `x-default`) теперь рендерится на **каждой** контентной странице и хабе систем, а не только на корне `/`. Это чинит взаимность, которую требует Google (односторонний hreflang игнорируется), — на этом стоит вся RU-стратегия спринта (`OMNISGM-SEO-SPRINT-JULY.md` §2.1).

## Изменения (2 файла + тест)
- **`web/src/layouts/Reader.astro`** — новый проп `alternates?: { en; ru; xDefault }` (пути от корня). В `<head>` три `<link rel="alternate" hreflang=…>` с `ORIGIN`-префиксом. Блок взаимоисключается с `bilingual` (корень).
- **`web/src/components/ReaderShell.astro`** — вычисление `alternates` из парных slug'ов (та же логика, что у переключателя языка EN/RU):
  - контентная: `en → /en/<slug>/`, `ru → /ru/<slug>/`, `x-default → EN`;
  - хаб `/en/ ↔ /ru/`: `x-default → /` (зеркало корня-кластера);
  - корень (`bilingual`): не трогаем; 404: `ReaderShell` там не используется.
- **`web/e2e/lang.spec.ts`** — 3 теста: ровно 3 абсолютных тега на EN-странице (x-default → EN), взаимность RU-пары, согласованность кластера хаб/корень.

## Проверка
- `npm run check` — 0 ошибок.
- `npm run build` + grep по `dist/`: **113 EN ↔ 113 RU**, страниц без hreflang нет, битых пар нет (взаимность по всем ~226 страницам, надёжнее выборочного curl). 404 — без hreflang.
- `npx playwright test lang` — 4/4 зелёных.
- Осталось (по критериям issue, после деплоя): внешний hreflang-checker (Merkle/Ahrefs) без ошибок взаимности.

🤖 Generated with [Claude Code](https://claude.com/claude-code)