### PR TITLE
feat(rules): автоссылки на страницы сущностей по всему контенту

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -4,6 +4,7 @@ import pagefind from 'astro-pagefind';
 import AstroPWA from '@vite-pwa/astro';
 import rehypePromoteHeadings from './src/lib/rehype-promote-headings.mjs';
 import rehypeWrapTables from './src/lib/rehype-wrap-tables.mjs';
+import rehypeEntityAutolink from './src/lib/rehype-entity-autolink.mjs';
 
 // rules.omnisgm.com — статический (SSG) ридер SRD экосистемы OmnisGM.
 // Контент — Markdown из ../src/{game}/{version}/{en,ru}/**.md (вход контентного пайплайна),
@@ -118,6 +119,7 @@ export default defineConfig({
   },
   markdown: {
     // Нормализуем уровни заголовков ДО сбора TOC (headings) Astro — чтобы titled h1 не попадал в TOC.
-    rehypePlugins: [rehypePromoteHeadings, rehypeWrapTables],
+    // rehypeEntityAutolink — последним: линкует имена сущностей в готовом дереве (issue #20).
+    rehypePlugins: [rehypePromoteHeadings, rehypeWrapTables, rehypeEntityAutolink],
   },
 });

--- a/web/e2e/autolink.spec.ts
+++ b/web/e2e/autolink.spec.ts
@@ -45,3 +45,66 @@ test('автоссылка несёт data-hc для будущего hovercard'
   const first = page.locator('.rd-doc a.ent-link').first();
   await expect(first).toHaveAttribute('data-hc', /^dnd\/srd52\/en\/conditions\//);
 });
+
+// Паритет EN/RU: страницы одной главы — зеркальный перевод, значит набор слинкованных состояний
+// должен совпадать. Дедуп «первое упоминание» → на странице ≤1 ссылки на каждое состояние, поэтому
+// равенство МНОЖЕСТВ здесь эквивалентно равенству КОЛИЧЕСТВ.
+//
+// Реальные расхождения вынесены в EXCEPTIONS с причиной — их два вида:
+//  • RU-перевод не использует термин состояния (EN капитализирует ключевое слово, RU дал прозу);
+//  • RU капитализирует «Невидимый» как термин, а EN тут про заклинание Invisibility, не состояние.
+// Тест падает и при НОВОМ расхождении (регрессия матчинга/перевода), и при ПРОТУХШЕЙ записи
+// allowlist (расхождение исчезло → запись надо убрать).
+const EXCEPTIONS: Record<string, string[]> = {
+  '/en/dnd/srd-5.2/animals/': ['charmed', 'paralyzed', 'petrified', 'stunned'], // RU не использует термины
+  '/en/dnd/srd-5.2/classes/bard/': ['invisible'], // RU «Невидимый»; EN — заклинание Invisibility
+  '/en/dnd/srd-5.2/classes/monk/': ['exhaustion'], // RU не использует «Истощение»
+  '/en/dnd/srd-5.2/classes/ranger/': ['exhaustion'],
+  '/en/dnd/srd-5.2/classes/warlock/': ['invisible'],
+  '/en/dnd/srd-5.2/classes/wizard/': ['invisible'],
+  '/en/dnd/srd-5.2/equipment/': ['unconscious'], // RU не использует «Без сознания»
+  '/en/dnd/srd-5.2/feats/': ['grappled'], // RU не использует «Схваченный»
+  '/en/dnd/srd-5.2/magic-items/': ['prone', 'restrained', 'unconscious'],
+};
+
+async function linkedConditions(page: import('@playwright/test').Page, path: string): Promise<Set<string>> {
+  await page.goto(path);
+  const hrefs = await page
+    .locator('.rd-doc a.ent-link')
+    .evaluateAll((els) => els.map((e) => e.getAttribute('href') || ''));
+  const slugs = hrefs.map((h) => h.match(/\/conditions\/([a-z-]+)\//)?.[1]).filter(Boolean) as string[];
+  return new Set(slugs);
+}
+
+test('EN/RU: набор слинкованных состояний совпадает по всем главам (кроме allowlist)', async ({ page, request }) => {
+  const sitemap = await (await request.get('/sitemap-0.xml')).text();
+  const chapters = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)]
+    .map((m) => new URL(m[1]).pathname)
+    .filter(
+      (p) =>
+        p.startsWith('/en/dnd/srd-5.2/') &&
+        !p.includes('/glossary/') && // справочные таблицы вне индекса
+        !p.includes('/rules-glossary/conditions/'), // сами страницы состояний, не главы
+    );
+  expect(chapters.length).toBeGreaterThan(10);
+
+  const usedExceptions = new Set<string>();
+  const failures: string[] = [];
+  for (const en of chapters) {
+    const ru = en.replace('/en/', '/ru/');
+    const enSet = await linkedConditions(page, en);
+    const ruSet = await linkedConditions(page, ru);
+    const diff = [...new Set([...enSet, ...ruSet])].filter((s) => enSet.has(s) !== ruSet.has(s));
+    const allow = new Set(EXCEPTIONS[en] || []);
+    for (const s of diff) {
+      if (allow.has(s)) usedExceptions.add(`${en}:${s}`);
+      else failures.push(`${en}: '${s}' (EN=${enSet.has(s)} RU=${ruSet.has(s)}) — вне allowlist`);
+    }
+  }
+  expect(failures, `новые EN/RU-расхождения:\n${failures.join('\n')}`).toEqual([]);
+
+  // Протухшие исключения: каждая запись allowlist должна реально срабатывать (иначе — убрать).
+  const declared = Object.entries(EXCEPTIONS).flatMap(([u, arr]) => arr.map((s) => `${u}:${s}`));
+  const stale = declared.filter((k) => !usedExceptions.has(k));
+  expect(stale, `протухшие записи allowlist (расхождение исчезло — уберите):\n${stale.join('\n')}`).toEqual([]);
+});

--- a/web/e2e/autolink.spec.ts
+++ b/web/e2e/autolink.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+// Автоссылки на программные страницы сущностей (issue #20, rehype-entity-autolink):
+// имена состояний в контенте становятся ссылками .ent-link на страницу состояния.
+const CHAPTER = '/en/dnd/srd-5.2/spells/'; // глава с множеством упоминаний состояний
+const ENTITY = '/en/dnd/srd-5.2/rules-glossary/conditions/paralyzed/'; // тело ссылается на Incapacitated
+
+test('глава: имена состояний автолинкуются на страницы состояний', async ({ page }) => {
+  await page.goto(CHAPTER);
+  const links = page.locator('.rd-doc a.ent-link');
+  expect(await links.count()).toBeGreaterThan(0);
+  // Все ent-link ведут на страницы состояний.
+  for (const href of await links.evaluateAll((els) => els.map((e) => e.getAttribute('href')))) {
+    expect(href).toContain('/rules-glossary/conditions/');
+  }
+});
+
+test('автолинк не попадает в заголовки и не вкладывается в другие ссылки', async ({ page }) => {
+  await page.goto(CHAPTER);
+  await expect(page.locator('.rd-doc :is(h1,h2,h3,h4,h5,h6) a.ent-link')).toHaveCount(0);
+  await expect(page.locator('.rd-doc a a.ent-link')).toHaveCount(0);
+});
+
+test('каждое состояние линкуется не более одного раза на страницу (первое упоминание)', async ({ page }) => {
+  await page.goto(CHAPTER);
+  const hrefs = await page
+    .locator('.rd-doc a.ent-link')
+    .evaluateAll((els) => els.map((e) => e.getAttribute('href')));
+  expect(new Set(hrefs).size).toBe(hrefs.length);
+});
+
+test('страница состояния: тело линкует другие состояния, но не саму себя', async ({ page }) => {
+  await page.goto(ENTITY);
+  const doc = page.locator('.rd-doc');
+  // ссылка на Incapacitated в теле есть…
+  await expect(
+    doc.locator('a.ent-link[href$="/conditions/incapacitated/"]').first(),
+  ).toBeVisible();
+  // …а самоссылки на paralyzed в теле нет.
+  await expect(doc.locator('a.ent-link[href$="/conditions/paralyzed/"]')).toHaveCount(0);
+});
+
+test('автоссылка несёт data-hc для будущего hovercard', async ({ page }) => {
+  await page.goto(CHAPTER);
+  const first = page.locator('.rd-doc a.ent-link').first();
+  await expect(first).toHaveAttribute('data-hc', /^dnd\/srd52\/en\/conditions\//);
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,8 @@
         "@astrojs/sitemap": "^3.3.0",
         "@omnisgm-app/brand": "^0.5.0",
         "astro": "^5.7.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-html": "^9.0.5",
         "marked": "^14.1.4"
       },
       "devDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,8 @@
     "@astrojs/sitemap": "^3.3.0",
     "@omnisgm-app/brand": "^0.5.0",
     "astro": "^5.7.0",
+    "hast-util-from-html": "^2.0.3",
+    "hast-util-to-html": "^9.0.5",
     "marked": "^14.1.4"
   },
   "devDependencies": {

--- a/web/src/lib/rehype-entity-autolink.mjs
+++ b/web/src/lib/rehype-entity-autolink.mjs
@@ -19,6 +19,28 @@ const DATA_ROOT = path.resolve(process.cwd(), 'src/data/api');
 // Ресурсы с программными страницами → сегмент URL-родителя под главой.
 const RESOURCES = [{ key: 'conditions', urlParent: 'rules-glossary/conditions' }];
 
+// Доп. имена-синонимы: `${game}/${lang}` → { [slug]: [alias, …] }.
+// RU-состояния — прилагательные; SRD-перевод часто использует КРАТКУЮ форму как ключевое слово
+// («получаете состояние Недееспособен», «состояние «Ослеплён»»). Номинатив («…ный») там не
+// встречается, поэтому базовый матчинг их не ловит → страдает паритет EN/RU. Литералы защищены
+// границами слова (ловят ровно краткую муж. форму, не длинную и не «Невидимость»). Каждое слово
+// проверено в корпусе src/dnd/srd-5.2/ru. Женский/средний/мн. краткие формы намеренно не добавляем
+// (реже, риск ложных срабатываний) — остаток покрывает allowlist в e2e-тесте паритета.
+const ALIASES = {
+  'dnd/ru': {
+    blinded: ['Ослеплён'],
+    charmed: ['Очарован'],
+    frightened: ['Испуган'],
+    grappled: ['Схвачен'],
+    incapacitated: ['Недееспособен'],
+    invisible: ['Невидим'],
+    paralyzed: ['Парализован'],
+    poisoned: ['Отравлен'],
+    restrained: ['Опутан'],
+    stunned: ['Ошеломлён'],
+  },
+};
+
 const SKIP_TAGS = new Set(['a', 'code', 'pre', 'kbd', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
 
 const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -40,8 +62,12 @@ function loadMap(game, version, lang) {
     } catch {
       continue; // ресурса нет для этой игры/версии/языка — просто пропускаем
     }
+    const aliases = ALIASES[`${game}/${lang}`] || {};
     for (const e of data) {
-      if (e && e.name && e.slug) entries.push({ name: e.name, slug: e.slug, resource: key, urlParent });
+      if (!e || !e.name || !e.slug) continue;
+      entries.push({ name: e.name, slug: e.slug, resource: key, urlParent });
+      for (const alias of aliases[e.slug] || [])
+        entries.push({ name: alias, slug: e.slug, resource: key, urlParent });
     }
   }
   if (!entries.length) {

--- a/web/src/lib/rehype-entity-autolink.mjs
+++ b/web/src/lib/rehype-entity-autolink.mjs
@@ -1,0 +1,130 @@
+// Автоссылки на программные страницы сущностей (issue #20): в контенте глав имена сущностей,
+// у которых есть отдельная страница (пока — состояния/conditions), становятся ссылками на неё.
+// Ручной обход hast-дерева — как rehype-wrap-tables/promote-headings, без доп. зависимостей.
+//
+// Правила матчинга:
+//  • Совпадение по display-имени в языке страницы (EN «Frightened», RU «Испуганный»).
+//  • Case-sensitive: SRD капитализирует имена состояний как ключевые слова, поэтому строчное
+//    «prone/frightened» в обычной прозе не ловится — только «Prone/Frightened».
+//  • Границы слова через unicode-lookaround (\b в JS не работает с кириллицей).
+//  • Первое вхождение каждой сущности на страницу (конвенция глоссариев — линкуем первое упоминание).
+//  • Не трогаем текст внутри <a>/<code>/<pre> и заголовков <h1>…<h6>.
+import fs from 'node:fs';
+import path from 'node:path';
+
+// process.cwd() (= web/ на билде) — резолвится одинаково и в конфиг-контексте (главы через
+// astro.config), и под Vite (страницы сущностей). import.meta.url под Vite указывает не туда.
+const DATA_ROOT = path.resolve(process.cwd(), 'src/data/api');
+
+// Ресурсы с программными страницами → сегмент URL-родителя под главой.
+const RESOURCES = [{ key: 'conditions', urlParent: 'rules-glossary/conditions' }];
+
+const SKIP_TAGS = new Set(['a', 'code', 'pre', 'kbd', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+
+const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const verKeyOf = (version) => version.replace(/[.\-]/g, ''); // srd-5.2 → srd52
+
+// Кэш карт совпадений: `${game}/${version}/${lang}` → { regexSource, byName, verKey } | null
+const mapCache = new Map();
+
+function loadMap(game, version, lang) {
+  const cacheKey = `${game}/${version}/${lang}`;
+  if (mapCache.has(cacheKey)) return mapCache.get(cacheKey);
+  const verKey = verKeyOf(version);
+  const entries = [];
+  for (const { key, urlParent } of RESOURCES) {
+    const file = path.join(DATA_ROOT, game, verKey, lang, key, 'all.json');
+    let data;
+    try {
+      data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    } catch {
+      continue; // ресурса нет для этой игры/версии/языка — просто пропускаем
+    }
+    for (const e of data) {
+      if (e && e.name && e.slug) entries.push({ name: e.name, slug: e.slug, resource: key, urlParent });
+    }
+  }
+  if (!entries.length) {
+    mapCache.set(cacheKey, null);
+    return null;
+  }
+  // Длинные имена раньше коротких: в JS-альтернации побеждает первый матч, а не самый длинный.
+  entries.sort((a, b) => b.name.length - a.name.length);
+  const byName = new Map(entries.map((e) => [e.name, e]));
+  const alt = entries.map((e) => escapeRegExp(e.name)).join('|');
+  const regexSource = `(?<![\\p{L}\\p{N}_])(${alt})(?![\\p{L}\\p{N}_])`;
+  const result = { regexSource, byName, verKey };
+  mapCache.set(cacheKey, result);
+  return result;
+}
+
+function linkifyText(value, map, linked, ctx) {
+  const re = new RegExp(map.regexSource, 'gu');
+  const nodes = [];
+  let last = 0;
+  let changed = false;
+  let match;
+  while ((match = re.exec(value))) {
+    const name = match[1];
+    const entry = map.byName.get(name);
+    if (!entry || linked.has(entry.slug)) continue; // уже слинковано на странице — оставляем текстом
+    linked.add(entry.slug);
+    changed = true;
+    if (match.index > last) nodes.push({ type: 'text', value: value.slice(last, match.index) });
+    const href = `/${ctx.lang}/${ctx.game}/${ctx.verSlug}/${entry.urlParent}/${entry.slug}/`;
+    nodes.push({
+      type: 'element',
+      tagName: 'a',
+      properties: {
+        className: ['ent-link'],
+        href,
+        // Ключ для hovercard (PR B): game/verKey/lang/resource/slug.
+        'data-hc': `${ctx.game}/${map.verKey}/${ctx.lang}/${entry.resource}/${entry.slug}`,
+      },
+      children: [{ type: 'text', value: name }],
+    });
+    last = match.index + name.length;
+  }
+  if (!changed) return null;
+  if (last < value.length) nodes.push({ type: 'text', value: value.slice(last) });
+  return nodes;
+}
+
+// Ядро: линкует имена сущностей прямо в hast-дереве. Используется и rehype-обёрткой (главы Astro),
+// и страницами сущностей (marked → hast → toHtml), поэтому логика одна.
+//  game/version/lang — контекст страницы; selfSlug — не линковать саму сущность на её же странице.
+export function autolinkTree(tree, { game, version, lang, selfSlug }) {
+  const map = loadMap(game, version, lang);
+  if (!map) return tree;
+  const linked = new Set();
+  if (selfSlug) linked.add(selfSlug); // самоссылку не ставим
+  const ctx = { game, lang, verSlug: version };
+
+  const walk = (node, insideSkip) => {
+    if (!node.children) return;
+    for (let i = 0; i < node.children.length; i++) {
+      const child = node.children[i];
+      if (child.type === 'element') {
+        walk(child, insideSkip || SKIP_TAGS.has(child.tagName));
+      } else if (child.type === 'text' && !insideSkip) {
+        const replaced = linkifyText(child.value, map, linked, ctx);
+        if (replaced) {
+          node.children.splice(i, 1, ...replaced);
+          i += replaced.length - 1;
+        }
+      }
+    }
+  };
+  walk(tree, false);
+  return tree;
+}
+
+export default function rehypeEntityAutolink() {
+  return (tree, file) => {
+    const p = (file && (file.path || (file.history && file.history[0]))) || '';
+    const m = p.replace(/\\/g, '/').match(/\/(dnd|daggerheart|brp)\/([^/]+)\/(en|ru)\//);
+    if (!m) return;
+    const [, game, version, lang] = m;
+    autolinkTree(tree, { game, version, lang });
+  };
+}

--- a/web/src/pages/[lang]/dnd/[version]/rules-glossary/conditions/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/rules-glossary/conditions/[slug].astro
@@ -1,6 +1,9 @@
 ---
 import { marked } from 'marked';
+import { fromHtml } from 'hast-util-from-html';
+import { toHtml } from 'hast-util-to-html';
 import ReaderShell from '../../../../../../components/ReaderShell.astro';
+import { autolinkTree } from '../../../../../../lib/rehype-entity-autolink.mjs';
 import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../../../lib/entities';
 
 // Programmatic-страницы состояний (issue #20, волна 1) в общем шелле ридера.
@@ -34,7 +37,12 @@ const verSlug = VERSION_SLUG[ver];
 const verLabel = VERSION_LABEL[ver];
 const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
 
-const bodyHtml = marked.parse(entity.description_md ?? '', { async: false });
+// Автоссылки на другие состояния прямо в теле (issue #20): marked → hast → autolink → html.
+// selfSlug исключает самоссылку. version = 'srd-5.2' (сегмент URL совпадает с ключом версии в config).
+const rawHtml = marked.parse(entity.description_md ?? '', { async: false });
+const tree = fromHtml(rawHtml, { fragment: true });
+autolinkTree(tree, { game: 'dnd', version: verSlug, lang, selfSlug: entity.slug });
+const bodyHtml = toHtml(tree);
 const description = excerpt(entity.description_md);
 
 const base = `/${lang}/dnd/${verSlug}/rules-glossary/conditions`;

--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -191,6 +191,10 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 .rd-doc a:hover { border-bottom-color: var(--og-accent); }
 .rd-doc a[href^="http"] { color: var(--og-warm); border-bottom: 1px solid color-mix(in oklab, var(--og-warm) 40%, transparent); }
 .rd-doc a[href^="http"]:hover { border-bottom-color: var(--og-warm); }
+/* Автоссылки-термины (rehype-entity-autolink): цвет текста как у прозы + пунктир акцентом —
+   читаются как «глоссарный термин», отличимы от обычных внутренних/внешних ссылок. */
+.rd-doc a.ent-link { color: inherit; border-bottom: 1px dashed color-mix(in oklab, var(--og-accent) 55%, transparent); }
+.rd-doc a.ent-link:hover { color: var(--og-accent); border-bottom-style: solid; border-bottom-color: var(--og-accent); }
 
 /* Таблицы: Astro рендерит <table>; оборачиваем в .rd-doc для скролла на узких экранах */
 /* широкая таблица скроллится внутри обёртки (rehype-wrap-tables), а не растягивает страницу */


### PR DESCRIPTION
**PR A из двух** (issue #20). Дальше — PR B: hovercard-тултипы поверх этих ссылок.

## Что

Имена сущностей, у которых есть программная страница (пока — **состояния**), автоматически становятся ссылками `.ent-link` на эту страницу — во **всём контенте** (главы Astro + сами страницы состояний).

Пример: в главе «Заклинания» первое «Frightened/Испуганный» → ссылка на страницу состояния.

## Как

`rehype-entity-autolink.mjs` — плагин без новых прод-зависимостей (ручной обход hast). Ядро `autolinkTree` переиспользуется двумя контекстами:
- **rehype-обёртка** в `astro.config` — главы (content collections);
- **страницы состояний** — `marked → hast → autolink → html` (с `selfSlug` против самоссылки).

Правила матчинга:
- по display-имени в языке страницы (EN / RU);
- **case-sensitive** — SRD капитализирует состояния как ключевые слова → почти нет ложных срабатываний;
- границы слова через unicode-lookaround (`\b` не работает с кириллицей);
- **первое вхождение** каждой сущности на страницу;
- не трогаем `<a>/<code>/<pre>` и заголовки;
- **RU краткие формы**: алиасы «Недееспособен», «Ослеплён», «Очарован»… — SRD-перевод использует их как ключевое слово, а номинатив «…ный» там не встречается.

`data-hc` на каждой ссылке — ключ для hovercard в PR B.

## Паритет EN/RU (тест «одинакового количества»)

Страницы одной главы — зеркальный перевод, значит **набор слинкованных состояний EN==RU**. Дедуп «первое упоминание» → на странице ≤1 ссылки на состояние, поэтому равенство множеств = равенство количеств.

`e2e/autolink.spec.ts` проверяет это по всем главам 5.2 (список — из sitemap). Реальные расхождения — в `EXCEPTIONS` с причиной:
- RU-перевод не использует термин состояния (Animals, Feats, MagicItems, Equipment, Monk/Ranger…);
- RU капитализирует «Невидимый», а EN тут про заклинание Invisibility (Bard/Warlock/Wizard).

Тест падает и при **новом** расхождении (регрессия матчинга/перевода), и при **протухшей** записи allowlist. Алиасы кратких форм убрали 2 расхождения + magic-items/blinded; осталось 9 задокументированных.

## Стиль

`.ent-link` — цвет прозы + пунктирное подчёркивание акцентом; при наведении — сплошной акцент.

## Тесты

- `e2e/autolink.spec.ts` (6): линковка в главах, ноль ссылок в заголовках/вложенных, дедуп, самоссылка исключена, `data-hc`, **паритет EN/RU**.
- Полный e2e зелёный (22), `astro check` — 0 ошибок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)