### PR TITLE
feat(seo): UTM в CTA-воронку + page в событие аналитики (#14)

### DIFF
--- a/web/src/components/ReaderShell.astro
+++ b/web/src/components/ReaderShell.astro
@@ -129,7 +129,7 @@ const searchUi = {
 
     <header class="rd-topbar">
       <div class="rd-brand">
-        <a href={MAIN} class="rd-brand-link" aria-label="OmnisGM">
+        <a href={`${MAIN}/?utm_source=rules&utm_medium=topbar&utm_campaign=funnel`} class="rd-brand-link" aria-label="OmnisGM">
           <span class="rd-brand-mark" set:html={BRAND_MARK} />
           <span class="rd-brand-name">OmnisGM</span>
         </a>
@@ -207,12 +207,15 @@ const searchUi = {
             <slot />
           </article>
 
-          {/* CTA-воронка в основной продукт (лист персонажа). Событие Analytics на клик. */}
+          {/* CTA-воронка в основной продукт (лист персонажа). Событие Analytics на клик.
+              UTM — атрибуция конверсии в аналитике Table (#14): utm_content = currentId
+              (компактный nav-id страницы, языконезависимый; sourceId с путём/языком —
+              избыточен для отчётов, страница «какая конвертит» важнее языка). */}
           <a
             class="rd-cta"
-            href="https://omnisgm.com"
+            href={`${MAIN}/?utm_source=rules&utm_medium=cta&utm_campaign=funnel&utm_content=${encodeURIComponent(currentId)}`}
             data-pagefind-ignore
-            onclick="window.omnisTrack&&window.omnisTrack('cta_character_sheet',{from:'reader'})"
+            onclick={`window.omnisTrack&&window.omnisTrack('cta_character_sheet',{from:'reader',page:'${currentId}'})`}
           >
             <span class="rd-cta-body">
               <span class="rd-cta-title"><I18n en="Build your character in OmnisGM" ru="Соберите персонажа в OmnisGM" bilingual={bilingual} lang={lang} /></span>


### PR DESCRIPTION
Закрывает [#14](https://github.com/OmnisGM-App/OmnisGM-Rules/issues/14).

- CTA «Соберите персонажа» → `https://omnisgm.com/?utm_source=rules&utm_medium=cta&utm_campaign=funnel&utm_content={currentId}`;
- событие `cta_character_sheet` → `{from:'reader', page: currentId}` — видно, какие страницы конвертят (GA4 после #33 работает);
- **отличие от текста issue:** `utm_content` = `currentId` (компактный nav-id вроде `d52-spells`, языконезависимый), а не `sourceId` с путём и языком — для отчёта «какая страница конвертит» язык лишний, а язык визита GA и так знает;
- бонус: топбар-ссылка на omnisgm.com получила `utm_medium=topbar` (тот же кросс-домен — иначе эти клики размажутся по referral); JSON-LD `org.url` сознательно не тронут (чистый URL организации).

Проверено: build чистый, в dist CTA несёт полный UTM (`utm_content=d52-spells` на странице заклинаний, `home` на хабе), e2e 6/6.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4pEspRYkG4rKeFheJHjpy