### PR TITLE
feat(rules): hovercard-подсказки для автоссылок (issue #20, вариант B)

### DIFF
--- a/web/e2e/hovercard.spec.ts
+++ b/web/e2e/hovercard.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+// Hovercard автоссылок (issue #20, вариант B: fetch-on-hover served JSON).
+// При наведении/фокусе на a.ent-link[data-hc] показывается карточка сущности с данными
+// из /hc/{game}/{ver}/{lang}.json. RU-глава заклинаний богата упоминаниями состояний.
+const CHAPTER = '/ru/dnd/srd-5.2/spells/';
+
+test('карточка появляется при наведении на автоссылку', async ({ page }) => {
+  await page.goto(CHAPTER);
+  const link = page.locator('.rd-doc a.ent-link[data-hc]').first();
+  await expect(link).toBeVisible();
+  const card = page.locator('#ent-hovercard');
+  await expect(card).toHaveCount(0); // до первого показа элемента нет в DOM
+  await link.hover();
+  await expect(card).toBeVisible();
+  await expect(card.locator('.ent-hc-name')).not.toBeEmpty();
+  await expect(card.locator('.ent-hc-excerpt')).not.toBeEmpty();
+});
+
+test('содержимое карточки соответствует данным сущности из /hc JSON', async ({ page, request }) => {
+  await page.goto(CHAPTER);
+  const link = page.locator('.rd-doc a.ent-link[data-hc]').first();
+  const hc = (await link.getAttribute('data-hc'))!; // dnd/srd52/ru/conditions/<slug>
+  const [game, ver, lang, ...rest] = hc.split('/');
+  const bucket = await (await request.get(`/hc/${game}/${ver}/${lang}.json`)).json();
+  const c = bucket[rest.join('/')];
+  expect(c, 'запись сущности есть в бакете hovercard').toBeTruthy();
+
+  await link.hover();
+  const card = page.locator('#ent-hovercard');
+  await expect(card).toBeVisible();
+  await expect(card.locator('.ent-hc-name')).toHaveText(c.name);
+  // RU: показываем EN-подпись (name_en), если она есть и отличается от имени.
+  if (c.name_en && c.name_en !== c.name) await expect(card.locator('.ent-hc-en')).toHaveText(c.name_en);
+});
+
+test('клавиатурный фокус открывает карточку и связывает aria-describedby', async ({ page }) => {
+  await page.goto(CHAPTER);
+  const link = page.locator('.rd-doc a.ent-link[data-hc]').first();
+  await link.focus();
+  const card = page.locator('#ent-hovercard');
+  await expect(card).toBeVisible();
+  await expect(link).toHaveAttribute('aria-describedby', 'ent-hovercard');
+  await page.keyboard.press('Escape');
+  await expect(card).toBeHidden();
+  await expect(link).not.toHaveAttribute('aria-describedby', 'ent-hovercard');
+});
+
+test('карточка скрывается, когда курсор уходит со ссылки', async ({ page }) => {
+  await page.goto(CHAPTER);
+  const link = page.locator('.rd-doc a.ent-link[data-hc]').first();
+  await link.hover();
+  await expect(page.locator('#ent-hovercard')).toBeVisible();
+  await page.mouse.move(0, 0);
+  await expect(page.locator('#ent-hovercard')).toBeHidden();
+});

--- a/web/src/components/ReaderShell.astro
+++ b/web/src/components/ReaderShell.astro
@@ -591,3 +591,106 @@ const searchUi = {
     }
   }
 </script>
+
+{/* Hovercard автоссылок (issue #20, вариант B): при наведении/фокусе на a.ent-link[data-hc]
+    показываем карточку сущности. Данные тянутся один раз на бакет game/verKey/lang из
+    /hc/{game}/{ver}/{lang}.json (ключ бакета = префикс data-hc). Карточка — единый элемент в body. */}
+<script>
+  type HCard = { name: string; name_en: string | null; excerpt: string; href: string };
+  const hcBuckets = new Map<string, Promise<Record<string, HCard> | null>>();
+  const hcLoad = (game: string, ver: string, lang: string) => {
+    const key = `${game}/${ver}/${lang}`;
+    let p = hcBuckets.get(key);
+    if (!p) {
+      p = fetch(`/hc/${game}/${ver}/${lang}.json`).then((r) => (r.ok ? r.json() : null)).catch(() => null);
+      hcBuckets.set(key, p);
+    }
+    return p;
+  };
+
+  const card = document.createElement('div');
+  card.className = 'ent-hovercard';
+  card.id = 'ent-hovercard';
+  card.setAttribute('role', 'tooltip');
+  const elName = document.createElement('span'); elName.className = 'ent-hc-name';
+  const elEn = document.createElement('span'); elEn.className = 'ent-hc-en';
+  const elEx = document.createElement('p'); elEx.className = 'ent-hc-excerpt';
+  card.append(elName, elEn, elEx);
+  let mounted = false;
+
+  let current: HTMLElement | null = null;
+  let showTimer = 0;
+  let token = 0;
+
+  const place = (anchor: HTMLElement) => {
+    const r = anchor.getBoundingClientRect();
+    const cw = card.offsetWidth, ch = card.offsetHeight, pad = 8, gap = 6;
+    const vw = document.documentElement.clientWidth, vh = document.documentElement.clientHeight;
+    let left = Math.min(r.left, vw - cw - pad);
+    left = Math.max(pad, left) + window.scrollX;
+    let top = r.bottom + gap;
+    if (r.bottom + gap + ch > vh && r.top - gap - ch > 0) top = r.top - ch - gap;
+    card.style.left = `${left}px`;
+    card.style.top = `${top + window.scrollY}px`;
+  };
+
+  const hide = () => {
+    clearTimeout(showTimer); showTimer = 0; token++;
+    if (!current) return;
+    current.removeAttribute('aria-describedby');
+    current = null;
+    card.classList.remove('is-open');
+  };
+
+  const show = (anchor: HTMLElement) => {
+    const hc = anchor.getAttribute('data-hc');
+    if (!hc) return;
+    const parts = hc.split('/');
+    if (parts.length < 5) return;
+    const [game, ver, lang] = parts;
+    const rkey = parts.slice(3).join('/');
+    const my = ++token;
+    hcLoad(game, ver, lang).then((map) => {
+      if (my !== token) return;
+      const c = map && map[rkey];
+      if (!c) return;
+      elName.textContent = c.name;
+      if (c.name_en && c.name_en !== c.name) { elEn.textContent = c.name_en; elEn.style.display = ''; }
+      else elEn.style.display = 'none';
+      elEx.textContent = c.excerpt;
+      elEx.style.display = c.excerpt ? '' : 'none';
+      if (!mounted) { document.body.appendChild(card); mounted = true; }
+      current = anchor;
+      anchor.setAttribute('aria-describedby', 'ent-hovercard');
+      card.classList.add('is-open');
+      place(anchor);
+    });
+  };
+
+  const onEnter = (e: Event) => {
+    if ('pointerType' in e && (e as PointerEvent).pointerType === 'touch') return; // тач — навигация тапом
+    const a = (e.target as Element)?.closest?.('a.ent-link[data-hc]') as HTMLElement | null;
+    if (!a || a === current) return;
+    clearTimeout(showTimer);
+    showTimer = window.setTimeout(() => show(a), e.type === 'focusin' ? 0 : 130);
+  };
+  const onLeave = (e: Event) => {
+    const a = (e.target as Element)?.closest?.('a.ent-link[data-hc]');
+    if (!a) return;
+    const to = (e as PointerEvent).relatedTarget as Node | null;
+    if (to && (a as Element).contains(to)) return;
+    hide();
+  };
+
+  document.addEventListener('pointerover', onEnter, { passive: true });
+  document.addEventListener('pointerout', onLeave, { passive: true });
+  document.addEventListener('focusin', onEnter);
+  document.addEventListener('focusout', (e) => {
+    if (current && (e.target as Element)?.closest?.('a.ent-link') === current) hide();
+  });
+  document.addEventListener('keydown', (e) => { if ((e as KeyboardEvent).key === 'Escape') hide(); });
+  // Карточка позиционируется в координатах документа и «едет» вместе со ссылкой при скролле —
+  // прятать по scroll не нужно (и вредно: авто-скролл перед hover/focus гасил бы показ).
+  // По ресайзу — прячем открытую (геометрия ссылки могла сместиться).
+  window.addEventListener('resize', () => { if (current) hide(); }, { passive: true });
+</script>

--- a/web/src/pages/hc/[game]/[ver]/[lang].json.ts
+++ b/web/src/pages/hc/[game]/[ver]/[lang].json.ts
@@ -1,0 +1,38 @@
+import type { APIRoute } from 'astro';
+import { loadEntities, excerpt, VERSION_SLUG } from '../../../../lib/entities';
+
+// Hovercard-данные для автоссылок (issue #20, вариант B: fetch-on-hover served JSON).
+// На каждый бакет `game/verKey/lang` отдаём карту `resource/slug` → { name, name_en, excerpt, href }.
+// Ключ бакета совпадает с префиксом `data-hc` из rehype-entity-autolink (game/verKey/lang/...).
+// Бакеты собираем только там, где реально существуют страницы сущностей (см. [slug].astro).
+
+const RESOURCES = [{ key: 'conditions', urlParent: 'rules-glossary/conditions' }];
+
+// Согласовано со сборкой страниц состояний: пока только srd52 (en/ru).
+const BUILDS = [
+  { game: 'dnd', ver: 'srd52', lang: 'en' },
+  { game: 'dnd', ver: 'srd52', lang: 'ru' },
+];
+
+export function getStaticPaths() {
+  return BUILDS.map((b) => ({ params: { game: b.game, ver: b.ver, lang: b.lang } }));
+}
+
+export const GET: APIRoute = ({ params }) => {
+  const { ver, lang, game } = params as { game: string; ver: string; lang: string };
+  const verSlug = VERSION_SLUG[ver];
+  const map: Record<string, { name: string; name_en: string | null; excerpt: string; href: string }> = {};
+  for (const { key, urlParent } of RESOURCES) {
+    for (const e of loadEntities(ver, lang, key)) {
+      map[`${key}/${e.slug}`] = {
+        name: e.name,
+        name_en: (e.name_en as string) ?? null,
+        excerpt: excerpt(e.description_md, 160),
+        href: `/${lang}/${game}/${verSlug}/${urlParent}/${e.slug}/`,
+      };
+    }
+  }
+  return new Response(JSON.stringify(map), {
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+  });
+};

--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -196,6 +196,24 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 .rd-doc a.ent-link { color: inherit; border-bottom: 1px dashed color-mix(in oklab, var(--og-accent) 55%, transparent); }
 .rd-doc a.ent-link:hover { color: var(--og-accent); border-bottom-style: solid; border-bottom-color: var(--og-accent); }
 
+/* Hovercard автоссылок (issue #20, вариант B): карточка сущности при наведении/фокусе.
+   Единый переиспользуемый элемент в <body>; позицию задаёт клиентский скрипт (top/left). */
+.ent-hovercard {
+  position: absolute; z-index: 60; top: 0; left: 0; max-width: 320px; width: max-content;
+  padding: 12px 14px; border-radius: 12px;
+  background: var(--og-bg-2); border: 1px solid var(--og-border-strong);
+  box-shadow: 0 8px 28px -6px rgba(0, 0, 0, 0.45), 0 2px 8px -2px rgba(0, 0, 0, 0.3);
+  font-size: 13.5px; line-height: 1.5; color: var(--og-text-2);
+  opacity: 0; visibility: hidden; transform: translateY(3px);
+  transition: opacity 0.12s ease, transform 0.12s ease, visibility 0s linear 0.12s;
+  pointer-events: none; /* v1: карточка некликабельна, навигация — по самой ссылке */
+}
+.ent-hovercard.is-open { opacity: 1; visibility: visible; transform: translateY(0); transition-delay: 0s; }
+.ent-hc-name { font-weight: 600; color: var(--og-text); font-size: 15px; }
+.ent-hc-en { display: block; margin-top: 2px; font-family: var(--font-mono); font-size: 11.5px; font-weight: 400; letter-spacing: 0.2px; color: var(--og-text-muted); }
+.ent-hc-excerpt { margin-top: 8px; }
+@media (prefers-reduced-motion: reduce) { .ent-hovercard { transition: opacity 0.12s ease, visibility 0s linear 0.12s; transform: none; } }
+
 /* Таблицы: Astro рендерит <table>; оборачиваем в .rd-doc для скролла на узких экранах */
 /* широкая таблица скроллится внутри обёртки (rehype-wrap-tables), а не растягивает страницу */
 .rd-table-wrap { overflow-x: auto; max-width: 100%; margin: 0 0 22px; -webkit-overflow-scrolling: touch; }


### PR DESCRIPTION
Закрывает часть **issue #20** — всплывающие подсказки при наведении на автоссылки-термины (вариант B: fetch-on-hover served JSON, задел `data-hc` уже был).

## Что делает
При наведении **или фокусе** на `a.ent-link[data-hc]` показывается карточка сущности: **имя** + **EN-подпись** (для RU) + **короткий эффект** (~160 симв). Клик по самой ссылке ведёт на страницу сущности как раньше.

## Как устроено
- **Раздача данных** — статик-эндпоинт `src/pages/hc/[game]/[ver]/[lang].json.ts` → `/hc/dnd/srd52/{en,ru}.json`. Карта `resource/slug → { name, name_en, excerpt, href }`. Ключ бакета = префикс `data-hc`. Пока `conditions`, srd52 en/ru (там, где реально есть страницы состояний).
- **Клиент** (инлайн-скрипт в `ReaderShell`): один делегированный слушатель; фетч бакета **один раз** (кэш + дедуп in-flight); задержка показа ~130мс (без мельтешения); карточка — единый переиспользуемый элемент в `<body>`, позиционируется под ссылкой с клампом к вьюпорту (или сверху, если не влезает).
- **A11y**: `role="tooltip"` + `aria-describedby`, показ **по focus** (клавиатура), скрытие по `Esc`/blur/leave. Тач — пропускаем (навигация тапом). `prefers-reduced-motion` учтён.
- **Стиль** `.ent-hovercard` — тема-aware, на токенах.

## Заметки
- Карточка **некликабельна** (v1) — навигация по самой ссылке; `pointer-events:none`, чтобы не мешала.
- Позиция в координатах документа → при скролле карточка едет вместе со ссылкой (scroll-hide намеренно убран — он же гасил показ при авто-скролле Playwright/фокуса).
- **srd51-линки**: если состояние ссылается на несуществующую пока страницу 5.1 — карточка просто не покажется (fetch-бакета нет). Отдельный pre-existing вопрос страниц 5.1 не трогаю.

## Проверки
- `astro check`: 0 ошибок.
- e2e `hovercard.spec.ts` (4): показ по hover, соответствие данным `/hc` JSON, клавиатура+`aria-describedby`+`Esc`, скрытие при уходе курсора.
- Полный прогон **26/26 e2e** — визуальные снапшоты не поехали (карточка скрыта до наведения).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP