### PR TITLE
feat(rules): страницы заклинаний D&D 5.2 + подклассы в API (issue #20)

### DIFF
--- a/.github/scripts/generate_api.py
+++ b/.github/scripts/generate_api.py
@@ -7,6 +7,7 @@ Usage:
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -108,6 +109,92 @@ def resolve_cross_refs(all_data: dict) -> None:
                     if slug:
                         resolved.append(slug)
                 entity["spells"] = resolved
+
+
+# Подклассы SRD 5.2, которые дают доступ к заклинаниям (спелл-гранты в 03_Classes/*.md).
+# Заголовок таблицы в EN — `Table: <Name> Spells`; RU-название берём из этого мапа.
+# ver-каталог для класс-файлов (ver → префикс пути в src).
+VER_DIR = {"srd52": "srd-5.2", "srd51": "srd-5.1"}
+SUBCLASS_LABELS = {
+    "Life Domain":      {"en": "Life Domain",      "ru": "Домен жизни"},
+    "Oath of Devotion": {"en": "Oath of Devotion", "ru": "Клятва преданности"},
+    "Fiend":            {"en": "Fiend",            "ru": "Исчадие"},
+    "Draconic":         {"en": "Draconic",         "ru": "Драконье чародейство"},
+}
+
+
+def _parse_subclass_spell_tables(text: str) -> dict[str, set[str]]:
+    """Из EN-разметки класса извлечь {подкласс: {имена заклинаний}} по таблицам спелл-грантов.
+
+    Таблица подкласса: строка `Table: <Name> Spells`, где <Name> — не базовый список
+    (`Level N <Class>` / `Cantrips`). Имена заклинаний — в последнем столбце (через запятую).
+    """
+    out: dict[str, set[str]] = {}
+    lines = text.split("\n")
+    i = 0
+    while i < len(lines):
+        m = re.match(r"^Table:\s+(.+?)\s+Spells\s*$", lines[i].strip())
+        if m and not re.search(r"Level \d|Cantrips", m.group(1)):
+            name = m.group(1).strip()
+            spells: set[str] = set()
+            j = i + 1
+            while j < len(lines) and not lines[j].lstrip().startswith("|"):
+                j += 1
+            seen_sep = False
+            while j < len(lines) and lines[j].lstrip().startswith("|"):
+                cells = [c.strip() for c in lines[j].strip().strip("|").split("|")]
+                joined = "".join(cells)
+                if joined and set(joined) <= set("-: "):
+                    seen_sep = True
+                elif seen_sep and len(cells) >= 2:
+                    for sp in cells[-1].split(","):
+                        sp = sp.strip()
+                        if sp:
+                            spells.add(sp)
+                j += 1
+            if spells:
+                out[name] = spells
+        i += 1
+    return out
+
+
+def inject_spell_subclasses(all_data: dict, src_root: Path) -> None:
+    """Добавить полю заклинания `subclasses` — подклассы, дающие к нему доступ (по слагу)."""
+    versions = {ver for (ver, lang, res) in all_data if res == "spells"}
+    for ver in versions:
+        vdir = VER_DIR.get(ver)
+        if not vdir:
+            continue
+        classes_dir = src_root / vdir / "en" / "03_Classes"
+        if not classes_dir.is_dir():
+            continue
+        # подкласс(EN) → {EN-имена заклинаний}
+        sub_spells: dict[str, set[str]] = {}
+        for f in sorted(classes_dir.glob("*.md")):
+            for name, spells in _parse_subclass_spell_tables(f.read_text(encoding="utf-8")).items():
+                if name in SUBCLASS_LABELS:
+                    sub_spells.setdefault(name, set()).update(spells)
+        if not sub_spells:
+            continue
+        # EN-имя заклинания → slug
+        en_lookup = {sp["name"].lower(): sp["slug"] for sp in all_data.get((ver, "en", "spells"), [])}
+        # slug → [подкласс(EN)]
+        slug_subs: dict[str, list[str]] = {}
+        for name, spells in sub_spells.items():
+            for sp in spells:
+                slug = en_lookup.get(sp.lower())
+                if slug:
+                    slug_subs.setdefault(slug, []).append(name)
+        # инжект в заклинания всех языков этой версии (локализованное имя подкласса)
+        for (k_ver, k_lang, k_res), entities in all_data.items():
+            if k_ver != ver or k_res != "spells":
+                continue
+            for e in entities:
+                subs = slug_subs.get(e["slug"])
+                if subs:
+                    e["subclasses"] = [
+                        SUBCLASS_LABELS[n].get(k_lang, n) for n in sorted(set(subs))
+                    ]
 
 
 def write_json(path: Path, data) -> None:
@@ -286,6 +373,7 @@ def main():
 
     # Resolve cross-references
     resolve_cross_refs(all_data)
+    inject_spell_subclasses(all_data, src_root)
 
     # Write files and collect hierarchy info
     file_count = 0

--- a/.github/scripts/schemas.py
+++ b/.github/scripts/schemas.py
@@ -52,6 +52,10 @@ SPELL_SCHEMA = {
             "type": "array",
             "items": {"type": "string"},
         },
+        "subclasses": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
         "casting_time": {
             "type": "object",
             "properties": {

--- a/web/e2e/autolink.spec.ts
+++ b/web/e2e/autolink.spec.ts
@@ -89,7 +89,10 @@ test('EN/RU: набор слинкованных состояний совпад
       (p) =>
         p.startsWith('/en/dnd/srd-5.2/') &&
         !p.includes('/glossary/') && // справочные таблицы вне индекса
-        !p.includes('/rules-glossary/conditions/'), // сами страницы состояний, не главы
+        !p.includes('/rules-glossary/conditions/') && // сами страницы состояний, не главы
+        !/\/spells\/[^/]+\/$/.test(p), // страницы отдельных заклинаний (не глава /spells/):
+        // их описания переведены независимо → паритет линковки состояний тут не гарантирован
+        // (глава /spells/ остаётся в наборе).
     );
   expect(chapters.length).toBeGreaterThan(10);
 

--- a/web/e2e/spells.spec.ts
+++ b/web/e2e/spells.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+// Программные страницы заклинаний (issue #20, волна 2): /{lang}/dnd/{ver}/spells/{slug}/.
+// Стат-блок, ссылки классов/подклассов, тултип компонентов, автоссылки состояний + hovercard,
+// SEO (hreflang, sitemap, индексируемость), нормализация школы.
+
+test('страница заклинания: заголовок, EN-имя, стат-блок', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/fireball/');
+  await expect(page.locator('.rd-doc h1')).toContainText('Огненный шар');
+  await expect(page.locator('.ent-en')).toHaveText('Fireball');
+  await expect(page.locator('.spell-lvl')).toHaveText('3-й уровень, Воплощения'); // школа нормализована
+  const meta = page.locator('.spell-meta');
+  await expect(meta).toContainText('Время накладывания');
+  await expect(meta).toContainText('Дистанция');
+  await expect(meta).toContainText('Длительность');
+});
+
+test('компоненты В/С/М — abbr с подсказкой (полное слово в title)', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/fireball/');
+  const abbrs = page.locator('.spell-meta abbr');
+  await expect(abbrs).toHaveCount(3);
+  await expect(abbrs.nth(0)).toHaveAttribute('title', 'Вербальный');
+  await expect(abbrs.nth(1)).toHaveAttribute('title', 'Соматический');
+  await expect(abbrs.nth(2)).toHaveAttribute('title', 'Материальный');
+});
+
+test('классы и подклассы — ссылки на страницы классов', async ({ page }) => {
+  // Aid даётся Домом жизни (Жрец) и Клятвой преданности (Паладин).
+  await page.goto('/ru/dnd/srd-5.2/spells/aid/');
+  const meta = page.locator('.spell-meta');
+  // класс-ссылка (та же cleric-страница используется и подклассом → уточняем текстом)
+  await expect(meta.locator('a[href="/ru/dnd/srd-5.2/classes/cleric/"]', { hasText: 'Жрец' })).toBeVisible();
+  // строка подклассов + ссылки
+  await expect(meta).toContainText('Подклассы');
+  await expect(meta.locator('a[href="/ru/dnd/srd-5.2/classes/cleric/"]', { hasText: 'Домен жизни' })).toBeVisible();
+  await expect(meta.locator('a[href="/ru/dnd/srd-5.2/classes/paladin/"]', { hasText: 'Клятва преданности' })).toBeVisible();
+});
+
+test('в теле заклинания — автоссылки состояний и hovercard', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/hold-person/');
+  const cond = page.locator('.rd-doc a.ent-link[data-hc]').first();
+  await expect(cond).toBeVisible();
+  await cond.hover();
+  await expect(page.locator('#ent-hovercard')).toBeVisible();
+});
+
+test('SEO: hreflang-тройка, индексируема, в sitemap', async ({ page, request }) => {
+  const res = await page.goto('/en/dnd/srd-5.2/spells/fireball/');
+  expect(res?.status()).toBe(200);
+  await expect(page.locator('link[rel="alternate"][hreflang="en"]')).toHaveCount(1);
+  await expect(page.locator('link[rel="alternate"][hreflang="ru"]')).toHaveCount(1);
+  await expect(page.locator('link[rel="alternate"][hreflang="x-default"]')).toHaveCount(1);
+  await expect(page.locator('meta[name="robots"][content*="noindex"]')).toHaveCount(0);
+  const sm = await (await request.get('/sitemap-0.xml')).text();
+  expect(sm).toContain('/dnd/srd-5.2/spells/fireball/');
+});

--- a/web/e2e/spells.spec.ts
+++ b/web/e2e/spells.spec.ts
@@ -28,12 +28,12 @@ test('классы и подклассы — ссылки на страницы 
   // Aid даётся Домом жизни (Жрец) и Клятвой преданности (Паладин).
   await page.goto('/ru/dnd/srd-5.2/spells/aid/');
   const meta = page.locator('.spell-meta');
-  // класс-ссылка (та же cleric-страница используется и подклассом → уточняем текстом)
-  await expect(meta.locator('a[href="/ru/dnd/srd-5.2/classes/cleric/"]', { hasText: 'Жрец' })).toBeVisible();
-  // строка подклассов + ссылки
+  // класс-ссылка «Жрец» (точное совпадение — подкласс тоже ведёт на cleric, но текст «Жрец: …»)
+  await expect(meta.locator('a[href="/ru/dnd/srd-5.2/classes/cleric/"]', { hasText: /^Жрец$/ })).toBeVisible();
+  // строка подклассов: формат «Класс: Подкласс», ссылка на страницу класса
   await expect(meta).toContainText('Подклассы');
-  await expect(meta.locator('a[href="/ru/dnd/srd-5.2/classes/cleric/"]', { hasText: 'Домен жизни' })).toBeVisible();
-  await expect(meta.locator('a[href="/ru/dnd/srd-5.2/classes/paladin/"]', { hasText: 'Клятва преданности' })).toBeVisible();
+  await expect(meta.locator('a[href="/ru/dnd/srd-5.2/classes/cleric/"]', { hasText: 'Жрец: Домен жизни' })).toBeVisible();
+  await expect(meta.locator('a[href="/ru/dnd/srd-5.2/classes/paladin/"]', { hasText: 'Паладин: Клятва преданности' })).toBeVisible();
 });
 
 test('в теле заклинания — автоссылки состояний и hovercard', async ({ page }) => {

--- a/web/e2e/spells.spec.ts
+++ b/web/e2e/spells.spec.ts
@@ -24,16 +24,19 @@ test('компоненты В/С/М — abbr с подсказкой (полно
   await expect(abbrs.nth(2)).toHaveAttribute('title', 'Материальный');
 });
 
-test('классы и подклассы — ссылки на страницы классов', async ({ page }) => {
-  // Aid даётся Домом жизни (Жрец) и Клятвой преданности (Паладин).
-  await page.goto('/ru/dnd/srd-5.2/spells/aid/');
+test('классы и подклассы — ссылки; подкласс скрыт, если класс уже в списке', async ({ page }) => {
+  // Fireball: классы Чародей/Волшебник; даётся подклассом Исчадие (Колдун) — Колдуна нет в
+  // списке классов, поэтому «Колдун: Исчадие» показывается.
+  await page.goto('/ru/dnd/srd-5.2/spells/fireball/');
   const meta = page.locator('.spell-meta');
-  // класс-ссылка «Жрец» (точное совпадение — подкласс тоже ведёт на cleric, но текст «Жрец: …»)
-  await expect(meta.locator('a[href="/ru/dnd/srd-5.2/classes/cleric/"]', { hasText: /^Жрец$/ })).toBeVisible();
-  // строка подклассов: формат «Класс: Подкласс», ссылка на страницу класса
+  await expect(meta.locator('a[href="/ru/dnd/srd-5.2/classes/sorcerer/"]', { hasText: /^Чародей$/ })).toBeVisible();
   await expect(meta).toContainText('Подклассы');
-  await expect(meta.locator('a[href="/ru/dnd/srd-5.2/classes/cleric/"]', { hasText: 'Жрец: Домен жизни' })).toBeVisible();
-  await expect(meta.locator('a[href="/ru/dnd/srd-5.2/classes/paladin/"]', { hasText: 'Паладин: Клятва преданности' })).toBeVisible();
+  await expect(meta.locator('a[href="/ru/dnd/srd-5.2/classes/warlock/"]', { hasText: 'Колдун: Исчадие' })).toBeVisible();
+
+  // Aid: даётся Домом жизни (Жрец) и Клятвой преданности (Паладин), но оба класса уже в полном
+  // списке Aid → строка подклассов избыточна и НЕ показывается.
+  await page.goto('/ru/dnd/srd-5.2/spells/aid/');
+  await expect(page.locator('.spell-meta')).not.toContainText('Подклассы');
 });
 
 test('в теле заклинания — автоссылки состояний и hovercard', async ({ page }) => {

--- a/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
@@ -92,7 +92,11 @@ const subClass = (s: string) => SUBCLASS_INFO[s];
 const subClsName = (s: string) => (lang === 'ru' ? SUBCLASS_INFO[s]?.cls_ru : SUBCLASS_INFO[s]?.cls_en) ?? '';
 const classUrl = (slug: string) => `/${lang}/dnd/${verSlug}/classes/${slug}/`;
 const classList = (Array.isArray(entity.classes) ? entity.classes : []) as string[];
-const subList = (Array.isArray(entity.subclasses) ? entity.subclasses : []) as string[];
+// Подклассы показываем ТОЛЬКО когда их родительский класс НЕ имеет заклинание в полном списке
+// (иначе грант подкласса избыточен — сам класс уже даёт доступ). Напр. Aid на списке Жреца →
+// «Жрец: Домен жизни» не показываем; Fireball не на списке Колдуна → «Колдун: Исчадие» остаётся.
+const subList = ((Array.isArray(entity.subclasses) ? entity.subclasses : []) as string[])
+  .filter((s) => !classList.includes(subClsName(s)));
 
 // Компоненты: аббревиатуры В/С/М с нативным тултипом (полное слово при наведении на ПК).
 const comp = (entity.components ?? {}) as Record<string, unknown>;

--- a/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
@@ -77,12 +77,19 @@ const CLASS_SLUG: Record<string, string> = {
   Бард: 'bard', Жрец: 'cleric', Друид: 'druid', Паладин: 'paladin', Следопыт: 'ranger',
   Чародей: 'sorcerer', Колдун: 'warlock', Волшебник: 'wizard',
 };
-const SUBCLASS_CLASS: Record<string, string> = {
-  'Life Domain': 'cleric', 'Домен жизни': 'cleric',
-  'Oath of Devotion': 'paladin', 'Клятва преданности': 'paladin',
-  Fiend: 'warlock', Исчадие: 'warlock',
-  Draconic: 'sorcerer', 'Драконье чародейство': 'sorcerer',
+// Подкласс → родительский класс (slug + локализованное имя): показываем «Класс: Подкласс».
+const SUBCLASS_INFO: Record<string, { slug: string; cls_ru: string; cls_en: string }> = {
+  'Life Domain':        { slug: 'cleric',   cls_ru: 'Жрец',    cls_en: 'Cleric' },
+  'Домен жизни':        { slug: 'cleric',   cls_ru: 'Жрец',    cls_en: 'Cleric' },
+  'Oath of Devotion':   { slug: 'paladin',  cls_ru: 'Паладин', cls_en: 'Paladin' },
+  'Клятва преданности': { slug: 'paladin',  cls_ru: 'Паладин', cls_en: 'Paladin' },
+  Fiend:                { slug: 'warlock',  cls_ru: 'Колдун',  cls_en: 'Warlock' },
+  Исчадие:              { slug: 'warlock',  cls_ru: 'Колдун',  cls_en: 'Warlock' },
+  Draconic:             { slug: 'sorcerer', cls_ru: 'Чародей', cls_en: 'Sorcerer' },
+  'Драконье чародейство': { slug: 'sorcerer', cls_ru: 'Чародей', cls_en: 'Sorcerer' },
 };
+const subClass = (s: string) => SUBCLASS_INFO[s];
+const subClsName = (s: string) => (lang === 'ru' ? SUBCLASS_INFO[s]?.cls_ru : SUBCLASS_INFO[s]?.cls_en) ?? '';
 const classUrl = (slug: string) => `/${lang}/dnd/${verSlug}/classes/${slug}/`;
 const classList = (Array.isArray(entity.classes) ? entity.classes : []) as string[];
 const subList = (Array.isArray(entity.subclasses) ? entity.subclasses : []) as string[];
@@ -162,7 +169,9 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
         <dt>{t('Подклассы', 'Subclasses')}</dt>
         <dd>
           {subList.map((s, i) => (
-            <Fragment>{i > 0 ? ', ' : ''}{SUBCLASS_CLASS[s] ? <a href={classUrl(SUBCLASS_CLASS[s])}>{s}</a> : s}</Fragment>
+            <Fragment>{i > 0 ? ', ' : ''}{subClass(s)
+              ? <a href={classUrl(subClass(s)!.slug)}>{subClsName(s)}: {s}</a>
+              : s}</Fragment>
           ))}
         </dd>
       </div>

--- a/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
@@ -1,0 +1,238 @@
+---
+import { marked } from 'marked';
+import { fromHtml } from 'hast-util-from-html';
+import { toHtml } from 'hast-util-to-html';
+import ReaderShell from '../../../../../components/ReaderShell.astro';
+import { autolinkTree } from '../../../../../lib/rehype-entity-autolink.mjs';
+import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
+
+// Programmatic-страницы заклинаний (issue #20, волна 2) в общем шелле ридера.
+// URL: /{lang}/dnd/{version}/spells/{slug}/. EN и RU делят канонический (англ.) слаг → hreflang.
+// Родитель для nav/breadcrumb/CTA — глава «Заклинания».
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-spells' };
+
+// Школа: в RU JSON поле переведено наполовину (Evocation vs Воплощения) — нормализуем
+// двусторонним мапом независимо от того, что пришло в данных.
+const SCHOOLS: [string, string][] = [
+  ['Abjuration', 'Ограждения'], ['Conjuration', 'Вызова'], ['Divination', 'Прорицания'],
+  ['Enchantment', 'Очарования'], ['Evocation', 'Воплощения'], ['Illusion', 'Иллюзии'],
+  ['Necromancy', 'Некромантии'], ['Transmutation', 'Преобразования'],
+];
+const schoolLabel = (raw: string, lang: string) => {
+  const p = SCHOOLS.find(([en, ru]) => en === raw || ru === raw);
+  return p ? (lang === 'ru' ? p[1] : p[0]) : raw;
+};
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as const },
+    { ver: 'srd52', lang: 'ru' as const },
+  ];
+  const paths = [];
+  for (const { ver, lang } of BUILDS) {
+    const spells = loadEntities(ver, lang, 'spells');
+    const siblings = spells.map((s) => ({ slug: s.slug, name: s.name, school: s.school as string, level: s.level as string }));
+    for (const entity of spells) {
+      paths.push({
+        params: { lang, version: VERSION_SLUG[ver], slug: entity.slug },
+        props: { entity, ver, lang, siblings },
+      });
+    }
+  }
+  return paths;
+}
+
+const { entity, ver, lang, siblings } = Astro.props;
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+
+// Тело + «на высоких уровнях» с автоссылками на состояния (issue #20): marked → hast → autolink → html.
+const render = (md: string | undefined | null) => {
+  if (!md || md === 'None') return '';
+  const tree = fromHtml(marked.parse(md, { async: false }), { fragment: true });
+  autolinkTree(tree, { game: 'dnd', version: verSlug, lang, selfSlug: entity.slug });
+  return toHtml(tree);
+};
+const bodyHtml = render(entity.description_md as string);
+const higherHtml = render(entity.higher_levels_md as string);
+const cantripHtml = render(entity.cantrip_upgrade_md as string);
+const description = excerpt(entity.description_md as string);
+
+// Стат-блок
+const lvl = String(entity.level ?? '');
+const isCantrip = lvl === '0';
+const school = schoolLabel(entity.school as string, lang);
+const levelLine = isCantrip
+  ? t(`Заговор, ${school}`, `${school} cantrip`)
+  : t(`${lvl}-й уровень, ${school}`, `${ordinalEn(lvl)}-level ${school}`);
+function ordinalEn(n: string) {
+  const s = ['th', 'st', 'nd', 'rd'], v = Number(n) % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+// Классы/подклассы → ссылки на страницы классов (/{lang}/dnd/{ver}/classes/{slug}/).
+const CLASS_SLUG: Record<string, string> = {
+  Bard: 'bard', Cleric: 'cleric', Druid: 'druid', Paladin: 'paladin', Ranger: 'ranger',
+  Sorcerer: 'sorcerer', Warlock: 'warlock', Wizard: 'wizard',
+  Бард: 'bard', Жрец: 'cleric', Друид: 'druid', Паладин: 'paladin', Следопыт: 'ranger',
+  Чародей: 'sorcerer', Колдун: 'warlock', Волшебник: 'wizard',
+};
+const SUBCLASS_CLASS: Record<string, string> = {
+  'Life Domain': 'cleric', 'Домен жизни': 'cleric',
+  'Oath of Devotion': 'paladin', 'Клятва преданности': 'paladin',
+  Fiend: 'warlock', Исчадие: 'warlock',
+  Draconic: 'sorcerer', 'Драконье чародейство': 'sorcerer',
+};
+const classUrl = (slug: string) => `/${lang}/dnd/${verSlug}/classes/${slug}/`;
+const classList = (Array.isArray(entity.classes) ? entity.classes : []) as string[];
+const subList = (Array.isArray(entity.subclasses) ? entity.subclasses : []) as string[];
+
+// Компоненты: аббревиатуры В/С/М с нативным тултипом (полное слово при наведении на ПК).
+const comp = (entity.components ?? {}) as Record<string, unknown>;
+const compItems: { a: string; full: string }[] = [];
+if (comp.verbal) compItems.push({ a: t('В', 'V'), full: t('Вербальный', 'Verbal') });
+if (comp.somatic) compItems.push({ a: t('С', 'S'), full: t('Соматический', 'Somatic') });
+if (comp.material) compItems.push({ a: t('М', 'M'), full: t('Материальный', 'Material') });
+const materialDesc = comp.material && comp.material_desc ? (comp.material_desc as string) : '';
+
+const castVal = (entity.casting_time as Record<string, unknown>)?.value as string;
+const rangeVal = (entity.range as Record<string, unknown>)?.value as string;
+const durVal = (entity.duration as Record<string, unknown>)?.value as string;
+
+const base = `/${lang}/dnd/${verSlug}/spells`;
+// «Та же школа» — до 8 других заклинаний той же школы (внутренняя перелинковка/SEO).
+const sameSchool = (siblings as { slug: string; name: string; school: string }[])
+  .filter((s) => s.slug !== entity.slug && schoolLabel(s.school, lang) === school)
+  .slice(0, 8);
+
+const upLink = { href: `${base}/`, ru: 'Заклинания', en: 'Spells' };
+const kind = t('Заклинание', 'Spell');
+const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel} ${kind}`)} · OmnisGM Rules`;
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={entity.name}
+  description={description}
+  headings={[]}
+  upLink={upLink}
+>
+  <h1>
+    {entity.name}
+    {lang === 'ru' && entity.name_en && <span class="ent-en">{entity.name_en}</span>}
+  </h1>
+
+  <p class="spell-lvl">{levelLine}</p>
+
+  <dl class="spell-meta">
+    {castVal && (
+      <div class="spell-meta-row"><dt>{t('Время накладывания', 'Casting Time')}</dt><dd>{castVal}</dd></div>
+    )}
+    {rangeVal && (
+      <div class="spell-meta-row"><dt>{t('Дистанция', 'Range')}</dt><dd>{rangeVal}</dd></div>
+    )}
+    {compItems.length > 0 && (
+      <div class="spell-meta-row">
+        <dt>{t('Компоненты', 'Components')}</dt>
+        <dd>
+          {compItems.map((c, i) => (
+            <Fragment>{i > 0 ? ', ' : ''}<abbr title={c.full}>{c.a}</abbr></Fragment>
+          ))}
+          {materialDesc && <span class="spell-mat"> ({materialDesc})</span>}
+        </dd>
+      </div>
+    )}
+    {durVal && (
+      <div class="spell-meta-row"><dt>{t('Длительность', 'Duration')}</dt><dd>{durVal}</dd></div>
+    )}
+    {classList.length > 0 && (
+      <div class="spell-meta-row">
+        <dt>{t('Классы', 'Classes')}</dt>
+        <dd>
+          {classList.map((c, i) => (
+            <Fragment>{i > 0 ? ', ' : ''}{CLASS_SLUG[c] ? <a href={classUrl(CLASS_SLUG[c])}>{c}</a> : c}</Fragment>
+          ))}
+        </dd>
+      </div>
+    )}
+    {subList.length > 0 && (
+      <div class="spell-meta-row">
+        <dt>{t('Подклассы', 'Subclasses')}</dt>
+        <dd>
+          {subList.map((s, i) => (
+            <Fragment>{i > 0 ? ', ' : ''}{SUBCLASS_CLASS[s] ? <a href={classUrl(SUBCLASS_CLASS[s])}>{s}</a> : s}</Fragment>
+          ))}
+        </dd>
+      </div>
+    )}
+  </dl>
+
+  <Fragment set:html={bodyHtml} />
+
+  {higherHtml && (
+    <>
+      <h2>{t('На более высоких уровнях', 'Using a Higher-Level Spell Slot')}</h2>
+      <Fragment set:html={higherHtml} />
+    </>
+  )}
+  {cantripHtml && (
+    <>
+      <h2>{t('Улучшение заговора', 'Cantrip Upgrade')}</h2>
+      <Fragment set:html={cantripHtml} />
+    </>
+  )}
+
+  {sameSchool.length > 0 && (
+    <nav class="ent-related" aria-label={t('Та же школа', 'Same school')}>
+      <span class="ent-related-h">{t(`Ещё из школы ${school}`, `More ${school} spells`)}</span>
+      <span class="ent-related-list">
+        {sameSchool.map((r) => (
+          <a href={`${base}/${r.slug}/`}><strong>{r.name}</strong></a>
+        ))}
+      </span>
+    </nav>
+  )}
+</ReaderShell>
+
+<style>
+  .ent-en {
+    display: block; margin-top: 8px;
+    font-family: var(--font-mono); font-size: 14px; font-weight: 400; letter-spacing: 0;
+    color: var(--og-text-muted);
+  }
+  /* Подзаголовок «3-й уровень, Воплощения» — курсив, приглушённо, как флейвор под именем. */
+  .spell-lvl {
+    margin: -6px 0 18px; font-style: italic; color: var(--og-text-muted); font-size: 15px;
+  }
+  /* Стат-блок: карточка с рядами «поле — значение». */
+  .spell-meta {
+    margin: 0 0 24px; padding: 14px 16px; border: 1px solid var(--og-border); border-radius: 10px;
+    background: var(--og-bg-2); display: grid; gap: 8px;
+  }
+  .spell-meta-row { display: grid; grid-template-columns: 180px 1fr; gap: 12px; align-items: baseline; }
+  .spell-meta dt {
+    font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.6px; text-transform: uppercase;
+    color: var(--og-text-muted); font-weight: 600;
+  }
+  .spell-meta dd { margin: 0; color: var(--og-text-2); }
+  /* Компоненты В/С/М: подсказка (полное слово) по наведению — нативный title. */
+  .spell-meta abbr {
+    text-decoration: none; border-bottom: 1px dotted var(--og-text-muted); cursor: help;
+    font-weight: 600; color: var(--og-text);
+  }
+  .spell-mat { color: var(--og-text-muted); }
+  /* Классы/подклассы — ссылки: как ent-related, цвет прозы + акцентное подчёркивание. */
+  .spell-meta a { color: var(--og-accent); border-bottom: 1px solid color-mix(in oklab, var(--og-accent) 45%, transparent); text-decoration: none; }
+  .spell-meta a:hover { border-bottom-color: var(--og-accent); }
+  @media (max-width: 560px) {
+    .spell-meta-row { grid-template-columns: 1fr; gap: 2px; }
+  }
+  .ent-related { display: block; margin-top: 40px; padding-top: 20px; border-top: 1px solid var(--og-border); }
+  .ent-related-h {
+    display: block; font-size: 13px; text-transform: uppercase; letter-spacing: 1px;
+    color: var(--og-text-muted); margin-bottom: 10px;
+  }
+  .ent-related-list { display: flex; flex-wrap: wrap; gap: 6px 14px; }
+</style>


### PR DESCRIPTION
Волна 2 issue #20 — программные страницы заклинаний (+678 URL в sitemap) + подклассы в JSON API.

## Страницы `/{lang}/dnd/srd-5.2/spells/{slug}/`
- ~678 стр. (en+ru), в sitemap, индексируемы, hreflang×3, breadcrumb+Article JSON-LD.
- Имя + EN-подпись, «уровень, школа» (школа нормализована — в JSON была вперемешку EN/RU).
- **Стат-блок**: время накладывания · дистанция · компоненты · длительность · классы · подклассы.
- Описание **с автоссылками на состояния + hovercard'ами**, «на высоких уровнях», «ещё из школы» (перелинковка).

## Детали
- **Компоненты В/С/М** — `<abbr>` с нативным тултипом (полное слово на ПК).
- **Классы и подклассы — ссылки** на страницы классов. Подклассы в формате «Класс: Подкласс» (Колдун: Исчадие), и показываются только когда класс НЕ имеет заклинание в полном списке (иначе избыточно).
- **Подклассы в API**: `generate_api.py` парсит спелл-гранты 4 подклассов SRD 5.2 (Домен жизни/Клятва преданности/Исчадие/Драконье чародейство) из `03_Classes`, инжектит по слагу; `schemas.py` — поле `subclasses`.

## Проверки
- astro check: 0 ошибок; **31/31 e2e** (5 новых `spells.spec.ts`: стат-блок, abbr-компоненты, классы/подклассы-ссылки + фильтр избыточности, автоссылки+hovercard в теле, SEO).
- `autolink.spec.ts`: страницы отдельных заклинаний исключены из chapter-паритета (описания переведены независимо).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP