### PR TITLE
fix(ci): IndexNow-пинг не должен ронять деплой (#17)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,8 +101,13 @@ jobs:
       # IndexNow — мгновенный пинг Bing + Яндекс о задеплоенных страницах (#17).
       # URL берём из свежесобранного web/dist/sitemap-0.xml (predeploy собрал его тем же билдом,
       # что ушёл на хостинг) — только реально существующие URL, битых не шлём. Для нового сайта
-      # на первичной индексации шлём весь набор (~226 URL, лимит IndexNow — 10 000/запрос).
+      # на первичной индексации шлём весь набор (~223 URL, лимит IndexNow — 10 000/запрос).
       # KEY — публичный по дизайну, лежит в web/public/${KEY}.txt и совпадает с этой строкой.
+      #
+      # ВАЖНО: это best-effort уведомление ПОСЛЕ уже успешного деплоя — оно НЕ должно ронять ран.
+      # Любой не-2xx (в т.ч. 403 SiteVerificationNotCompleted при самом первом пинге, пока движок
+      # не подтянул ключ-файл) → ::warning::, exit 0. Сайт от этого не страдает; следующий деплой
+      # после завершения верификации вернёт 200/202.
       - name: IndexNow ping
         if: success()
         env:
@@ -111,16 +116,19 @@ jobs:
           host="rules.omnisgm.com"
           urls=$(grep -ohE '<loc>[^<]+</loc>' web/dist/sitemap-[0-9]*.xml 2>/dev/null | sed -E 's#</?loc>##g')
           n=$(printf '%s\n' "$urls" | grep -c . || true)
-          if [ "$n" -eq 0 ]; then echo "sitemap пуст — IndexNow пропущен."; exit 0; fi
+          if [ "$n" -eq 0 ]; then echo "::warning::IndexNow: sitemap пуст — пинг пропущен."; exit 0; fi
           payload=$(printf '%s\n' "$urls" | grep . | jq -R . \
             | jq -sc --arg h "$host" --arg k "$KEY" --arg kl "https://$host/$KEY.txt" \
                 '{host:$h,key:$k,keyLocation:$kl,urlList:.}')
           resp=$(curl -s -w '\n%{http_code}' -X POST 'https://api.indexnow.org/indexnow' \
             -H 'Content-Type: application/json; charset=utf-8' --data "$payload")
           code=$(printf '%s' "$resp" | tail -n1)
+          body=$(printf '%s\n' "$resp" | sed '$d')
           echo "IndexNow: $n URL, HTTP $code"
-          printf '%s\n' "$resp" | sed '$d'
+          [ -n "$body" ] && echo "$body"
           case "$code" in
             200|202) echo "✔ IndexNow принял пинг ($code)";;
-            *) echo "❌ IndexNow вернул $code"; exit 1;;
+            403) echo "::warning::IndexNow вернул 403 (вероятно верификация ключа ещё идёт) — деплой не затронут, следующий пинг пройдёт.";;
+            *)   echo "::warning::IndexNow вернул $code — пинг best-effort, деплой не затронут.";;
           esac
+          exit 0


### PR DESCRIPTION
Хвост #17. Первый деплой после мёржа #32 **выкатился успешно** (Firebase + CF-purge ✔, сайт корректен: `/llms.txt` → 200, ключ-файл → 200, заглушки `classes/classes` → 404), но шаг `IndexNow ping` вернул **403 `SiteVerificationNotCompleted`** — ожидаемое поведение при самом первом пинге: движок ещё не подтянул только что выложенный ключ-файл. Из-за `exit 1` это покрасило весь ран.

## Фикс
IndexNow — best-effort уведомление **после** уже успешного деплоя. Теперь оно не роняет workflow:
- `200/202` → `✔` (как раньше);
- `403` → `::warning::` (верификация ключа ещё идёт), `exit 0`;
- любой другой не-2xx → `::warning::`, `exit 0`.

Сайт от статуса пинга не зависит; верификация ключа асинхронная — следующий деплой вернёт 200/202.

## Примечание
Правка трогает только `.github/workflows/deploy.yml`, которого нет в `paths:` триггера деплоя, — мёрж сам деплой не запустит. Проверить прохождение IndexNow можно вручную (`workflow_dispatch`) после завершения верификации ключа, либо это случится на ближайшем контентном деплое.

🤖 Generated with [Claude Code](https://claude.com/claude-code)