### PR TITLE
feat(seo): programmatic-страницы состояний — вертикальный срез (#20)

### DIFF
--- a/.github/scripts/generate_api.py
+++ b/.github/scripts/generate_api.py
@@ -13,19 +13,69 @@ from pathlib import Path
 # Add scripts dir to path so parsers package is importable
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import jsonschema
+# jsonschema is only needed for validation. Keep it optional so build-time data
+# generation (Astro prebuild → getStaticPaths) can run with plain python3, without
+# installing pip packages in CI.
+try:
+    import jsonschema
+except ImportError:
+    jsonschema = None
 
 from config import (SOURCES, SKIP_HEADINGS_SPELL, SKIP_HEADINGS_MONSTER,
                     SKIP_HEADINGS_EQUIPMENT, SKIP_HEADINGS_FEAT)
 from parsers import (parse_spells, parse_monsters, parse_magic_items,
                      parse_weapons, parse_armor, parse_equipment,
                      parse_conditions, parse_feats)
+from parsers.base import slugify
 from schemas import RESOURCE_SCHEMAS
 
 SYSTEM = "dnd"
 SYSTEM_NAME = "Dungeons & Dragons"
 
 VERSION_NAMES = {"srd52": "SRD 5.2.1", "srd51": "SRD 5.1"}
+
+
+_RU_EN_MAP_CACHE: dict[str, dict[str, str]] = {}
+
+
+def load_ru_to_en_map(src_root: Path) -> dict[str, str]:
+    """Build {RU term → EN term} from the authoritative base dictionary.
+
+    Used to backfill name_en (and thus a canonical English slug) for RU entities
+    whose headings lack the "(English)" suffix — notably conditions, which read
+    "#### Ослеплённый [Состояние]" with no inline English. Columns:
+    | Оригинал 5.2 | Оригинал 5.1 | Перевод | ... |  → map[Перевод] = Оригинал 5.2.
+    """
+    key = str(src_root)
+    if key in _RU_EN_MAP_CACHE:
+        return _RU_EN_MAP_CACHE[key]
+
+    mapping: dict[str, str] = {}
+    dict_path = src_root / "translate" / "01_dictionary_base.md"
+    if dict_path.is_file():
+        for line in dict_path.read_text(encoding="utf-8").splitlines():
+            if not line.startswith("|") or "---" in line:
+                continue
+            cells = [c.strip() for c in line.strip().strip("|").split("|")]
+            if len(cells) >= 3 and cells[0] not in ("Оригинал 5.2", "Оригинал"):
+                en, ru = cells[0], cells[2]
+                if en and ru and en != "—" and ru not in mapping:
+                    mapping[ru] = en
+    _RU_EN_MAP_CACHE[key] = mapping
+    return mapping
+
+
+def backfill_name_en(entities: list[dict], src_root: Path) -> None:
+    """For RU entities missing name_en, fill it from the base dictionary and
+    re-slug on the canonical English name (so /ru and /en share one slug)."""
+    mapping = load_ru_to_en_map(src_root)
+    for entity in entities:
+        if entity.get("name_en"):
+            continue
+        en = mapping.get(entity.get("name", ""))
+        if en:
+            entity["name_en"] = en
+            entity["slug"] = slugify(en)
 
 
 def resolve_cross_refs(all_data: dict) -> None:
@@ -162,6 +212,8 @@ def main():
     parser.add_argument("--output-dir", required=True, help="Output directory for JSON API (e.g. site/api)")
     parser.add_argument("--individual", action="store_true",
                         help="Generate individual {slug}.json files (default: only all.json per resource)")
+    parser.add_argument("--no-validate", action="store_true",
+                        help="Skip JSON Schema validation (for build-time data generation without jsonschema)")
     args = parser.parse_args()
 
     src_root = Path(args.src_root)
@@ -213,6 +265,8 @@ def main():
         elif entity_type == "condition":
             entities = parse_conditions(text, heading_level, lang, after)
             resource = "conditions"
+            if lang == "ru":
+                backfill_name_en(entities, src_root)
         elif entity_type == "feat":
             entities = parse_feats(text, heading_level, lang, after, SKIP_HEADINGS_FEAT)
             resource = "feats"
@@ -237,10 +291,15 @@ def main():
     file_count = 0
 
     # Validate all parsed entities against JSON Schemas
-    for (ver, lang, resource), entities in all_data.items():
-        schema = RESOURCE_SCHEMAS.get(resource)
-        if schema:
-            validate_entities(entities, schema, resource, f"{ver}/{lang}")
+    if args.no_validate:
+        print("  (schema validation skipped: --no-validate)", file=sys.stderr)
+    elif jsonschema is None:
+        print("  Warning: jsonschema not installed — skipping validation", file=sys.stderr)
+    else:
+        for (ver, lang, resource), entities in all_data.items():
+            schema = RESOURCE_SCHEMAS.get(resource)
+            if schema:
+                validate_entities(entities, schema, resource, f"{ver}/{lang}")
 
     # Collectors for hierarchical meta files
     # ver → lang → resource → slugs

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -18,3 +18,6 @@ public/icon-512.png
 public/maskable-192.png
 public/maskable-512.png
 public/apple-touch-icon.png
+
+# Сгенерированные данные сущностей для programmatic-страниц (prebuild)
+src/data/api/

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@astrojs/sitemap": "^3.3.0",
         "@omnisgm-app/brand": "^0.5.0",
-        "astro": "^5.7.0"
+        "astro": "^5.7.0",
+        "marked": "^14.1.4"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
@@ -6872,6 +6873,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.4.tgz",
+      "integrity": "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/web/package.json
+++ b/web/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "description": "rules.omnisgm.com — Astro (SSG) SRD reader for the OmnisGM ecosystem",
   "scripts": {
-    "predev": "node scripts/copy-brand-assets.mjs",
+    "predev": "node scripts/copy-brand-assets.mjs && node scripts/gen-entity-data.mjs",
     "dev": "astro dev",
-    "prebuild": "node scripts/copy-brand-assets.mjs",
+    "prebuild": "node scripts/copy-brand-assets.mjs && node scripts/gen-entity-data.mjs",
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",
@@ -17,7 +17,8 @@
   "dependencies": {
     "@astrojs/sitemap": "^3.3.0",
     "@omnisgm-app/brand": "^0.5.0",
-    "astro": "^5.7.0"
+    "astro": "^5.7.0",
+    "marked": "^14.1.4"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",

--- a/web/scripts/gen-entity-data.mjs
+++ b/web/scripts/gen-entity-data.mjs
@@ -1,0 +1,35 @@
+// Build-time entity data for programmatic pages (issue #20).
+//
+// getStaticPaths needs structured entity JSON at BUILD time, but the public
+// /api is generated at DEPLOY (firebase predeploy, after astro build). So we run
+// the SAME parser here, before astro build, writing to src/data/api/ (gitignored).
+// --no-validate keeps it dependency-free (plain python3, no jsonschema) so it
+// runs in CI without extra setup.
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..'); // .../OmnisGM-Rules
+const script = resolve(repoRoot, '.github/scripts/generate_api.py');
+const srcRoot = resolve(repoRoot, 'src/dnd');
+const outDir = resolve(here, '../src/data/api');
+const python = process.env.PYTHON || 'python3';
+
+if (!existsSync(script)) {
+  console.error(`[gen-entity-data] parser not found: ${script}`);
+  process.exit(1);
+}
+
+try {
+  execFileSync(
+    python,
+    [script, '--src-root', srcRoot, '--output-dir', outDir, '--no-validate'],
+    { stdio: 'inherit' },
+  );
+  console.log(`[gen-entity-data] entity data → ${outDir}`);
+} catch (err) {
+  console.error('[gen-entity-data] generation failed:', err.message);
+  process.exit(1);
+}

--- a/web/src/lib/entities.ts
+++ b/web/src/lib/entities.ts
@@ -1,0 +1,51 @@
+// Загрузка структурированных сущностей (заклинания/состояния/…) для programmatic-страниц.
+// Данные готовит prebuild-скрипт (scripts/gen-entity-data.mjs) в src/data/api/ — тот же
+// парсер, что и публичный /api. Читаем с диска в getStaticPaths (Node на этапе билда).
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Билд запускается из web/ (cwd) — резолвим от него, а не от import.meta.url
+// (в бандле Astro последний указывает в dist/ и ломает относительный путь).
+const DATA_ROOT = path.resolve(process.cwd(), 'src/data/api');
+
+// Ключ версии в API → сегмент версии в URL (как в читалке).
+export const VERSION_SLUG: Record<string, string> = {
+  srd52: 'srd-5.2',
+  srd51: 'srd-5.1',
+};
+
+// Короткая метка версии для заголовков/сниппетов.
+export const VERSION_LABEL: Record<string, string> = {
+  srd52: '5.2',
+  srd51: '5.1',
+};
+
+export interface Entity {
+  slug: string;
+  name: string;
+  name_en?: string | null;
+  description_md?: string;
+  [key: string]: unknown;
+}
+
+export function loadEntities(ver: string, lang: string, resource: string): Entity[] {
+  const file = path.join(DATA_ROOT, 'dnd', ver, lang, resource, 'all.json');
+  if (!fs.existsSync(file)) return [];
+  return JSON.parse(fs.readFileSync(file, 'utf-8')) as Entity[];
+}
+
+// Плоский текстовый сниппет из markdown (для <meta description>): снимаем разметку,
+// схлопываем пробелы, режем по границе слова до ~limit символов.
+export function excerpt(md: string | undefined, limit = 155): string {
+  if (!md) return '';
+  const plain = md
+    .replace(/\*\*_?([^*]+?)_?\*\*/g, '$1') // bold / bold-italic
+    .replace(/[*_`>#]/g, '')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // ссылки → текст
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (plain.length <= limit) return plain;
+  const cut = plain.slice(0, limit);
+  const lastSpace = cut.lastIndexOf(' ');
+  return `${cut.slice(0, lastSpace > 0 ? lastSpace : limit).trim()}…`;
+}

--- a/web/src/pages/[lang]/dnd/[version]/conditions/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/conditions/[slug].astro
@@ -1,0 +1,228 @@
+---
+import { marked } from 'marked';
+import Reader from '../../../../../layouts/Reader.astro';
+import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
+
+export function getStaticPaths() {
+  // Вертикальный срез (issue #20, волна 1): bilingual страницы состояний, srd-5.2.
+  // RU и EN делят один канонический (английский) слаг → корректный hreflang.
+  // (RU-слаги состояний чинятся в generate_api: backfill name_en из base-словаря.)
+  // 5.1 добавляется одной строкой в BUILDS.
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as const },
+    { ver: 'srd52', lang: 'ru' as const },
+  ];
+  const paths = [];
+  for (const { ver, lang } of BUILDS) {
+    const conditions = loadEntities(ver, lang, 'conditions');
+    const siblings = conditions.map((c) => ({ slug: c.slug, name: c.name }));
+    for (const entity of conditions) {
+      paths.push({
+        params: { lang, version: VERSION_SLUG[ver], slug: entity.slug },
+        props: { entity, ver, lang, siblings },
+      });
+    }
+  }
+  return paths;
+}
+
+const { entity, ver, lang, siblings } = Astro.props;
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+
+const bodyHtml = marked.parse(entity.description_md ?? '', { async: false });
+const description = excerpt(entity.description_md);
+
+const base = `/${lang}/dnd/${verSlug}`;
+const pagePath = `${base}/conditions/${entity.slug}/`;
+const chapterPath = `${base}/rules-glossary/`;
+const canonical = new URL(pagePath, Astro.site).toString();
+
+// EN и RU делят слаг → hreflang-пара (Reader ждёт пути от корня).
+const alternates = {
+  en: `/en/dnd/${verSlug}/conditions/${entity.slug}/`,
+  ru: `/ru/dnd/${verSlug}/conditions/${entity.slug}/`,
+  xDefault: `/en/dnd/${verSlug}/conditions/${entity.slug}/`,
+};
+
+const kind = t('Состояние', 'Condition');
+const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel} ${kind}`)}`;
+
+const related = siblings.filter((s) => s.slug !== entity.slug);
+
+// CTA-дип-линк в основной продукт (лист персонажа). Точечный якорь компендиума — TODO,
+// пока ведём на продукт с utm-меткой источника.
+const ctaUrl = 'https://omnisgm.com/?utm_source=rules&utm_medium=entity&utm_campaign=conditions';
+
+const crumbs = [
+  { name: `D&D SRD ${verLabel}`, href: `${base}/legal/` },
+  { name: t('Глоссарий правил', 'Rules Glossary'), href: chapterPath },
+  { name: t('Состояния', 'Conditions'), href: null },
+  { name: entity.name, href: null },
+];
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'DefinedTerm',
+      '@id': `${canonical}#term`,
+      name: entity.name,
+      description: excerpt(entity.description_md, 300),
+      inDefinedTermSet: {
+        '@type': 'DefinedTermSet',
+        name: t(`D&D SRD ${verLabel} — Состояния`, `Dungeons & Dragons SRD ${verLabel} — Conditions`),
+      },
+      url: canonical,
+    },
+    {
+      '@type': 'BreadcrumbList',
+      itemListElement: crumbs.map((c, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        name: c.name,
+        ...(c.href ? { item: new URL(c.href, Astro.site).toString() } : {}),
+      })),
+    },
+  ],
+};
+---
+
+<Reader title={title} description={description} lang={lang} canonical={canonical} jsonLd={jsonLd} alternates={alternates}>
+  <main class="ent">
+    <nav class="ent-crumbs" aria-label="Breadcrumb">
+      {crumbs.map((c, i) => (
+        <>
+          {i > 0 && <span class="sep">/</span>}
+          {c.href ? <a href={c.href}>{c.name}</a> : <span>{c.name}</span>}
+        </>
+      ))}
+    </nav>
+
+    <header class="ent-head">
+      <span class="ent-kind">{kind} · D&D {verLabel}</span>
+      <h1>{entity.name}</h1>
+      {entity.name_en && lang === 'ru' && <span class="ent-en">{entity.name_en}</span>}
+    </header>
+
+    <article class="rd-doc" set:html={bodyHtml} />
+
+    <aside class="ent-changes">
+      <h2>{t('Изменения в 5.2', 'Changes in 5.2')}</h2>
+      <p class="muted">{t(
+        'Автогенерируемый дифф 5.1 → 5.2 появится здесь (issue #20 §2.2). Заглушка среза.',
+        'Auto-generated 5.1 → 5.2 diff will appear here (issue #20 §2.2). Slice placeholder.',
+      )}</p>
+    </aside>
+
+    <a class="ent-cta" href={ctaUrl} rel="nofollow">
+      {t('Открыть в OmnisGM — лист персонажа →', 'Open in OmnisGM — character sheet →')}
+    </a>
+
+    {related.length > 0 && (
+      <section class="ent-related">
+        <h2>{t('Другие состояния', 'Other conditions')}</h2>
+        <ul>
+          {related.map((r) => (
+            <li><a href={`${base}/conditions/${r.slug}/`}>{r.name}</a></li>
+          ))}
+        </ul>
+      </section>
+    )}
+
+    <p class="ent-source">
+      {t('Источник', 'Source')}: <a href={chapterPath}>{t('Глоссарий правил', 'Rules Glossary')} · D&D SRD {verLabel}</a>
+    </p>
+  </main>
+</Reader>
+
+<style>
+  .ent {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 32px 20px 80px;
+    font-family: var(--font-body);
+    color: var(--og-text-2);
+  }
+  .ent-crumbs {
+    font-size: 13px;
+    color: var(--og-text-muted);
+    margin-bottom: 24px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+  }
+  .ent-crumbs a { color: var(--og-text-muted); text-decoration: none; }
+  .ent-crumbs a:hover { color: var(--og-accent); }
+  .ent-crumbs .sep { color: var(--og-decor); }
+
+  .ent-head { margin-bottom: 8px; }
+  .ent-kind {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: var(--og-accent);
+  }
+  .ent-head h1 {
+    font-family: var(--font-display);
+    font-size: 40px;
+    line-height: 1.06;
+    letter-spacing: -1.2px;
+    font-weight: 600;
+    margin: 6px 0 4px;
+    color: var(--og-text);
+  }
+  .ent-en {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 14px;
+    color: var(--og-text-muted);
+    margin-bottom: 24px;
+  }
+
+  .ent-changes {
+    margin: 32px 0;
+    padding: 16px 20px;
+    border: 1px solid var(--og-border);
+    border-radius: 12px;
+    background: var(--og-bg-2, transparent);
+  }
+  .ent-changes h2 { font-size: 15px; margin: 0 0 4px; color: var(--og-text); }
+  .muted { color: var(--og-text-muted); font-size: 14px; margin: 0; }
+
+  .ent-cta {
+    display: inline-block;
+    margin: 24px 0;
+    padding: 12px 20px;
+    border-radius: 10px;
+    background: var(--og-accent);
+    color: #0F1016;
+    font-weight: 600;
+    text-decoration: none;
+  }
+  .ent-cta:hover { filter: brightness(1.08); }
+
+  .ent-related { margin-top: 40px; }
+  .ent-related h2 { font-size: 18px; color: var(--og-text); margin-bottom: 12px; }
+  .ent-related ul {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 14px;
+  }
+  .ent-related a { color: var(--og-accent); text-decoration: none; }
+  .ent-related a:hover { text-decoration: underline; }
+
+  .ent-source {
+    margin-top: 40px;
+    padding-top: 20px;
+    border-top: 1px solid var(--og-border);
+    font-size: 14px;
+    color: var(--og-text-muted);
+  }
+  .ent-source a { color: var(--og-accent); text-decoration: none; }
+</style>


### PR DESCRIPTION
Первый вертикальный срез волны 1 [#20](https://github.com/OmnisGM-App/OmnisGM-Rules/issues/20): страницы отдельных сущностей из JSON API через `getStaticPaths`. Область — **состояния**, srd-5.2, **EN+RU (15×2)**. Доказывает весь пайплайн перед масштабированием на ~2000 сущностей.

## Пайплайн (что доказано)
| Слой | Решение |
|---|---|
| **Данные на билде** | `/api` генерится в deploy **после** build. Добавлен prebuild-шаг `web/scripts/gen-entity-data.mjs` — тот же парсер (`--no-validate`) пишет JSON в gitignored `web/src/data/api/`. CI-safe: `jsonschema` сделан опциональным. |
| **Роут** | `[lang]/dnd/[version]/conditions/[slug].astro` + `getStaticPaths` из JSON API |
| **Шаблон** | слой `Reader` (SEO/head), рендер правила (`marked`), breadcrumb, блок «Изменения в 5.2» (заглушка §2.2), CTA-дип-линк в Table, «другие состояния», ссылка на главу |
| **SEO** | canonical, meta, OG; **JSON-LD** `DefinedTerm`+`BreadcrumbList`; в sitemap (не под noindex) |
| **Bilingual** | EN/RU делят канонический слаг → **взаимный hreflang** en↔ru↔x-default; подписи локализованы |

## RU-слаги — починены в корне
Были битые: заголовки состояний `#### Ослеплённый [Состояние]` без `(English)` → `name_en=None` → слаг из кириллицы калечился (`ослепле-нныи`). 

Фикс в `generate_api.py`: для RU-сущностей без `name_en` — **backfill из authoritative `translate/01_dictionary_base.md`** + переслаг на канонический английский. Теперь состояния как заклинания: `slug=blinded, name=Ослеплённый, name_en=Blinded`. Чинит и **публичный API**, и страницы; EN/RU слаги совпадают.

## Проверки
- `astro build` — 30 страниц (`/{en,ru}/dnd/srd-5.2/conditions/{slug}/`); `astro check` — **0 errors**.
- hreflang взаимный (проверено на обеих сторонах пары).
- Сгенерированные данные (`src/data/api/`) gitignored — в коммит не попали.

## Вне среза (следующие куски §2)
Автолинковка упоминаний (rehype-плагин), хабы (по классу/уровню, CR/типу), автодифф 5.1→5.2. 5.1 добавляется одной строкой в `BUILDS`.

## Скриншоты
EN и RU версии страницы «Frightened / Испуганный» — в треде обсуждения.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP