### PR TITLE
feat(seo): llms.txt + IndexNow-пинг в деплой (#17)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,3 +97,30 @@ jobs:
           echo "$resp"
           echo "$resp" | grep -q '"success":true' || { echo "❌ Cloudflare purge не удался"; exit 1; }
           echo "✔ Cloudflare: edge-кэш фикс-файлов rules.omnisgm.com сброшен"
+
+      # IndexNow — мгновенный пинг Bing + Яндекс о задеплоенных страницах (#17).
+      # URL берём из свежесобранного web/dist/sitemap-0.xml (predeploy собрал его тем же билдом,
+      # что ушёл на хостинг) — только реально существующие URL, битых не шлём. Для нового сайта
+      # на первичной индексации шлём весь набор (~226 URL, лимит IndexNow — 10 000/запрос).
+      # KEY — публичный по дизайну, лежит в web/public/${KEY}.txt и совпадает с этой строкой.
+      - name: IndexNow ping
+        if: success()
+        env:
+          KEY: 94c855220fc93a1e6ccdc3f67fdfbb92
+        run: |
+          host="rules.omnisgm.com"
+          urls=$(grep -ohE '<loc>[^<]+</loc>' web/dist/sitemap-[0-9]*.xml 2>/dev/null | sed -E 's#</?loc>##g')
+          n=$(printf '%s\n' "$urls" | grep -c . || true)
+          if [ "$n" -eq 0 ]; then echo "sitemap пуст — IndexNow пропущен."; exit 0; fi
+          payload=$(printf '%s\n' "$urls" | grep . | jq -R . \
+            | jq -sc --arg h "$host" --arg k "$KEY" --arg kl "https://$host/$KEY.txt" \
+                '{host:$h,key:$k,keyLocation:$kl,urlList:.}')
+          resp=$(curl -s -w '\n%{http_code}' -X POST 'https://api.indexnow.org/indexnow' \
+            -H 'Content-Type: application/json; charset=utf-8' --data "$payload")
+          code=$(printf '%s' "$resp" | tail -n1)
+          echo "IndexNow: $n URL, HTTP $code"
+          printf '%s\n' "$resp" | sed '$d'
+          case "$code" in
+            200|202) echo "✔ IndexNow принял пинг ($code)";;
+            *) echo "❌ IndexNow вернул $code"; exit 1;;
+          esac

--- a/web/e2e/lang.spec.ts
+++ b/web/e2e/lang.spec.ts
@@ -52,25 +52,13 @@ test('hreflang: хаб /en/ и корень / дают согласованну�
   expect(root).toEqual(hub); // корень и хабы — один кластер, тройка совпадает
 });
 
-// Страница ВНЕ nav-дерева (обзор группы «Классы»): пара должна строиться от URL,
-// а не от nav — иначе такие страницы выводили корневую тройку («no return tag»)
-// и переключатель языка вёл на хаб вместо зеркала.
-const EN_OFFNAV = '/en/dnd/srd-5.2/classes/classes/';
-const RU_OFFNAV = '/ru/dnd/srd-5.2/classes/classes/';
-
-test('hreflang: вне-nav страница связывает собственную EN↔RU-пару', async ({ page }) => {
-  await page.goto(EN_OFFNAV);
-  const m = await hreflangMap(page);
-  expect(new URL(m.en!).pathname).toBe(EN_OFFNAV);
-  expect(new URL(m.ru!).pathname).toBe(RU_OFFNAV);
-  expect(m['x-default']).toBe(m.en);
-
-  await page.goto(RU_OFFNAV);
-  expect(await hreflangMap(page)).toEqual(m); // взаимность
-});
-
-test('тумблер языка на вне-nav странице ведёт на зеркало, а не на хаб', async ({ page }) => {
-  await page.goto(EN_OFFNAV);
-  await page.locator('.rd-lang-btn', { hasText: 'RU' }).click();
-  await expect(page).toHaveURL(new RegExp(RU_OFFNAV.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '$'));
+// Заглушки обзора глав (напр. 06_Classes/00_Classes.md = только «# Classes») нужны контентному
+// пайплайну для PDF, но на сайте это пустой тонкий контент — роут не генерируем (см. #17). Это были
+// единственные страницы вне nav-дерева; после удаления вне-nav контентных страниц не осталось.
+// Тест страхует от регресса — что заглушка не вернётся в билд как индексируемая страница.
+test('пустая заглушка обзора классов не отдаётся (404)', async ({ page }) => {
+  for (const url of ['/en/dnd/srd-5.2/classes/classes/', '/ru/dnd/srd-5.1/classes/classes/']) {
+    const resp = await page.goto(url);
+    expect(resp?.status(), url).toBe(404);
+  }
 });

--- a/web/public/94c855220fc93a1e6ccdc3f67fdfbb92.txt
+++ b/web/public/94c855220fc93a1e6ccdc3f67fdfbb92.txt
@@ -1,0 +1,1 @@
+94c855220fc93a1e6ccdc3f67fdfbb92

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -1,0 +1,83 @@
+# OmnisGM Rules
+
+> A fast, static, bilingual (English + Russian) reader for tabletop RPG System Reference Documents (SRDs): Dungeons & Dragons 5.2.1 and 5.1, Daggerheart 1.0, and Basic Roleplaying 1.0. Every rules page is rendered to plain semantic HTML from Markdown sources — no client-side app shell — which makes the content clean and reliable to cite.
+
+OmnisGM Rules (rules.omnisgm.com) is part of the OmnisGM ecosystem, built around an interactive character sheet at https://omnisgm.com. The rules site exists so players can look up a rule and then build a character for those very rules.
+
+Content notes for machine consumers:
+- Each page exists in two languages under `/en/…` and `/ru/…` with reciprocal `hreflang` pairs. The Russian text is a careful, glossary-driven translation, not machine output.
+- URLs use trailing slashes and mirror the source tree: `/{lang}/{game}/{version}/{section}/`.
+- The canonical Markdown source for every page is public on GitHub (linked below) — prefer it when you need the raw text.
+- All content is official SRD material reproduced under its respective open license; attribution and license terms are on each system's Legal page.
+
+## D&D — SRD 5.2.1
+
+- [Playing the Game](https://rules.omnisgm.com/en/dnd/srd-5.2/playing-the-game/): core rules — the d20 test, advantage, conditions
+- [Character Creation](https://rules.omnisgm.com/en/dnd/srd-5.2/character-creation/)
+- Classes — all twelve, from [Barbarian](https://rules.omnisgm.com/en/dnd/srd-5.2/classes/barbarian/) to [Wizard](https://rules.omnisgm.com/en/dnd/srd-5.2/classes/wizard/)
+- [Character Origins](https://rules.omnisgm.com/en/dnd/srd-5.2/character-origins/): species and backgrounds
+- [Feats](https://rules.omnisgm.com/en/dnd/srd-5.2/feats/)
+- [Equipment](https://rules.omnisgm.com/en/dnd/srd-5.2/equipment/)
+- [Spells](https://rules.omnisgm.com/en/dnd/srd-5.2/spells/)
+- [Magic Items](https://rules.omnisgm.com/en/dnd/srd-5.2/magic-items/)
+- [Monsters](https://rules.omnisgm.com/en/dnd/srd-5.2/monsters/) and [Monsters A–Z](https://rules.omnisgm.com/en/dnd/srd-5.2/monsters-a-z/)
+- [Rules Glossary](https://rules.omnisgm.com/en/dnd/srd-5.2/rules-glossary/)
+- [Gameplay Toolbox](https://rules.omnisgm.com/en/dnd/srd-5.2/gameplay-toolbox/)
+- [Legal & license](https://rules.omnisgm.com/en/dnd/srd-5.2/legal/)
+
+## D&D — SRD 5.1
+
+- [Abilities](https://rules.omnisgm.com/en/dnd/srd-5.1/abilities/), [Adventuring](https://rules.omnisgm.com/en/dnd/srd-5.1/adventuring/), [Combat](https://rules.omnisgm.com/en/dnd/srd-5.1/combat/)
+- [Races](https://rules.omnisgm.com/en/dnd/srd-5.1/races/); classes from [Barbarian](https://rules.omnisgm.com/en/dnd/srd-5.1/classes/barbarian/) to [Wizard](https://rules.omnisgm.com/en/dnd/srd-5.1/classes/wizard/)
+- [Spells](https://rules.omnisgm.com/en/dnd/srd-5.1/spells/), [Equipment](https://rules.omnisgm.com/en/dnd/srd-5.1/equipment/), [Magic Items](https://rules.omnisgm.com/en/dnd/srd-5.1/magic-items/)
+- [Monsters](https://rules.omnisgm.com/en/dnd/srd-5.1/monsters/) and [Monsters A–Z](https://rules.omnisgm.com/en/dnd/srd-5.1/monsters-a-z/)
+- [Converting 5.1 → 5.2.1](https://rules.omnisgm.com/en/dnd/converting-srd-5.2/converting-to-srd-5.2.1/)
+- [Legal & license](https://rules.omnisgm.com/en/dnd/srd-5.1/legal/)
+
+## Daggerheart — SRD 1.0
+
+- [Introduction](https://rules.omnisgm.com/en/daggerheart/srd-1.0/introduction/) and [Core Mechanics](https://rules.omnisgm.com/en/daggerheart/srd-1.0/core-mechanics/)
+- [Character Creation](https://rules.omnisgm.com/en/daggerheart/srd-1.0/character-creation/), [Domains](https://rules.omnisgm.com/en/daggerheart/srd-1.0/domains/), [Domain Card Reference](https://rules.omnisgm.com/en/daggerheart/srd-1.0/domain-card-reference/)
+- [Ancestries](https://rules.omnisgm.com/en/daggerheart/srd-1.0/ancestries/) and [Communities](https://rules.omnisgm.com/en/daggerheart/srd-1.0/communities/)
+- [Adversaries](https://rules.omnisgm.com/en/daggerheart/srd-1.0/adversaries/) and [Environments](https://rules.omnisgm.com/en/daggerheart/srd-1.0/environments/)
+- [GM Guide](https://rules.omnisgm.com/en/daggerheart/srd-1.0/gmguide/)
+- [Legal & license](https://rules.omnisgm.com/en/daggerheart/srd-1.0/legal/)
+
+## Basic Roleplaying — SRD 1.0
+
+- [Introduction](https://rules.omnisgm.com/en/brp/srd-1.0/introduction/) and [System](https://rules.omnisgm.com/en/brp/srd-1.0/system/)
+- [Character Creation](https://rules.omnisgm.com/en/brp/srd-1.0/character-creation/) and [Combat](https://rules.omnisgm.com/en/brp/srd-1.0/combat/)
+- [Spot Rules](https://rules.omnisgm.com/en/brp/srd-1.0/spot-rules/) and [Glossary](https://rules.omnisgm.com/en/brp/srd-1.0/glossary/glossary/)
+- [Legal & license](https://rules.omnisgm.com/en/brp/srd-1.0/legal/)
+
+## Russian translations
+
+Every section above has a Russian counterpart — swap `/en/` for `/ru/` in any URL. Entry points:
+
+- [D&D · SRD 5.2.1 (RU)](https://rules.omnisgm.com/ru/dnd/srd-5.2/playing-the-game/)
+- [D&D · SRD 5.1 (RU)](https://rules.omnisgm.com/ru/dnd/srd-5.1/combat/)
+- [Daggerheart · SRD 1.0 (RU)](https://rules.omnisgm.com/ru/daggerheart/srd-1.0/core-mechanics/)
+- [Basic Roleplaying · SRD 1.0 (RU)](https://rules.omnisgm.com/ru/brp/srd-1.0/system/)
+
+## Markdown sources
+
+The raw Markdown behind every page lives in the public repository, mirrored per game/version/language:
+
+- [OmnisGM-Rules repository](https://github.com/OmnisGM-App/OmnisGM-Rules)
+- [D&D SRD 5.2.1 — EN](https://github.com/OmnisGM-App/OmnisGM-Rules/tree/main/src/dnd/srd-5.2/en) · [RU](https://github.com/OmnisGM-App/OmnisGM-Rules/tree/main/src/dnd/srd-5.2/ru)
+- [D&D SRD 5.1 — EN](https://github.com/OmnisGM-App/OmnisGM-Rules/tree/main/src/dnd/srd-5.1/en) · [RU](https://github.com/OmnisGM-App/OmnisGM-Rules/tree/main/src/dnd/srd-5.1/ru)
+- [Daggerheart SRD 1.0 — EN](https://github.com/OmnisGM-App/OmnisGM-Rules/tree/main/src/daggerheart/srd-1.0/en) · [RU](https://github.com/OmnisGM-App/OmnisGM-Rules/tree/main/src/daggerheart/srd-1.0/ru)
+- [Basic Roleplaying SRD 1.0 — EN](https://github.com/OmnisGM-App/OmnisGM-Rules/tree/main/src/brp/srd-1.0/en) · [RU](https://github.com/OmnisGM-App/OmnisGM-Rules/tree/main/src/brp/srd-1.0/ru)
+
+## Licenses
+
+Each system reproduces official SRD content under its own open license — see the per-system Legal pages linked above for full terms and attribution:
+
+- **D&D SRD 5.2.1 and 5.1** — SRD content © Wizards of the Coast, licensed under Creative Commons Attribution 4.0 (CC BY 4.0).
+- **Daggerheart SRD 1.0** — Daggerheart content used under the Darrington Press Community Gaming License (DPCGL). © Critical Role LLC. Not affiliated with or endorsed by Darrington Press.
+- **Basic Roleplaying SRD 1.0** — © Chaosium Inc., used under the Basic Roleplaying Open Game License v1.0.
+
+## About
+
+- [OmnisGM — interactive character sheet](https://omnisgm.com): the companion app these rules link out to
+- [The Guild Herald — TTRPG news](https://news.omnisgm.com)

--- a/web/src/pages/[lang]/[...slug].astro
+++ b/web/src/pages/[lang]/[...slug].astro
@@ -6,7 +6,11 @@ import { nodeBySlug, findPath, label as navLabel } from '../../lib/nav';
 
 export async function getStaticPaths() {
   const all = await getCollection('srd');
-  return all.map((entry) => {
+  return all
+    // Заглушки обзора глав (напр. 06_Classes/00_Classes.md = только «# Classes») нужны контентному
+    // пайплайну для PDF, но на сайте это пустая тонкая страница — роут не генерим (см. #17).
+    .filter((entry) => !/\/\d+_Classes\/00_Classes$/.test(entry.id))
+    .map((entry) => {
     const ref = parseId(entry.id);
     return {
       params: { lang: ref.lang, slug: `${ref.game}/${ref.version}/${ref.slug}` },


### PR DESCRIPTION
Closes #17.

Один PR на обе подзадачи спринта (§2.2 llms.txt, §2.3 IndexNow) + попутная чистка пустых страниц-заглушек (по фидбеку в ходе работы).

## 1. llms.txt (§2.2)
`web/public/llms.txt` по спецификации [llmstxt.org](https://llmstxt.org) — H1 + blockquote + списки ссылок:
- описание сайта и заметки для машинных потребителей (двуязычность, trailing-slash, markdown-исходники);
- структура по системам: D&D SRD 5.2.1 / 5.1, Daggerheart 1.0, BRP 1.0 — ключевые разделы;
- вход в русские версии; ссылки на markdown-исходники в GitHub; лицензии (CC BY 4.0 / DPCGL / BRP OGL).
- **Все ~49 rules-URL сверены с sitemap — битых нет.**

## 2. IndexNow (§2.3)
- Публичный ключ: `web/public/94c855220fc93a1e6ccdc3f67fdfbb92.txt`.
- Шаг **«IndexNow ping»** в `deploy.yml` после Cloudflare-purge: URL берутся из свежесобранного `web/dist/sitemap-0.xml` (predeploy собрал его тем же билдом, что ушёл на хостинг) → шлём только существующие URL, битых нет. Для первичной индексации нового сайта — весь набор (~223 URL, лимит IndexNow 10k/запрос). Ключ публичный по дизайну; строка в workflow совпадает с файлом. Без падений: 200/202 = успех.

## 3. Пустые заглушки обзора классов (попутно)
`/{lang}/dnd/srd-{5.1,5.2}/classes/classes/` рендерились из `00_Classes.md` (только `# Classes`) — тонкий контент без пользы для индекса.
- Роут больше не генерируется (фильтр в `[...slug].astro` `getStaticPaths`, `\d+_Classes/00_Classes` — обе версии, EN+RU = 4 страницы).
- Файлы `00_Classes.md` **остаются в `src/`** — нужны контентному пайплайну для PDF.
- Это были единственные вне-nav страницы; 2 e2e-теста из #31 заменены на тест «заглушка → 404» (страховка от регресса). sitemap: 228 → 223 URL.

## Проверки
- `astro check` — 0 ошибок; `build` чистый.
- `e2e` — **7/7** в CI-режиме (свежая сборка, без reuse-сервера), включая 404-тест на обе версии.
- llms.txt-ссылки и IndexNow-payload (223 URL, валидный JSON, верный host/key/keyLocation) сверены с sitemap.

## После мёржа (критерии issue, ручное)
- `https://rules.omnisgm.com/llms.txt` → 200.
- Первый деплой в Actions → лог «IndexNow: 223 URL, HTTP 200/202».
- Яндекс.Вебмастер через пару дней → обходы по IndexNow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)