### PR TITLE
fix(analytics): GA4 через PUBLIC_-префикс env (#18)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,9 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
+          # Astro отдаёт клиентским скриптам только PUBLIC_-переменные — gtag читает именно её (#18).
+          # Значение то же (секрет не переименовываем); VITE_-строку оставляем для firebaseConfig.
+          PUBLIC_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
 
       # Сброс edge-кэша Cloudflare после деплоя — точечно, фикс-имена на rules.omnisgm.com
       # (иконки/favicon/manifest/sw/og кэшируются на edge; HTML/хэш-ассеты не трогаем).

--- a/web/src/lib/analytics-client.ts
+++ b/web/src/lib/analytics-client.ts
@@ -2,7 +2,10 @@
 // это GA4 под капотом). Намеренно НЕ тащим firebase SDK в бандл: грузим лёгкий gtag с Google CDN
 // отложенно (не влияет на LCP). Без measurementId — тихо пропускаем.
 // Экспортит window.omnisTrack(name, params) для событий (клик CTA-воронки в лист персонажа).
-const ID = import.meta.env.VITE_FIREBASE_MEASUREMENT_ID as string | undefined;
+// Префикс PUBLIC_, а не VITE_: Astro отдаёт клиентским скриптам только PUBLIC_-переменные
+// (переопределяет vite'овский envPrefix). С VITE_ значение на клиенте — undefined, и минификатор
+// вырезал весь gtag-блок из бандла (GA4 не работал на проде вообще). См. #18.
+const ID = import.meta.env.PUBLIC_FIREBASE_MEASUREMENT_ID as string | undefined;
 
 declare global {
   interface Window {


### PR DESCRIPTION
Closes #18.

## Проблема
GA4 на проде **не работал никогда**. Astro отдаёт клиентским скриптам только env-переменные с префиксом `PUBLIC_` (переопределяет vite'овский `envPrefix`). `import.meta.env.VITE_FIREBASE_MEASUREMENT_ID` в `analytics-client.ts` на клиенте всегда `undefined` → минификатор видит `if (!ID) return` и вырезает весь gtag-блок из бандла. Секреты/инфраструктура были в порядке — дело в префиксе.

## Фикс (2 файла)
- **`web/src/lib/analytics-client.ts`** — `VITE_` → `PUBLIC_FIREBASE_MEASUREMENT_ID` (+ комментарий с причиной).
- **`.github/workflows/deploy.yml`** — прокидываем `PUBLIC_FIREBASE_MEASUREMENT_ID` из того же секрета `VITE_FIREBASE_MEASUREMENT_ID` (переименовывать секрет не нужно; `VITE_`-строку оставил — она нужна для `firebaseConfig`).

## Проверка
- `npm run check` — 0 ошибок.
- `PUBLIC_FIREBASE_MEASUREMENT_ID=G-RRH57ELLZS astro build`: `gtag/js` и measurementId вшиты во **все 227 страниц** `dist/` (до фикса — **0**).
- `npm run test:e2e` — 6/6.
- Побочно чинит CTA-воронку: `window.omnisTrack` теперь существует (раньше onclick звал несуществующую функцию), события `cta_character_sheet` начнут считаться.

## После мёржа
Деплой → `analytics.google.com` → property omnisgm-rules → Realtime: свой визит должен быть виден.

🤖 Generated with [Claude Code](https://claude.com/claude-code)