### PR TITLE
fix(analytics): gtag должен пушить объект arguments, а не массив (#18)

### DIFF
--- a/web/src/lib/analytics-client.ts
+++ b/web/src/lib/analytics-client.ts
@@ -23,8 +23,12 @@ export function initAnalytics(): void {
   document.head.appendChild(s);
 
   window.dataLayer = window.dataLayer || [];
-  function gtag(...args: unknown[]) {
-    window.dataLayer!.push(args);
+  // gtag.js принимает ТОЛЬКО объект arguments — массив от rest-параметров он молча
+  // игнорирует (команды не применяются, хиты не шлются). Поэтому push(arguments),
+  // функция обязана быть не-стрелочной. Проверено вживую в #18.
+  function gtag(..._args: unknown[]) {
+    // eslint-disable-next-line prefer-rest-params
+    window.dataLayer!.push(arguments);
   }
   gtag('js', new Date());
   gtag('config', ID); // авто page_view (трафик)


### PR DESCRIPTION
Вторая корневая причина мёртвого GA4 (диагноз в [#18](https://github.com/OmnisGM-App/OmnisGM-Rules/issues/18#issuecomment-4877162561)): gtag.js принимает только объект `arguments` — массивы от rest-параметров игнорирует молча. `'js'`/`'config'` не применялись, ни один `/g/collect` не уходил, хотя скрипт грузился (это и скрывало проблему от curl-проверок — нашлось только реальным браузером).

**Фикс:** `push(arguments)` в не-стрелочной функции; сигнатура и все вызовы (`gtag('js',…)`, `gtag('config',…)`, `omnisTrack`) не меняются.

**Проверено:** `astro check` чистый; тестовая сборка — в бандле `dataLayer.push(arguments)`, минификатор функцию не переписал.

**Проверка на проде после мержа:** открыть rules.omnisgm.com → DevTools Network → фильтр `collect` → POST на `google-analytics.com/g/collect`; затем GA Realtime (property omnisgm-rules) — визит с просмотром страницы.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4pEspRYkG4rKeFheJHjpy