### PR TITLE
chore(deps): @omnisgm-app/brand → ^0.5.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/sitemap": "^3.3.0",
-        "@omnisgm-app/brand": "^0.4.0",
+        "@omnisgm-app/brand": "^0.5.0",
         "astro": "^5.7.0"
       },
       "devDependencies": {
@@ -2865,9 +2865,9 @@
       }
     },
     "node_modules/@omnisgm-app/brand": {
-      "version": "0.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.4.0/ba864e5289832f8902b5083ad274e86d1bb7454b",
-      "integrity": "sha512-MjnvOaLIXHlRKM7/65SfnKxMUq0nhAh0ydfnHxri5TuWpd+9K/wdvKfdUMXzlHK9uSQYodYSFenukLwyTrcu5w=="
+      "version": "0.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.5.0/856e2e375efc8f6bfeced71d0e7ac28983673623",
+      "integrity": "sha512-UlBVJrsV+351dDyXHGLDgI2w8QnWwRFm2iLr3xEinn+RJSZeserwJEMiy9AB8zFb4905PXswnWu9Nh6U6Yvzag=="
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.3.0",
-    "@omnisgm-app/brand": "^0.4.0",
+    "@omnisgm-app/brand": "^0.5.0",
     "astro": "^5.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Parity-бамп бренд-пакета до `0.5.0` (синхронизация экосистемы после апдейта Table).

`0.5.0` = `0.4.0` + иконка App Store (`icon-1024.png`); токены/CSS не менялись → **визуально no-op** для Rules. Диф минимальный (dep + lockfile-запись brand, в `web/`).

CI (astro check + build) проверит `npm ci` + сборку. E2E у Rules локальный и токен-идентичным бампом не затрагивается.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnZqPj9LYvNCSz8MiWxqLo