### PR TITLE
docs: ссылки на экосистему + русская версия README (#88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- When editing this file, mirror the change in README.ru.md -->
 # OmnisGM Rules — TTRPG SRD Markdown
 
 **English** · [Русский](README.ru.md)
@@ -5,11 +6,8 @@
 [Live site](https://rules.omnisgm.com)
 
 A curated collection of tabletop RPG **System Reference Documents (SRDs)** in Markdown, published as a
-fast, static reader at **rules.omnisgm.com**. Part of the **OmnisGM** ecosystem. Content is available in
-**English and Russian** (the Russian edition is a full, glossary-driven translation).
-
-> **Issues & contributions are welcome — please file them in English.** This keeps the project
-> accessible to the broadest audience. Russian is fine too if English is hard for you, but English is preferred.
+fast, static reader at **rules.omnisgm.com**. Part of the **OmnisGM** ecosystem. **Every SRD includes a
+complete Russian translation — a corpus available nowhere else.**
 
 ## The OmnisGM ecosystem
 
@@ -24,51 +22,29 @@ physical table:
 - **[The Guild Herald](https://news.omnisgm.com)** — OmnisGM News: a bilingual (EN/RU) tabletop RPG news
   digest (releases, crowdfunding, rules updates, industry and events).
 
-## Sources
+## Systems
 
-### D&D
-
-- [SRD 5.2.1](https://www.dndbeyond.com/srd) — System Reference Document 5.2.1 by Wizards of the Coast LLC, licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
-- [dndsrd5.2_markdown](https://github.com/springbov/dndsrd5.2_markdown) — English SRD 5.2 in Markdown
-- [dndsrd5.2_markdown (yuvalsapir)](https://github.com/yuvalsapir/dndsrd5.2_markdown) — updates to 5.2.1
-- [DND.SRD.Wiki](https://github.com/oldmanumby/DND.SRD.Wiki) — SRD 5.1 in Markdown (wiki)
-- [dnd-5e-srd-markdown](https://github.com/downfallx/dnd-5e-srd-markdown) — missing dragon stat blocks
-- [Lazy GM Tools](https://github.com/mshea/lazy_gm_tools) / [slyflourish.com](https://slyflourish.com/) — monster data
-
-### Tools
-
-- [marker](https://github.com/VikParuchuri/marker) — PDF → Markdown conversion
-
-## Roadmap
-
-### Done / planned / considered
-
-| Status | System | Publisher | License | SRD format |
+| Status | System | Publisher | License | Notes |
 |:---:|---|---|---|---|
-| :white_check_mark: | D&D SRD 5.2.1 | Wizards of the Coast | CC BY 4.0 | [PDF](https://www.dndbeyond.com/srd) |
-| :white_check_mark: | D&D SRD 5.1 | Wizards of the Coast | CC BY 4.0 | [PDF](https://www.dndbeyond.com/srd) |
-| :white_check_mark: | Daggerheart SRD 1.0 | Darrington Press | [DPCGL](https://darringtonpress.com/license/) | [PDF](https://www.daggerheart.com/srd/), [Markdown](https://github.com/seansbox/daggerheart-srd) |
-| :white_check_mark: | Basic Roleplaying (BRP) | Chaosium | [BRP OGL v1.0](https://www.chaosium.com/brp-system-reference-document/) | [PDF](https://www.chaosium.com/brp-system-reference-document/) |
-| :calendar: | Pathfinder 2e | Paizo | [ORC](https://paizo.com/orclicense) | [Web](https://2e.aonprd.com/) |
-| :calendar: | Starfinder 2e | Paizo | [ORC](https://paizo.com/orclicense) | [Web](https://2e.aonsrd.com/) |
-| :calendar: | Year Zero Engine | Free League | [FTL](https://freeleaguepublishing.com/community-content/free-tabletop-licenses/) | [PDF](https://freeleaguepublishing.com/wp-content/uploads/2023/11/YZE-Standard-Reference-Document.pdf) |
-| :grey_question: | Dragonbane | Free League | [3rd Party License](https://freeleaguepublishing.com/community-content/free-tabletop-licenses/) | PDF |
-| :grey_question: | Fate Core / FAE | Evil Hat Productions | CC BY 3.0 | [Web](https://fate-srd.com/), [Markdown](https://github.com/amazingrando/fate-srd-content) |
-| :grey_question: | Blades in the Dark | One Seven Design | CC BY 3.0 | [Web](https://bladesinthedark.com/), [Markdown](https://github.com/amazingrando/blades-in-the-dark-srd-content) |
-| :grey_question: | Dungeon World | Sage LaTorra | CC BY 3.0 | [Web](https://www.dungeonworldsrd.com/), [GitHub](https://github.com/Sagelt/Dungeon-World) |
-| :grey_question: | 13th Age (Archmage Engine) | Pelgrane Press | OGL 1.0a | [Web](https://www.13thagesrd.com/), [PDF](https://pelgranepress.com/media/SRD/13thAgeArchmageEngineSRD.pdf) |
-| :grey_question: | MORK BORG | Free League | [3rd Party License](https://morkborg.com/license/) | [Web](https://morkborg.com/content/) |
-| :grey_question: | Worlds Without Number | Sine Nomine | CC0 | PDF (DriveThruRPG) |
-| :grey_question: | Cypher System | Monte Cook Games | [CSOL](https://www.montecookgames.com/cypher-system-open-license/) | [Web](https://callmepartario.github.io/og-csrd/) |
+| ✅ | D&D SRD 5.2.1 | Wizards of the Coast | CC BY 4.0 | [PDF](https://www.dndbeyond.com/srd) |
+| ✅ | D&D SRD 5.1 | Wizards of the Coast | CC BY 4.0 | [PDF](https://www.dndbeyond.com/srd) |
+| ✅ | Daggerheart SRD 1.0 | Darrington Press | [DPCGL](https://darringtonpress.com/license/) | [PDF](https://www.daggerheart.com/srd/), [Markdown](https://github.com/seansbox/daggerheart-srd) |
+| ✅ | Basic Roleplaying (BRP) | Chaosium | [BRP OGL v1.0](https://www.chaosium.com/brp-system-reference-document/) | [PDF](https://www.chaosium.com/brp-system-reference-document/) |
+| 📅 | Pathfinder 2e | Paizo | [ORC](https://paizo.com/orclicense) | [Web](https://2e.aonprd.com/) |
+| 📅 | Starfinder 2e | Paizo | [ORC](https://paizo.com/orclicense) | [Web](https://2e.aonsrd.com/) |
+| 📅 | Year Zero Engine | Free League | [FTL](https://freeleaguepublishing.com/community-content/free-tabletop-licenses/) | [PDF](https://freeleaguepublishing.com/wp-content/uploads/2023/11/YZE-Standard-Reference-Document.pdf) |
+| ❓ | Dragonbane | Free League | [3rd Party License](https://freeleaguepublishing.com/community-content/free-tabletop-licenses/) | PDF |
+| ❓ | Fate Core / FAE | Evil Hat Productions | CC BY 3.0 | [Web](https://fate-srd.com/), [Markdown](https://github.com/amazingrando/fate-srd-content) |
+| ❓ | Blades in the Dark | One Seven Design | CC BY 3.0 | [Web](https://bladesinthedark.com/), [Markdown](https://github.com/amazingrando/blades-in-the-dark-srd-content) |
+| ❓ | Dungeon World | Sage LaTorra | CC BY 3.0 | [Web](https://www.dungeonworldsrd.com/), [GitHub](https://github.com/Sagelt/Dungeon-World) |
+| ❓ | 13th Age (Archmage Engine) | Pelgrane Press | OGL 1.0a | [Web](https://www.13thagesrd.com/), [PDF](https://pelgranepress.com/media/SRD/13thAgeArchmageEngineSRD.pdf) |
+| ❓ | MORK BORG | Free League | [3rd Party License](https://morkborg.com/license/) | [Web](https://morkborg.com/content/) |
+| ❓ | Worlds Without Number | Sine Nomine | CC0 | PDF (DriveThruRPG) |
+| ❓ | Cypher System | Monte Cook Games | [CSOL](https://www.montecookgames.com/cypher-system-open-license/) | [Web](https://callmepartario.github.io/og-csrd/) |
+| 🚫 | World of Darkness (VtM, WtA, DtD…) | Paradox Interactive | — | No open SRD; the [Dark Pack](https://worldofdarkness.com/dark-pack) covers free fan content only |
+| 🚫 | 2d20 (Dune, Fallout, Star Trek…) | Modiphius | — | An SRD exists, but [World Builders](https://modiphius.net/en-us/pages/2d20worldbuilders) is tied to DriveThruRPG; free redistribution is not permitted |
 
-> :white_check_mark: — done · :calendar: — planned · :grey_question: — under consideration
-
-### Licensing does not permit
-
-| System | Publisher | Reason |
-|---|---|---|
-| World of Darkness (VtM, WtA, DtD…) | Paradox Interactive | No open SRD. The [Dark Pack](https://worldofdarkness.com/dark-pack) covers free fan content only |
-| 2d20 (Dune, Fallout, Star Trek…) | Modiphius | An SRD exists, but [World Builders](https://modiphius.net/en-us/pages/2d20worldbuilders) is tied to DriveThruRPG; free redistribution is not permitted |
+> ✅ done · 📅 planned · ❓ under consideration · 🚫 licensing does not permit
 
 ## Licenses
 
@@ -79,11 +55,27 @@ Each SRD is distributed under its own license. See `LICENSE.md` in the correspon
 - Daggerheart SRD 1.0 — DPCGL © Critical Role, LLC (not affiliated with or endorsed by Darrington Press); see the in-app [Legal page](src/daggerheart/srd-1.0/en/00_Legal.md)
 - Basic Roleplaying SRD 1.0 — BRP OGL v1.0 © Chaosium Inc.: [LICENSE.md](src/brp/srd-1.0/LICENSE.md)
 
-## Repository layout
+## Repository structure
 
 - `src/{game}/{version}/{en,ru}/` — Markdown content (input to the import/translation pipeline)
 - `web/` — the [Astro](https://astro.build) static-site reader published at rules.omnisgm.com
 - `.claude/` — import & translation pipeline (skills + rules). See [CLAUDE.md](CLAUDE.md)
+
+## Contributing
+
+**Issues & contributions are welcome — please file them in English.** This keeps the project accessible
+to the broadest audience. Russian is fine too if English is hard for you, but English is preferred.
+
+## Credits & tooling
+
+Markdown source material the import pipeline builds on:
+
+- [dndsrd5.2_markdown](https://github.com/springbov/dndsrd5.2_markdown) — English SRD 5.2 in Markdown
+- [dndsrd5.2_markdown (yuvalsapir)](https://github.com/yuvalsapir/dndsrd5.2_markdown) — updates to 5.2.1
+- [DND.SRD.Wiki](https://github.com/oldmanumby/DND.SRD.Wiki) — SRD 5.1 in Markdown (wiki)
+- [dnd-5e-srd-markdown](https://github.com/downfallx/dnd-5e-srd-markdown) — missing dragon stat blocks
+- [Lazy GM Tools](https://github.com/mshea/lazy_gm_tools) / [slyflourish.com](https://slyflourish.com/) — monster data
+- [marker](https://github.com/VikParuchuri/marker) — PDF → Markdown conversion
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OmnisGM Rules — TTRPG SRD Markdown
 
+**English** · [Русский](README.ru.md)
+
 [Live site](https://rules.omnisgm.com)
 
 A curated collection of tabletop RPG **System Reference Documents (SRDs)** in Markdown, published as a

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ fast, static reader at **rules.omnisgm.com**. Part of the **OmnisGM** ecosystem.
 > **Issues & contributions are welcome — please file them in English.** This keeps the project
 > accessible to the broadest audience. Russian is fine too if English is hard for you, but English is preferred.
 
+## The OmnisGM ecosystem
+
+This SRD reader is one of three products under **OmnisGM** — tools for running tabletop RPGs at a
+physical table:
+
+- **[OmnisGM](https://omnisgm.com)** — the flagship app: free realtime **D&D 2024 character sheets** for
+  in-person play. Each player keeps their sheet on their own phone; the Game Master sees every change live.
+  Installable PWA, works offline. The rules in this repo are the ones those sheets are built around.
+- **[OmnisGM Rules](https://rules.omnisgm.com)** — this project: a fast, static, bilingual (EN/RU) reader
+  for open SRDs, with clean citable HTML and public Markdown sources.
+- **[The Guild Herald](https://news.omnisgm.com)** — OmnisGM News: a bilingual (EN/RU) tabletop RPG news
+  digest (releases, crowdfunding, rules updates, industry and events).
+
 ## Sources
 
 ### D&D

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,3 +1,4 @@
+<!-- При правке этого файла обнови и README.md -->
 # OmnisGM Rules — Markdown-версии SRD настольных игр
 
 [English](README.md) · **Русский**
@@ -6,11 +7,8 @@
 
 Кураторская подборка **System Reference Document (SRD)** настольных ролевых игр в Markdown,
 опубликованная как быстрый статический ридер на **rules.omnisgm.com**. Часть экосистемы **OmnisGM**.
-Контент доступен на **английском и русском** (русское издание — полный перевод, управляемый глоссарием).
-
-> **Issues и контрибьюции приветствуются — по возможности оформляйте их на английском.** Так проект
-> остаётся доступным для самой широкой аудитории. Русский тоже подойдёт, если с английским тяжело, —
-> но английский предпочтителен.
+**У каждого SRD есть полный русский перевод — корпус, которого больше нет нигде:** перевод управляется
+глоссарием и проходит многораундовую верификацию, поэтому термины согласованы по всему тексту.
 
 ## Экосистема OmnisGM
 
@@ -26,51 +24,29 @@
 - **[The Guild Herald](https://news.omnisgm.com)** — OmnisGM News: двуязычная (EN/RU) лента новостей
   настольных ролевых игр (релизы, краудфандинг, обновления правил, индустрия и события).
 
-## Источники
+## Системы
 
-### D&D
-
-- [SRD 5.2.1](https://www.dndbeyond.com/srd) — System Reference Document 5.2.1 от Wizards of the Coast LLC, под лицензией [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
-- [dndsrd5.2_markdown](https://github.com/springbov/dndsrd5.2_markdown) — английский SRD 5.2 в Markdown
-- [dndsrd5.2_markdown (yuvalsapir)](https://github.com/yuvalsapir/dndsrd5.2_markdown) — обновления до 5.2.1
-- [DND.SRD.Wiki](https://github.com/oldmanumby/DND.SRD.Wiki) — SRD 5.1 в Markdown (wiki)
-- [dnd-5e-srd-markdown](https://github.com/downfallx/dnd-5e-srd-markdown) — недостающие стат-блоки драконов
-- [Lazy GM Tools](https://github.com/mshea/lazy_gm_tools) / [slyflourish.com](https://slyflourish.com/) — данные монстров
-
-### Инструменты
-
-- [marker](https://github.com/VikParuchuri/marker) — конвертация PDF → Markdown
-
-## Дорожная карта
-
-### Готово / запланировано / рассматривается
-
-| Статус | Система | Издатель | Лицензия | Формат SRD |
+| Статус | Система | Издатель | Лицензия | Примечания |
 |:---:|---|---|---|---|
-| :white_check_mark: | D&D SRD 5.2.1 | Wizards of the Coast | CC BY 4.0 | [PDF](https://www.dndbeyond.com/srd) |
-| :white_check_mark: | D&D SRD 5.1 | Wizards of the Coast | CC BY 4.0 | [PDF](https://www.dndbeyond.com/srd) |
-| :white_check_mark: | Daggerheart SRD 1.0 | Darrington Press | [DPCGL](https://darringtonpress.com/license/) | [PDF](https://www.daggerheart.com/srd/), [Markdown](https://github.com/seansbox/daggerheart-srd) |
-| :white_check_mark: | Basic Roleplaying (BRP) | Chaosium | [BRP OGL v1.0](https://www.chaosium.com/brp-system-reference-document/) | [PDF](https://www.chaosium.com/brp-system-reference-document/) |
-| :calendar: | Pathfinder 2e | Paizo | [ORC](https://paizo.com/orclicense) | [Web](https://2e.aonprd.com/) |
-| :calendar: | Starfinder 2e | Paizo | [ORC](https://paizo.com/orclicense) | [Web](https://2e.aonsrd.com/) |
-| :calendar: | Year Zero Engine | Free League | [FTL](https://freeleaguepublishing.com/community-content/free-tabletop-licenses/) | [PDF](https://freeleaguepublishing.com/wp-content/uploads/2023/11/YZE-Standard-Reference-Document.pdf) |
-| :grey_question: | Dragonbane | Free League | [3rd Party License](https://freeleaguepublishing.com/community-content/free-tabletop-licenses/) | PDF |
-| :grey_question: | Fate Core / FAE | Evil Hat Productions | CC BY 3.0 | [Web](https://fate-srd.com/), [Markdown](https://github.com/amazingrando/fate-srd-content) |
-| :grey_question: | Blades in the Dark | One Seven Design | CC BY 3.0 | [Web](https://bladesinthedark.com/), [Markdown](https://github.com/amazingrando/blades-in-the-dark-srd-content) |
-| :grey_question: | Dungeon World | Sage LaTorra | CC BY 3.0 | [Web](https://www.dungeonworldsrd.com/), [GitHub](https://github.com/Sagelt/Dungeon-World) |
-| :grey_question: | 13th Age (Archmage Engine) | Pelgrane Press | OGL 1.0a | [Web](https://www.13thagesrd.com/), [PDF](https://pelgranepress.com/media/SRD/13thAgeArchmageEngineSRD.pdf) |
-| :grey_question: | MORK BORG | Free League | [3rd Party License](https://morkborg.com/license/) | [Web](https://morkborg.com/content/) |
-| :grey_question: | Worlds Without Number | Sine Nomine | CC0 | PDF (DriveThruRPG) |
-| :grey_question: | Cypher System | Monte Cook Games | [CSOL](https://www.montecookgames.com/cypher-system-open-license/) | [Web](https://callmepartario.github.io/og-csrd/) |
+| ✅ | D&D SRD 5.2.1 | Wizards of the Coast | CC BY 4.0 | [PDF](https://www.dndbeyond.com/srd) |
+| ✅ | D&D SRD 5.1 | Wizards of the Coast | CC BY 4.0 | [PDF](https://www.dndbeyond.com/srd) |
+| ✅ | Daggerheart SRD 1.0 | Darrington Press | [DPCGL](https://darringtonpress.com/license/) | [PDF](https://www.daggerheart.com/srd/), [Markdown](https://github.com/seansbox/daggerheart-srd) |
+| ✅ | Basic Roleplaying (BRP) | Chaosium | [BRP OGL v1.0](https://www.chaosium.com/brp-system-reference-document/) | [PDF](https://www.chaosium.com/brp-system-reference-document/) |
+| 📅 | Pathfinder 2e | Paizo | [ORC](https://paizo.com/orclicense) | [Web](https://2e.aonprd.com/) |
+| 📅 | Starfinder 2e | Paizo | [ORC](https://paizo.com/orclicense) | [Web](https://2e.aonsrd.com/) |
+| 📅 | Year Zero Engine | Free League | [FTL](https://freeleaguepublishing.com/community-content/free-tabletop-licenses/) | [PDF](https://freeleaguepublishing.com/wp-content/uploads/2023/11/YZE-Standard-Reference-Document.pdf) |
+| ❓ | Dragonbane | Free League | [3rd Party License](https://freeleaguepublishing.com/community-content/free-tabletop-licenses/) | PDF |
+| ❓ | Fate Core / FAE | Evil Hat Productions | CC BY 3.0 | [Web](https://fate-srd.com/), [Markdown](https://github.com/amazingrando/fate-srd-content) |
+| ❓ | Blades in the Dark | One Seven Design | CC BY 3.0 | [Web](https://bladesinthedark.com/), [Markdown](https://github.com/amazingrando/blades-in-the-dark-srd-content) |
+| ❓ | Dungeon World | Sage LaTorra | CC BY 3.0 | [Web](https://www.dungeonworldsrd.com/), [GitHub](https://github.com/Sagelt/Dungeon-World) |
+| ❓ | 13th Age (Archmage Engine) | Pelgrane Press | OGL 1.0a | [Web](https://www.13thagesrd.com/), [PDF](https://pelgranepress.com/media/SRD/13thAgeArchmageEngineSRD.pdf) |
+| ❓ | MORK BORG | Free League | [3rd Party License](https://morkborg.com/license/) | [Web](https://morkborg.com/content/) |
+| ❓ | Worlds Without Number | Sine Nomine | CC0 | PDF (DriveThruRPG) |
+| ❓ | Cypher System | Monte Cook Games | [CSOL](https://www.montecookgames.com/cypher-system-open-license/) | [Web](https://callmepartario.github.io/og-csrd/) |
+| 🚫 | World of Darkness (VtM, WtA, DtD…) | Paradox Interactive | — | Нет открытого SRD; [Dark Pack](https://worldofdarkness.com/dark-pack) покрывает только бесплатный фанатский контент |
+| 🚫 | 2d20 (Dune, Fallout, Star Trek…) | Modiphius | — | SRD существует, но [World Builders](https://modiphius.net/en-us/pages/2d20worldbuilders) привязан к DriveThruRPG; свободное распространение не разрешено |
 
-> :white_check_mark: — готово · :calendar: — запланировано · :grey_question: — рассматривается
-
-### Лицензия не позволяет
-
-| Система | Издатель | Причина |
-|---|---|---|
-| World of Darkness (VtM, WtA, DtD…) | Paradox Interactive | Нет открытого SRD. [Dark Pack](https://worldofdarkness.com/dark-pack) покрывает только бесплатный фанатский контент |
-| 2d20 (Dune, Fallout, Star Trek…) | Modiphius | SRD существует, но [World Builders](https://modiphius.net/en-us/pages/2d20worldbuilders) привязан к DriveThruRPG; свободное распространение не разрешено |
+> ✅ готово · 📅 запланировано · ❓ рассматривается · 🚫 лицензия не позволяет
 
 ## Лицензии
 
@@ -86,6 +62,23 @@
 - `src/{game}/{version}/{en,ru}/` — Markdown-контент (вход пайплайна импорта/перевода)
 - `web/` — статический ридер на [Astro](https://astro.build), публикуемый на rules.omnisgm.com
 - `.claude/` — пайплайн импорта и перевода (скиллы + правила). См. [CLAUDE.md](CLAUDE.md)
+
+## Как участвовать
+
+**Issues и контрибьюции приветствуются — по возможности оформляйте их на английском.** Так проект
+остаётся доступным для самой широкой аудитории. Русский тоже подойдёт, если с английским тяжело, —
+но английский предпочтителен.
+
+## Благодарности и инструменты
+
+Markdown-исходники, на которых строится пайплайн импорта:
+
+- [dndsrd5.2_markdown](https://github.com/springbov/dndsrd5.2_markdown) — английский SRD 5.2 в Markdown
+- [dndsrd5.2_markdown (yuvalsapir)](https://github.com/yuvalsapir/dndsrd5.2_markdown) — обновления до 5.2.1
+- [DND.SRD.Wiki](https://github.com/oldmanumby/DND.SRD.Wiki) — SRD 5.1 в Markdown (wiki)
+- [dnd-5e-srd-markdown](https://github.com/downfallx/dnd-5e-srd-markdown) — недостающие стат-блоки драконов
+- [Lazy GM Tools](https://github.com/mshea/lazy_gm_tools) / [slyflourish.com](https://slyflourish.com/) — данные монстров
+- [marker](https://github.com/VikParuchuri/marker) — конвертация PDF → Markdown
 
 ---
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,92 @@
+# OmnisGM Rules — Markdown-версии SRD настольных игр
+
+[English](README.md) · **Русский**
+
+[Живой сайт](https://rules.omnisgm.com)
+
+Кураторская подборка **System Reference Document (SRD)** настольных ролевых игр в Markdown,
+опубликованная как быстрый статический ридер на **rules.omnisgm.com**. Часть экосистемы **OmnisGM**.
+Контент доступен на **английском и русском** (русское издание — полный перевод, управляемый глоссарием).
+
+> **Issues и контрибьюции приветствуются — по возможности оформляйте их на английском.** Так проект
+> остаётся доступным для самой широкой аудитории. Русский тоже подойдёт, если с английским тяжело, —
+> но английский предпочтителен.
+
+## Экосистема OmnisGM
+
+Этот ридер SRD — один из трёх продуктов **OmnisGM**, инструментов для настольных ролевых игр за
+**очным столом**:
+
+- **[OmnisGM](https://omnisgm.com)** — флагманское приложение: бесплатные realtime-**листы персонажа
+  D&D 2024** для очной игры. Каждый игрок держит свой лист на своём телефоне, а Мастер видит все
+  изменения вживую. Устанавливаемое PWA, работает офлайн. Правила из этого репозитория — те самые,
+  вокруг которых построены эти листы.
+- **[OmnisGM Rules](https://rules.omnisgm.com)** — этот проект: быстрый статический двуязычный (EN/RU)
+  ридер открытых SRD с чистым цитируемым HTML и публичными Markdown-исходниками.
+- **[The Guild Herald](https://news.omnisgm.com)** — OmnisGM News: двуязычная (EN/RU) лента новостей
+  настольных ролевых игр (релизы, краудфандинг, обновления правил, индустрия и события).
+
+## Источники
+
+### D&D
+
+- [SRD 5.2.1](https://www.dndbeyond.com/srd) — System Reference Document 5.2.1 от Wizards of the Coast LLC, под лицензией [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
+- [dndsrd5.2_markdown](https://github.com/springbov/dndsrd5.2_markdown) — английский SRD 5.2 в Markdown
+- [dndsrd5.2_markdown (yuvalsapir)](https://github.com/yuvalsapir/dndsrd5.2_markdown) — обновления до 5.2.1
+- [DND.SRD.Wiki](https://github.com/oldmanumby/DND.SRD.Wiki) — SRD 5.1 в Markdown (wiki)
+- [dnd-5e-srd-markdown](https://github.com/downfallx/dnd-5e-srd-markdown) — недостающие стат-блоки драконов
+- [Lazy GM Tools](https://github.com/mshea/lazy_gm_tools) / [slyflourish.com](https://slyflourish.com/) — данные монстров
+
+### Инструменты
+
+- [marker](https://github.com/VikParuchuri/marker) — конвертация PDF → Markdown
+
+## Дорожная карта
+
+### Готово / запланировано / рассматривается
+
+| Статус | Система | Издатель | Лицензия | Формат SRD |
+|:---:|---|---|---|---|
+| :white_check_mark: | D&D SRD 5.2.1 | Wizards of the Coast | CC BY 4.0 | [PDF](https://www.dndbeyond.com/srd) |
+| :white_check_mark: | D&D SRD 5.1 | Wizards of the Coast | CC BY 4.0 | [PDF](https://www.dndbeyond.com/srd) |
+| :white_check_mark: | Daggerheart SRD 1.0 | Darrington Press | [DPCGL](https://darringtonpress.com/license/) | [PDF](https://www.daggerheart.com/srd/), [Markdown](https://github.com/seansbox/daggerheart-srd) |
+| :white_check_mark: | Basic Roleplaying (BRP) | Chaosium | [BRP OGL v1.0](https://www.chaosium.com/brp-system-reference-document/) | [PDF](https://www.chaosium.com/brp-system-reference-document/) |
+| :calendar: | Pathfinder 2e | Paizo | [ORC](https://paizo.com/orclicense) | [Web](https://2e.aonprd.com/) |
+| :calendar: | Starfinder 2e | Paizo | [ORC](https://paizo.com/orclicense) | [Web](https://2e.aonsrd.com/) |
+| :calendar: | Year Zero Engine | Free League | [FTL](https://freeleaguepublishing.com/community-content/free-tabletop-licenses/) | [PDF](https://freeleaguepublishing.com/wp-content/uploads/2023/11/YZE-Standard-Reference-Document.pdf) |
+| :grey_question: | Dragonbane | Free League | [3rd Party License](https://freeleaguepublishing.com/community-content/free-tabletop-licenses/) | PDF |
+| :grey_question: | Fate Core / FAE | Evil Hat Productions | CC BY 3.0 | [Web](https://fate-srd.com/), [Markdown](https://github.com/amazingrando/fate-srd-content) |
+| :grey_question: | Blades in the Dark | One Seven Design | CC BY 3.0 | [Web](https://bladesinthedark.com/), [Markdown](https://github.com/amazingrando/blades-in-the-dark-srd-content) |
+| :grey_question: | Dungeon World | Sage LaTorra | CC BY 3.0 | [Web](https://www.dungeonworldsrd.com/), [GitHub](https://github.com/Sagelt/Dungeon-World) |
+| :grey_question: | 13th Age (Archmage Engine) | Pelgrane Press | OGL 1.0a | [Web](https://www.13thagesrd.com/), [PDF](https://pelgranepress.com/media/SRD/13thAgeArchmageEngineSRD.pdf) |
+| :grey_question: | MORK BORG | Free League | [3rd Party License](https://morkborg.com/license/) | [Web](https://morkborg.com/content/) |
+| :grey_question: | Worlds Without Number | Sine Nomine | CC0 | PDF (DriveThruRPG) |
+| :grey_question: | Cypher System | Monte Cook Games | [CSOL](https://www.montecookgames.com/cypher-system-open-license/) | [Web](https://callmepartario.github.io/og-csrd/) |
+
+> :white_check_mark: — готово · :calendar: — запланировано · :grey_question: — рассматривается
+
+### Лицензия не позволяет
+
+| Система | Издатель | Причина |
+|---|---|---|
+| World of Darkness (VtM, WtA, DtD…) | Paradox Interactive | Нет открытого SRD. [Dark Pack](https://worldofdarkness.com/dark-pack) покрывает только бесплатный фанатский контент |
+| 2d20 (Dune, Fallout, Star Trek…) | Modiphius | SRD существует, но [World Builders](https://modiphius.net/en-us/pages/2d20worldbuilders) привязан к DriveThruRPG; свободное распространение не разрешено |
+
+## Лицензии
+
+Каждый SRD распространяется под своей лицензией. См. `LICENSE.md` в соответствующей папке.
+
+- D&D SRD 5.2 — CC BY 4.0: [LICENSE.md](src/dnd/srd-5.2/LICENSE.md) | [LICENSE-RU.md](src/dnd/srd-5.2/LICENSE-RU.md)
+- D&D SRD 5.1 — CC BY 4.0: [LICENSE.md](src/dnd/srd-5.1/LICENSE.md) | [LICENSE-RU.md](src/dnd/srd-5.1/LICENSE-RU.md)
+- Daggerheart SRD 1.0 — DPCGL © Critical Role, LLC (не аффилировано с Darrington Press и не одобрено ими); см. встроенную [страницу Legal](src/daggerheart/srd-1.0/en/00_Legal.md)
+- Basic Roleplaying SRD 1.0 — BRP OGL v1.0 © Chaosium Inc.: [LICENSE.md](src/brp/srd-1.0/LICENSE.md)
+
+## Структура репозитория
+
+- `src/{game}/{version}/{en,ru}/` — Markdown-контент (вход пайплайна импорта/перевода)
+- `web/` — статический ридер на [Astro](https://astro.build), публикуемый на rules.omnisgm.com
+- `.claude/` — пайплайн импорта и перевода (скиллы + правила). См. [CLAUDE.md](CLAUDE.md)
+
+---
+
+*Это неофициальный фанатский проект. Все товарные знаки принадлежат их правообладателям.*


### PR DESCRIPTION
## Что и зачем

Rules — **единственный публичный репозиторий** экосистемы, а README публичных репо активно читают AI-краулеры и LLM (пункт AI-видимости из Table#88).

**Два изменения:**

1. **Ecosystem-ссылки.** В интро было «Part of the OmnisGM ecosystem» **без единой ссылки** — краулер не находил флагман. Добавлен раздел «The OmnisGM ecosystem» с прямыми ссылками на omnisgm.com (флагман), rules и news.
2. **Русская версия.** Экосистема двуязычна (EN/RU), а один из контрольных запросов мониторинга AI-видимости — **русский** («где почитать SRD 5.2 на русском»). Добавлен `README.ru.md` (полный перевод) + строка-переключатель **EN/RU** вверху обоих файлов. Названия систем/издателей/лицензий и ссылки оставлены как есть.

Только документация, кода/сборки не касается. CI (astro check+build) без изменений.

Связано: Table#88 (AI-видимость экосистемы).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnZqPj9LYvNCSz8MiWxqLo