### PR TITLE
fix(seo): hreflang и тумблер языка на страницах вне nav-дерева (#13)

### DIFF
--- a/web/e2e/lang.spec.ts
+++ b/web/e2e/lang.spec.ts
@@ -51,3 +51,26 @@ test('hreflang: хаб /en/ и корень / дают согласованну�
   const root = await hreflangMap(page);
   expect(root).toEqual(hub); // корень и хабы — один кластер, тройка совпадает
 });
+
+// Страница ВНЕ nav-дерева (обзор группы «Классы»): пара должна строиться от URL,
+// а не от nav — иначе такие страницы выводили корневую тройку («no return tag»)
+// и переключатель языка вёл на хаб вместо зеркала.
+const EN_OFFNAV = '/en/dnd/srd-5.2/classes/classes/';
+const RU_OFFNAV = '/ru/dnd/srd-5.2/classes/classes/';
+
+test('hreflang: вне-nav страница связывает собственную EN↔RU-пару', async ({ page }) => {
+  await page.goto(EN_OFFNAV);
+  const m = await hreflangMap(page);
+  expect(new URL(m.en!).pathname).toBe(EN_OFFNAV);
+  expect(new URL(m.ru!).pathname).toBe(RU_OFFNAV);
+  expect(m['x-default']).toBe(m.en);
+
+  await page.goto(RU_OFFNAV);
+  expect(await hreflangMap(page)).toEqual(m); // взаимность
+});
+
+test('тумблер языка на вне-nav странице ведёт на зеркало, а не на хаб', async ({ page }) => {
+  await page.goto(EN_OFFNAV);
+  await page.locator('.rd-lang-btn', { hasText: 'RU' }).click();
+  await expect(page).toHaveURL(new RegExp(RU_OFFNAV.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '$'));
+});

--- a/web/src/components/ReaderShell.astro
+++ b/web/src/components/ReaderShell.astro
@@ -7,7 +7,7 @@ import markRaw from '@omnisgm-app/brand/assets/mark.svg?raw';
 // Фирменный знак — ЕДИНЫЙ источник из бренд-пакета. Снимаем фикс. размер, масштабируем под контейнер.
 const BRAND_MARK = markRaw.replace(/\s(width|height)="[^"]*"/g, '').replace('<svg ', '<svg style="display:block;width:100%;height:100%" ');
 import {
-  NAV, SYSTEMS, FLAT_PAGES, findPath, systemOf, nodeById, isGroup, flattenPages,
+  NAV, SYSTEMS, FLAT_PAGES, findPath, systemOf, isGroup, flattenPages,
   label, routeOf, systemRoute, homeRoute, type Lang, type NavGroup, type NavNode,
 } from '../lib/nav';
 
@@ -39,23 +39,27 @@ if (currentId === 'home') { openIds.add('dnd'); openIds.add('d52'); }
 
 const crumb = trail.slice(0, -1).map((n) => label(n, lang)).join('  ·  ');
 
-const node = nodeById(currentId);
-const curSlug = node && !isGroup(node) ? node.slug : null;
 const other: Lang = lang === 'en' ? 'ru' : 'en';
-const counterpart = curSlug ? `/${other}/${curSlug}/` : `/${other}/`;
-// URL каждого языка (для мобильного <select>): текущий язык → текущий путь, другой → counterpart
+// Слаг из URL, а НЕ из nav-дерева: у страниц вне nav (обзор группы вроде classes/classes)
+// nodeBySlug ничего не находит, из-за чего пара строилась как у хаба — переключатель языка
+// вёл на /ru/, а hreflang выводил корневую тройку (checker: «no return tag»).
+// Парность EN↔RU гарантирована контент-пайплайном (зеркальная структура файлов).
+// Для хабов /en/·/ru/ и корня pathSlug пуст.
 const currentPath = Astro.url.pathname;
+const pathSlug = currentPath.replace(/^\/(en|ru)\//, '').replace(/\/+$/, '');
+const counterpart = pathSlug ? `/${other}/${pathSlug}/` : `/${other}/`;
+// URL каждого языка (для мобильного <select>): текущий язык → текущий путь, другой → counterpart
 const enUrl = lang === 'en' ? currentPath : counterpart;
 const ruUrl = lang === 'ru' ? currentPath : counterpart;
 
 // hreflang-пары (пути от корня) — та же парность slug'ов, что и у переключателя языка.
 // Корень (bilingual) выводит тройку сам; здесь — контентные страницы и хабы систем.
-//  • контентная (curSlug != null): en/ru — маршруты пары, x-default → EN.
-//  • хаб/вкладка (curSlug == null, не корень): /en/ ↔ /ru/, x-default → «/» (зеркало корня-кластера).
+//  • контентная (pathSlug непуст): en/ru — маршруты пары, x-default → EN.
+//  • хаб (pathSlug пуст, не корень): /en/ ↔ /ru/, x-default → «/» (зеркало корня-кластера).
 const alternates = bilingual
   ? undefined
-  : curSlug != null
-    ? { en: routeOf(curSlug, 'en'), ru: routeOf(curSlug, 'ru'), xDefault: routeOf(curSlug, 'en') }
+  : pathSlug
+    ? { en: routeOf(pathSlug, 'en'), ru: routeOf(pathSlug, 'ru'), xDefault: routeOf(pathSlug, 'en') }
     : { en: '/en/', ru: '/ru/', xDefault: '/' };
 
 const idx = FLAT_PAGES.findIndex((p) => p.id === currentId);


### PR DESCRIPTION
Хвост из ревью #13 ([комментарий](https://github.com/OmnisGM-App/OmnisGM-Rules/issues/13#issuecomment-4876159226)): 4 страницы (`classes/classes` в 5.2/5.1 × EN/RU) не входят в nav-дерево, поэтому попадали в ветку «хаб» — hreflang выводил корневую тройку (внешний checker дал бы «no return tag», EN↔RU-пара не связана), а тумблер языка вёл на хаб `/ru/` вместо зеркальной страницы.

**Фикс:** пара строится от `Astro.url.pathname` (замена языкового сегмента), а не от `nodeBySlug` — покрывает и любые будущие вне-nav страницы. Парность контента гарантирована пайплайном (зеркальная структура EN↔RU). Заодно `nodeById` стал не нужен — убран из импорта.

**Проверки:**
- `astro check` + build чистые;
- аудит всего `dist/` (113 EN-страниц): каждая ссылается сама на себя, все пары взаимные, `classes/classes` связывает свою пару;
- e2e 8/8, из них 2 новых кейса: hreflang вне-nav пары + тумблер языка ведёт на зеркало.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4pEspRYkG4rKeFheJHjpy