### PR TITLE
fix(rules): hovercard состояний — форматированный эффект вместо «каши»

### DIFF
--- a/web/e2e/hovercard.spec.ts
+++ b/web/e2e/hovercard.spec.ts
@@ -14,7 +14,11 @@ test('карточка появляется при наведении на ав�
   await link.hover();
   await expect(card).toBeVisible();
   await expect(card.locator('.ent-hc-name')).not.toBeEmpty();
-  await expect(card.locator('.ent-hc-excerpt')).not.toBeEmpty();
+  // эффект — форматированный блок с подэффектами, без вводной «Пока вы находитесь…»
+  const body = card.locator('.ent-hc-body');
+  await expect(body).not.toBeEmpty();
+  await expect(body).not.toContainText('Пока вы находитесь в состоянии');
+  await expect(body.locator('strong').first()).toBeVisible(); // жирные ярлыки сохранены
 });
 
 test('содержимое карточки соответствует данным сущности из /hc JSON', async ({ page, request }) => {

--- a/web/src/components/ReaderShell.astro
+++ b/web/src/components/ReaderShell.astro
@@ -596,7 +596,7 @@ const searchUi = {
     показываем карточку сущности. Данные тянутся один раз на бакет game/verKey/lang из
     /hc/{game}/{ver}/{lang}.json (ключ бакета = префикс data-hc). Карточка — единый элемент в body. */}
 <script>
-  type HCard = { name: string; name_en: string | null; excerpt: string; href: string };
+  type HCard = { name: string; name_en: string | null; effect: string; href: string };
   const hcBuckets = new Map<string, Promise<Record<string, HCard> | null>>();
   const hcLoad = (game: string, ver: string, lang: string) => {
     const key = `${game}/${ver}/${lang}`;
@@ -614,8 +614,8 @@ const searchUi = {
   card.setAttribute('role', 'tooltip');
   const elName = document.createElement('span'); elName.className = 'ent-hc-name';
   const elEn = document.createElement('span'); elEn.className = 'ent-hc-en';
-  const elEx = document.createElement('p'); elEx.className = 'ent-hc-excerpt';
-  card.append(elName, elEn, elEx);
+  const elBody = document.createElement('div'); elBody.className = 'ent-hc-body';
+  card.append(elName, elEn, elBody);
   let mounted = false;
 
   let current: HTMLElement | null = null;
@@ -657,8 +657,8 @@ const searchUi = {
       elName.textContent = c.name;
       if (c.name_en && c.name_en !== c.name) { elEn.textContent = c.name_en; elEn.style.display = ''; }
       else elEn.style.display = 'none';
-      elEx.textContent = c.excerpt;
-      elEx.style.display = c.excerpt ? '' : 'none';
+      elBody.innerHTML = c.effect || ''; // доверенный контент (наши SRD-данные, экранированы на билде)
+      elBody.style.display = c.effect ? '' : 'none';
       if (!mounted) { document.body.appendChild(card); mounted = true; }
       current = anchor;
       anchor.setAttribute('aria-describedby', 'ent-hovercard');

--- a/web/src/pages/hc/[game]/[ver]/[lang].json.ts
+++ b/web/src/pages/hc/[game]/[ver]/[lang].json.ts
@@ -1,5 +1,27 @@
 import type { APIRoute } from 'astro';
-import { loadEntities, excerpt, VERSION_SLUG } from '../../../../lib/entities';
+import { loadEntities, VERSION_SLUG } from '../../../../lib/entities';
+
+const escapeHtml = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+// Эффект состояния → компактный форматированный HTML для карточки.
+// Выкидываем вводную «Пока вы находитесь в состоянии …» / «While you have the … condition» —
+// имя состояния уже в заголовке карточки. Жирные ярлыки подэффектов сохраняем.
+function effectHtml(md: string | undefined): string {
+  if (!md) return '';
+  const blocks = md.split(/\n{2,}/).map((b) => b.trim()).filter(Boolean);
+  const isIntro = (b: string) => /^(Пока вы находитесь в состоянии|While you have the .* condition)/.test(b);
+  const body = blocks.length > 1 && isIntro(blocks[0]) ? blocks.slice(1) : blocks;
+  return body
+    .map((b) => {
+      const html = escapeHtml(b)
+        .replace(/\*\*_([^*]+?)_\*\*/g, '<strong>$1</strong>') // bold-italic ярлык
+        .replace(/\*\*([^*]+?)\*\*/g, '<strong>$1</strong>')
+        .replace(/(?<![\w*])_([^_]+?)_(?![\w*])/g, '<em>$1</em>')
+        .replace(/(?<![\w*])\*([^*]+?)\*(?![\w*])/g, '<em>$1</em>');
+      return `<p>${html}</p>`;
+    })
+    .join('');
+}
 
 // Hovercard-данные для автоссылок (issue #20, вариант B: fetch-on-hover served JSON).
 // На каждый бакет `game/verKey/lang` отдаём карту `resource/slug` → { name, name_en, excerpt, href }.
@@ -21,13 +43,13 @@ export function getStaticPaths() {
 export const GET: APIRoute = ({ params }) => {
   const { ver, lang, game } = params as { game: string; ver: string; lang: string };
   const verSlug = VERSION_SLUG[ver];
-  const map: Record<string, { name: string; name_en: string | null; excerpt: string; href: string }> = {};
+  const map: Record<string, { name: string; name_en: string | null; effect: string; href: string }> = {};
   for (const { key, urlParent } of RESOURCES) {
     for (const e of loadEntities(ver, lang, key)) {
       map[`${key}/${e.slug}`] = {
         name: e.name,
         name_en: (e.name_en as string) ?? null,
-        excerpt: excerpt(e.description_md, 160),
+        effect: effectHtml(e.description_md as string | undefined),
         href: `/${lang}/${game}/${verSlug}/${urlParent}/${e.slug}/`,
       };
     }

--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -199,7 +199,8 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 /* Hovercard автоссылок (issue #20, вариант B): карточка сущности при наведении/фокусе.
    Единый переиспользуемый элемент в <body>; позицию задаёт клиентский скрипт (top/left). */
 .ent-hovercard {
-  position: absolute; z-index: 60; top: 0; left: 0; max-width: 320px; width: max-content;
+  position: absolute; z-index: 60; top: 0; left: 0; max-width: 340px; width: max-content;
+  max-height: min(60vh, 420px); overflow: hidden;
   padding: 12px 14px; border-radius: 12px;
   background: var(--og-bg-2); border: 1px solid var(--og-border-strong);
   box-shadow: 0 8px 28px -6px rgba(0, 0, 0, 0.45), 0 2px 8px -2px rgba(0, 0, 0, 0.3);
@@ -211,7 +212,11 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 .ent-hovercard.is-open { opacity: 1; visibility: visible; transform: translateY(0); transition-delay: 0s; }
 .ent-hc-name { font-weight: 600; color: var(--og-text); font-size: 15px; }
 .ent-hc-en { display: block; margin-top: 2px; font-family: var(--font-mono); font-size: 11.5px; font-weight: 400; letter-spacing: 0.2px; color: var(--og-text-muted); }
-.ent-hc-excerpt { margin-top: 8px; }
+.ent-hc-body { margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--og-border-soft); }
+.ent-hc-body p { margin: 0 0 7px; }
+.ent-hc-body p:last-child { margin-bottom: 0; }
+.ent-hc-body strong { color: var(--og-text); font-weight: 600; }
+.ent-hc-body em { font-style: italic; }
 @media (prefers-reduced-motion: reduce) { .ent-hovercard { transition: opacity 0.12s ease, visibility 0s linear 0.12s; transform: none; } }
 
 /* Таблицы: Astro рендерит <table>; оборачиваем в .rd-doc для скролла на узких экранах */


### PR DESCRIPTION
Фоллоу-ап к #81 по ревью карточки (эффект слипался в «кашу» + обрезка «….»).

## Было
`excerpt()` снимал всю разметку и склеивал абзацы → жирные ярлыки подэффектов («Скорость 0.», «Атаки затронуты.») превращались в один run-on абзац, плюс обрезка `…`.

## Стало
Эндпоинт `/hc/...json` отдаёт поле `effect` как **форматированный HTML**:
- **вводная строка выкинута** — «Пока вы находитесь в состоянии «X», вы испытываете следующие эффекты.» (имя X уже в заголовке карточки);
- подэффекты — **отдельные абзацы с жирными ярлыками**;
- **без обрезки** (полный эффект); кап высоты `min(60vh, 420px)` на случай длинных (Истощение влезает целиком).

Клиент рендерит `.ent-hc-body` через `innerHTML` — контент доверенный (наши SRD-данные), HTML экранируется на билде (`&<>`), затем применяются только `**bold**`/`_em_`.

## Проверки
- `astro check` + сборка ок; эффект-HTML верифицирован (интро отсутствует во всех 15 состояниях).
- e2e `hovercard.spec.ts` (4/4): показ, соответствие `/hc` JSON, клавиатура+aria+Esc, скрытие. Обновлён тест содержимого — проверяет отсутствие интро и наличие `<strong>`-ярлыков.

Скриншот «до/после» — в треде обсуждения.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP