### PR TITLE
feat(rules): hovercard — шапка с источником, без дубля RU-имени

### DIFF
--- a/web/e2e/hovercard.spec.ts
+++ b/web/e2e/hovercard.spec.ts
@@ -13,7 +13,10 @@ test('карточка появляется при наведении на ав�
   await expect(card).toHaveCount(0); // до первого показа элемента нет в DOM
   await link.hover();
   await expect(card).toBeVisible();
-  await expect(card.locator('.ent-hc-name')).not.toBeEmpty();
+  // шапка: источник + EN-имя (RU-карточка); RU-имя не дублируем (навели на само слово)
+  await expect(card.locator('.ent-hc-src')).toHaveText('SRD 5.2.1');
+  await expect(card.locator('.ent-hc-en')).not.toBeEmpty();
+  await expect(card.locator('.ent-hc-name')).toHaveCount(0);
   // эффект — форматированный блок с подэффектами, без вводной «Пока вы находитесь…»
   const body = card.locator('.ent-hc-body');
   await expect(body).not.toBeEmpty();
@@ -33,8 +36,7 @@ test('содержимое карточки соответствует данн�
   await link.hover();
   const card = page.locator('#ent-hovercard');
   await expect(card).toBeVisible();
-  await expect(card.locator('.ent-hc-name')).toHaveText(c.name);
-  // RU: показываем EN-подпись (name_en), если она есть и отличается от имени.
+  // RU-карточка показывает оригинальное EN-имя (не RU-имя, на которое навели).
   if (c.name_en && c.name_en !== c.name) await expect(card.locator('.ent-hc-en')).toHaveText(c.name_en);
 });
 

--- a/web/src/components/ReaderShell.astro
+++ b/web/src/components/ReaderShell.astro
@@ -612,10 +612,15 @@ const searchUi = {
   card.className = 'ent-hovercard';
   card.id = 'ent-hovercard';
   card.setAttribute('role', 'tooltip');
-  const elName = document.createElement('span'); elName.className = 'ent-hc-name';
+  // Шапка: слева EN-имя (только в RU-карточке — имя, на которое навели, уже перед глазами;
+  // в EN оно избыточно), справа источник. Ниже — эффект.
+  const SRC: Record<string, string> = { srd52: 'SRD 5.2.1', srd51: 'SRD 5.1' };
+  const head = document.createElement('div'); head.className = 'ent-hc-head';
   const elEn = document.createElement('span'); elEn.className = 'ent-hc-en';
+  const elSrc = document.createElement('span'); elSrc.className = 'ent-hc-src';
+  head.append(elEn, elSrc);
   const elBody = document.createElement('div'); elBody.className = 'ent-hc-body';
-  card.append(elName, elEn, elBody);
+  card.append(head, elBody);
   let mounted = false;
 
   let current: HTMLElement | null = null;
@@ -654,9 +659,10 @@ const searchUi = {
       if (my !== token) return;
       const c = map && map[rkey];
       if (!c) return;
-      elName.textContent = c.name;
+      // EN-имя — только когда отличается от имени ссылки (RU-карточка); в EN c.name_en = null → скрыто.
       if (c.name_en && c.name_en !== c.name) { elEn.textContent = c.name_en; elEn.style.display = ''; }
-      else elEn.style.display = 'none';
+      else { elEn.textContent = ''; elEn.style.display = 'none'; }
+      elSrc.textContent = SRC[ver] || '';
       elBody.innerHTML = c.effect || ''; // доверенный контент (наши SRD-данные, экранированы на билде)
       elBody.style.display = c.effect ? '' : 'none';
       if (!mounted) { document.body.appendChild(card); mounted = true; }

--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -210,9 +210,11 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
   pointer-events: none; /* v1: карточка некликабельна, навигация — по самой ссылке */
 }
 .ent-hovercard.is-open { opacity: 1; visibility: visible; transform: translateY(0); transition-delay: 0s; }
-.ent-hc-name { font-weight: 600; color: var(--og-text); font-size: 15px; }
-.ent-hc-en { display: block; margin-top: 2px; font-family: var(--font-mono); font-size: 11.5px; font-weight: 400; letter-spacing: 0.2px; color: var(--og-text-muted); }
-.ent-hc-body { margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--og-border-soft); }
+.ent-hc-head { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--og-border-soft); }
+.ent-hc-head:empty { display: none; }
+.ent-hc-en { font-family: var(--font-mono); font-size: 12.5px; font-weight: 500; letter-spacing: 0.2px; color: var(--og-text-2); }
+.ent-hc-src { margin-left: auto; font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.3px; color: var(--og-text-muted); white-space: nowrap; }
+.ent-hc-body { margin-top: 8px; }
 .ent-hc-body p { margin: 0 0 7px; }
 .ent-hc-body p:last-child { margin-bottom: 0; }
 .ent-hc-body strong { color: var(--og-text); font-weight: 600; }


### PR DESCRIPTION
Фоллоу-ап к #81/#82 по ревью карточки.

## Изменения
- **Убрано RU-имя** — наводишь на само слово в тексте, дублировать в карточке незачем.
- **RU-карточка**: слева в шапке оставлено оригинальное **EN-имя** (напр. «Restrained») — полезно для двуязычного ридера.
- **EN-карточка**: имени нет (навёл на EN-слово), в шапке только источник.
- **Источник** «SRD 5.2.1» (для srd51 → «SRD 5.1») — справа в шапке, под чертой.

Структура: `[EN-имя] ──────── [SRD 5.2.1]` → черта → подэффекты жирными ярлыками. Цветовую индексацию (преимущество/помеха) сознательно не добавляем — отдельная история на потом.

## Проверки
- `astro check`: 0 ошибок.
- e2e `hovercard.spec.ts` (4/4): показ, источник `SRD 5.2.1` + EN-имя + отсутствие `.ent-hc-name`, соответствие `/hc` JSON, клавиатура+aria+Esc, скрытие.
- Полный прогон 26/26 — визуальные снапшоты целы.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP