### PR TITLE
ci: гонять e2e (Playwright) в CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: CI
 
-# Лёгкая проверка на PR в main: типы (astro check) + прод-сборка. E2E (Playwright) в CI
-# НЕ гоняем — они тяжёлые/нестабильные на раннере; запускаются локально: npm run test:e2e.
+# Проверка на PR в main: типы (astro check) + прод-сборка + e2e (Playwright).
+# E2E гоняем с --ignore-snapshots: поведенческие проверки идут, а визуальные снапшоты
+# пропускаются — их baseline привязан к платформе (…-darwin.png), на ubuntu не совпадут.
+# Визуальная регрессия остаётся локальным гейтом (npm run test:e2e).
 on:
   pull_request:
     branches: [main]
@@ -41,3 +43,39 @@ jobs:
       - name: Build
         working-directory: web
         run: npm run build
+
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      # prebuild страниц сущностей (gen-entity-data.mjs) вызывает python3 --no-validate
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install web deps
+        working-directory: web
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'   # браузер ставим отдельным шагом (только chromium)
+
+      - name: Install Playwright chromium
+        working-directory: web
+        run: npx playwright install --with-deps chromium
+
+      # webServer из playwright.config поднимает `astro build && astro preview` (прод-вывод).
+      # --ignore-snapshots: пропускаем сравнение скриншотов (baseline darwin ≠ ubuntu).
+      - name: Run e2e (behavioural; snapshots skipped)
+        working-directory: web
+        run: npm run test:e2e -- --ignore-snapshots
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
-// E2E гоняются ЛОКАЛЬНО (npm run test:e2e), в CI не тащим — там только astro check + build.
+// Поведенческие e2e гоняются и локально (npm run test:e2e), и в CI (job e2e,
+// с --ignore-snapshots). Визуальные снапшоты (visual.spec.ts) — ТОЛЬКО локально:
+// baseline привязан к платформе (…-darwin.png), на ubuntu-раннере не совпадёт.
 // Тестируем прод-вывод: собираем бандл и поднимаем `astro preview` (ровно то, что уедет
 // на хостинг), а не dev-сервер.
 const PORT = 4321;


### PR DESCRIPTION
Раньше e2e гонялись только локально. Раз CI бесплатный — добавляем job `e2e` на каждый PR.

## Что делает job
- Ставит Node + Python 3.12 (нужен prebuild-скрипту `gen-entity-data --no-validate`) + `chromium`.
- Гоняет `npm run test:e2e -- --ignore-snapshots` против прод-вывода (`astro build` + preview).

## Почему `--ignore-snapshots`
Поведенческие проверки (reader / lang / 404 / seo / layout-stability) идут и **падают при регрессии**. Визуальные снапшоты (`visual.spec.ts`) при этом **пропускаются** — их baseline привязан к платформе (`…-chromium-darwin.png`) и на ubuntu-раннере не совпадёт. Визуальная регрессия остаётся **локальным** гейтом.

(Позже, если захочется визуалку и в CI — сгенерим linux-baseline через playwright-docker и закоммитим `…-linux.png` рядом.)

## Проверки
- Локально `npm run test:e2e -- --ignore-snapshots` — **16 passed** (ровно то, что пойдёт в CI).
- YAML валиден; jobs: `check-build`, `e2e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP