### PR TITLE
fix(rules): заклинание — EN-имя и «уровень, школа» в одну строку

### DIFF
--- a/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
@@ -144,8 +144,10 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
 >
   <h1>
     {entity.name}
-    {lang === 'ru' && entity.name_en && <span class="ent-en">{entity.name_en}</span>}
-    <span class="spell-lvl">{levelLine}</span>
+    <span class="spell-sub">
+      {lang === 'ru' && entity.name_en && <span class="ent-en">{entity.name_en}</span>}
+      <span class="spell-lvl">{levelLine}</span>
+    </span>
   </h1>
 
   <dl class="spell-meta">
@@ -221,17 +223,21 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
 </ReaderShell>
 
 <style>
-  .ent-en {
+  /* Подстрока в шапке (над чертой): EN-имя + «уровень, школа» В ОДНУ СТРОКУ,
+     перенос только при нехватке места. */
+  .spell-sub {
     display: block; margin-top: 8px;
+    font-family: var(--font-body); font-weight: 400; letter-spacing: 0;
+  }
+  .ent-en {
     font-family: var(--font-mono); font-size: 14px; font-weight: 400; letter-spacing: 0;
     color: var(--og-text-muted);
   }
-  /* Подзаголовок «3-й уровень, Воплощения» — ВНУТРИ h1 (над чертой), рядом с EN-именем. */
   .spell-lvl {
-    display: block; margin-top: 6px;
-    font-family: var(--font-body); font-weight: 400; font-style: italic; font-size: 15px;
-    letter-spacing: 0; color: var(--og-text-muted);
+    font-style: italic; font-size: 14px; color: var(--og-text-muted);
   }
+  /* Разделитель «·» — только когда уровень идёт после EN-имени (в RU). */
+  .ent-en + .spell-lvl::before { content: ' · '; font-style: normal; }
   /* Стат-блок: карточка с рядами «поле — значение». */
   .spell-meta {
     margin: 0 0 24px; padding: 14px 16px; border: 1px solid var(--og-border); border-radius: 10px;


### PR DESCRIPTION
По ревью: подстрока в шапке (EN-имя + «уровень, школа») теперь в одну строку с разделителем «·» — «Hold Person · 2-й уровень, Очарования». Перенос только когда не влезает. В EN (нет отдельного EN-имени) — только «уровень, школа», без ведущего «·». 31/31 e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP