### PR TITLE
Глоссарий srd-5.2: исправить регистр в расшифровке NPC

### DIFF
--- a/src/dnd/srd-5.2/ru/14_Glossary/00_Glossary.md
+++ b/src/dnd/srd-5.2/ru/14_Glossary/00_Glossary.md
@@ -27,7 +27,7 @@
 | N | Н | Neutral | Нейтральный |
 | NE | НЗ | Neutral Evil | Нейтрально-злой |
 | NG | НД | Neutral Good | Нейтрально-добрый |
-| NPC | НИП | Nonplayer character | Неигровой персонаж |
+| NPC | НИП | Nonplayer Character | Неигровой персонаж |
 | PB | БМ | Proficiency Bonus | Бонус Мастерства |
 | PP | пм | Platinum Piece(s) | платиновая монета |
 | R | Р | Ritual | Ритуал |


### PR DESCRIPTION
## Проблема

Найдено при перепроверке глоссария. В `ru/14_Glossary/00_Glossary.md` таблица сокращений даёт английскую расшифровку `NPC` строчными — «Nonplayer **c**haracter», хотя:
- авторитетная EN-таблица сокращений (`en/14_Glossary/00_Glossary.md:30`) = «Nonplayer **C**haracter»
- сам RU-глоссарий в категории (стр. 469) = «Nonplayer **C**haracter (NPC)»

Внутренняя нестыковка регистра.

## Исправление
`| NPC | НИП | Nonplayer character | …` → `Nonplayer Character` (1 символ).

Кросс-сверка сокращений после фикса: 0 расхождений.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP