### PR TITLE
fix(reader): резервировать столбец TOC — убрать прыжок макета + e2e

### DIFF
--- a/web/e2e/layout-stability.spec.ts
+++ b/web/e2e/layout-stability.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+// Стабильность макета: пока TOC помещается по ширине (десктоп), правый столбец
+// зарезервирован ВСЕГДА — даже на страницах без оглавления (Legal, страницы сущностей).
+// Иначе контент прыгает на ширину TOC при навигации со страницы с TOC на страницу без.
+// Регрессия к «страница прыгает если панели нет, а потом есть».
+
+test.use({ viewport: { width: 1280, height: 900 } });
+
+test('правый столбец TOC зарезервирован и без оглавления — контент не прыгает', async ({ page }) => {
+  // Страница С оглавлением: глава заклинаний (разделы уровней = много h2).
+  await page.goto('/en/dnd/srd-5.2/spells/');
+  await expect(page.locator('#rd-toc')).toBeVisible();
+  const withToc = await page.locator('.rd-content').boundingBox();
+
+  // Страница БЕЗ оглавления: правовая информация (нет h2/h3 → TOC не рендерится).
+  await page.goto('/en/dnd/srd-5.2/legal/');
+  await expect(page.locator('#rd-toc')).toHaveCount(0); // самой панели нет
+  const noToc = await page.locator('.rd-content').boundingBox();
+
+  // Но грид всё равно держит 3 колонки — место под TOC зарезервировано.
+  const trackCount = await page.locator('.rd-body').evaluate(
+    (el) => getComputedStyle(el).gridTemplateColumns.trim().split(/\s+/).length,
+  );
+  expect(trackCount).toBe(3);
+
+  // Ключевое: ширина контентной колонки одинакова с TOC и без → нет горизонтального прыжка.
+  expect(withToc).not.toBeNull();
+  expect(noToc).not.toBeNull();
+  expect(Math.abs(withToc!.width - noToc!.width)).toBeLessThanOrEqual(1);
+});
+
+test('страница сущности (состояние) не прыгает относительно главы с TOC', async ({ page }) => {
+  await page.goto('/en/dnd/srd-5.2/spells/');
+  const withToc = await page.locator('.rd-content').boundingBox();
+
+  // Страница состояния — headings=[] → TOC нет, но столбец зарезервирован.
+  await page.goto('/en/dnd/srd-5.2/rules-glossary/conditions/frightened/');
+  await expect(page.locator('#rd-toc')).toHaveCount(0);
+  const entity = await page.locator('.rd-content').boundingBox();
+
+  expect(Math.abs(withToc!.width - entity!.width)).toBeLessThanOrEqual(1);
+});

--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -258,7 +258,11 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 /* ── Layout grid ───────────────────────────────────────────────────────── */
 .rd-root { --rd-bar: 54px; display: flex; flex-direction: column; min-height: 100vh; background: var(--og-bg); color: var(--og-text); }
 .rd-body { display: grid; grid-template-columns: 278px minmax(0,1fr) 236px; flex: 1; min-height: 0; }
-.rd-body.rd-no-toc { grid-template-columns: 278px minmax(0,1fr); }
+/* Пока TOC помещается по ширине (десктоп ≥1100px), правый столбец резервируем ВСЕГДА —
+   даже на страницах без TOC (Legal, страницы сущностей). Иначе контент прыгает на 236px
+   при переходе со страницы с оглавлением на страницу без него. Ниже 1100px столбец и так
+   схлопывается (см. медиазапросы), там резерва нет. */
+.rd-body.rd-no-toc { grid-template-columns: 278px minmax(0,1fr) 236px; }
 /* ① TOC не помещается → скрываем правый столбец, в панель приходит кнопка «На странице» */
 @media (max-width: 1100px) {
   .rd-body, .rd-body.rd-no-toc { grid-template-columns: 258px minmax(0,1fr); }


### PR DESCRIPTION
## Проблема
Правый столбец «Содержание» (TOC) рендерится условно (`toc.length > 1`), и класс `.rd-no-toc` схлопывал грид с 3 колонок до 2. При переходе со страницы **с** оглавлением на страницу **без** него (Legal, страницы сущностей) контентная колонка прыгала на ширину TOC (236px).

## Фикс
`web/src/styles/reader.css`: пока TOC помещается по ширине (десктоп ≥1100px), правый столбец резервируется **всегда** — даже пустой. Ниже 1100px он и так схлопывается (медиазапросы не тронуты) — там резерва нет, TOC уходит в кнопку «На странице».

## E2E
Новый `web/e2e/layout-stability.spec.ts` (2 теста, десктоп 1280px):
1. Ширина `.rd-content` одинакова на странице **с** TOC (`spells`) и **без** (`legal`); грид держит 3 колонки даже без TOC-панели.
2. Страница сущности (состояние) не прыгает относительно главы с TOC.

**Весь набор e2e — 13 passed** (11 старых + 2 новых), `astro check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP