### PR TITLE
feat(rules): автолинки заклинаний (issue #20, Slice B) — классы/монстры/предметы

### DIFF
--- a/web/e2e/autolink.spec.ts
+++ b/web/e2e/autolink.spec.ts
@@ -5,14 +5,26 @@ import { test, expect } from '@playwright/test';
 const CHAPTER = '/en/dnd/srd-5.2/spells/'; // глава с множеством упоминаний состояний
 const ENTITY = '/en/dnd/srd-5.2/rules-glossary/conditions/paralyzed/'; // тело ссылается на Incapacitated
 
-test('глава: имена состояний автолинкуются на страницы состояний', async ({ page }) => {
+test('глава: автоссылки ведут на страницы сущностей (состояния/заклинания)', async ({ page }) => {
   await page.goto(CHAPTER);
   const links = page.locator('.rd-doc a.ent-link');
   expect(await links.count()).toBeGreaterThan(0);
-  // Все ent-link ведут на страницы состояний.
+  // Все ent-link ведут на программную страницу сущности: состояние или заклинание.
   for (const href of await links.evaluateAll((els) => els.map((e) => e.getAttribute('href')))) {
-    expect(href).toContain('/rules-glossary/conditions/');
+    expect(href).toMatch(/\/(rules-glossary\/conditions|spells)\/[a-z-]+\/$/);
   }
+});
+
+test('заклинания: имена в спелл-таблицах классов и в курсиве линкуются на страницы заклинаний', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/classes/cleric/');
+  const spellLinks = page.locator('.rd-doc a.ent-link[href*="/dnd/srd-5.2/spells/"]');
+  expect(await spellLinks.count()).toBeGreaterThan(20); // таблицы спелл-листов + курсивные упоминания
+  // табличная ссылка (первая колонка спелл-листа)
+  await expect(page.locator('.rd-doc td a.ent-link[href*="/spells/"]').first()).toBeVisible();
+  // курсивная ссылка в прозе (<em><a>)
+  await expect(page.locator('.rd-doc em a.ent-link[href*="/spells/"]').first()).toBeVisible();
+  // обычное слово (не курсив, не в спелл-таблице) НЕ линкуется: «свет» строчным в прозе
+  await expect(page.locator('.rd-doc a.ent-link', { hasText: /^свет$/ })).toHaveCount(0);
 });
 
 test('автолинк не попадает в заголовки и не вкладывается в другие ссылки', async ({ page }) => {
@@ -46,7 +58,7 @@ test('страница состояния: тело линкует другие 
 test('автоссылка несёт data-hc для будущего hovercard', async ({ page }) => {
   await page.goto(CHAPTER);
   const first = page.locator('.rd-doc a.ent-link').first();
-  await expect(first).toHaveAttribute('data-hc', /^dnd\/srd52\/en\/conditions\//);
+  await expect(first).toHaveAttribute('data-hc', /^dnd\/srd52\/en\/(conditions|spells)\//);
 });
 
 // Паритет EN/RU: страницы одной главы — зеркальный перевод, значит НАБОР слинкованных состояний
@@ -63,11 +75,10 @@ test('автоссылка несёт data-hc для будущего hovercard'
 // Тест падает и при НОВОМ расхождении (регрессия матчинга/перевода), и при ПРОТУХШЕЙ записи
 // allowlist (расхождение исчезло → запись надо убрать).
 const EXCEPTIONS: Record<string, string[]> = {
-  '/en/dnd/srd-5.2/classes/bard/': ['invisible'], // RU «Невидимый»; EN — заклинание Invisibility
+  // (bard/warlock/wizard : invisible — сняты: «Невидимость» теперь линкуется как ЗАКЛИНАНИЕ
+  //  в спелл-листах, не как состояние, → расхождение состояния исчезло на обоих языках.)
   '/en/dnd/srd-5.2/classes/monk/': ['exhaustion'], // RU не использует «Истощение»
   '/en/dnd/srd-5.2/classes/ranger/': ['exhaustion'],
-  '/en/dnd/srd-5.2/classes/warlock/': ['invisible'],
-  '/en/dnd/srd-5.2/classes/wizard/': ['invisible'],
   '/en/dnd/srd-5.2/feats/': ['grappled'], // RU не использует «Схваченный»
   '/en/dnd/srd-5.2/magic-items/': ['prone', 'unconscious'], // RU: иные формы/прозой
 };

--- a/web/e2e/hovercard.spec.ts
+++ b/web/e2e/hovercard.spec.ts
@@ -7,7 +7,7 @@ const CHAPTER = '/ru/dnd/srd-5.2/spells/';
 
 test('карточка появляется при наведении на автоссылку', async ({ page }) => {
   await page.goto(CHAPTER);
-  const link = page.locator('.rd-doc a.ent-link[data-hc]').first();
+  const link = page.locator('.rd-doc a.ent-link[data-hc*="/conditions/"]').first();
   await expect(link).toBeVisible();
   const card = page.locator('#ent-hovercard');
   await expect(card).toHaveCount(0); // до первого показа элемента нет в DOM
@@ -26,7 +26,7 @@ test('карточка появляется при наведении на ав�
 
 test('содержимое карточки соответствует данным сущности из /hc JSON', async ({ page, request }) => {
   await page.goto(CHAPTER);
-  const link = page.locator('.rd-doc a.ent-link[data-hc]').first();
+  const link = page.locator('.rd-doc a.ent-link[data-hc*="/conditions/"]').first();
   const hc = (await link.getAttribute('data-hc'))!; // dnd/srd52/ru/conditions/<slug>
   const [game, ver, lang, ...rest] = hc.split('/');
   const bucket = await (await request.get(`/hc/${game}/${ver}/${lang}.json`)).json();
@@ -42,7 +42,7 @@ test('содержимое карточки соответствует данн�
 
 test('клавиатурный фокус открывает карточку и связывает aria-describedby', async ({ page }) => {
   await page.goto(CHAPTER);
-  const link = page.locator('.rd-doc a.ent-link[data-hc]').first();
+  const link = page.locator('.rd-doc a.ent-link[data-hc*="/conditions/"]').first();
   await link.focus();
   const card = page.locator('#ent-hovercard');
   await expect(card).toBeVisible();
@@ -54,7 +54,7 @@ test('клавиатурный фокус открывает карточку и
 
 test('карточка скрывается, когда курсор уходит со ссылки', async ({ page }) => {
   await page.goto(CHAPTER);
-  const link = page.locator('.rd-doc a.ent-link[data-hc]').first();
+  const link = page.locator('.rd-doc a.ent-link[data-hc*="/conditions/"]').first();
   await link.hover();
   await expect(page.locator('#ent-hovercard')).toBeVisible();
   await page.mouse.move(0, 0);

--- a/web/src/lib/rehype-entity-autolink.mjs
+++ b/web/src/lib/rehype-entity-autolink.mjs
@@ -1,43 +1,37 @@
-// Автоссылки на программные страницы сущностей (issue #20): в контенте глав имена сущностей,
-// у которых есть отдельная страница (пока — состояния/conditions), становятся ссылками на неё.
-// Ручной обход hast-дерева — как rehype-wrap-tables/promote-headings, без доп. зависимостей.
+// Автоссылки на программные страницы сущностей (issue #20): имена сущностей в контенте
+// становятся ссылками на их страницы. Ручной обход hast-дерева — без доп. зависимостей.
 //
-// Правила матчинга:
-//  • Совпадение по display-имени в языке страницы (EN «Frightened», RU «Испуганный»).
-//  • Case-sensitive: SRD капитализирует имена состояний как ключевые слова, поэтому строчное
-//    «prone/frightened» в обычной прозе не ловится — только «Prone/Frightened».
-//  • Границы слова через unicode-lookaround (\b в JS не работает с кириллицей).
-//  • Первое вхождение каждой сущности на страницу (конвенция глоссариев — линкуем первое упоминание).
-//  • Не трогаем текст внутри <a>/<code>/<pre> и заголовков <h1>…<h6>.
+// Два режима матчинга (по ресурсу):
+//  • text  — состояния: plain-текст, case-sensitive keyword с границами слова (SRD капитализирует
+//    имена состояний; строчное «prone» не ловим). Синонимы-краткие формы — в ALIASES.
+//  • exact — заклинания: линкуем ТОЛЬКО там, где SRD сам разметил ссылку — курсив `<em>Свет</em>`
+//    (полный текст = имя) ИЛИ первая колонка таблиц спелл-листов классов. Слово «свет» в прозе
+//    не трогаем — только явные курсивные упоминания. Так снимается переусердствование.
+//
+// Не трогаем текст внутри <a>/<code>/<pre>/<kbd> и заголовков <h1>…<h6>.
 import fs from 'node:fs';
 import path from 'node:path';
 
-// process.cwd() (= web/ на билде) — резолвится одинаково и в конфиг-контексте (главы через
-// astro.config), и под Vite (страницы сущностей). import.meta.url под Vite указывает не туда.
+// process.cwd() (= web/ на билде) — резолвится одинаково в конфиг-контексте (главы) и под Vite
+// (страницы сущностей). import.meta.url под Vite указывает не туда.
 const DATA_ROOT = path.resolve(process.cwd(), 'src/data/api');
 
-// Ресурсы с программными страницами → сегмент URL-родителя под главой.
-const RESOURCES = [{ key: 'conditions', urlParent: 'rules-glossary/conditions' }];
+// Ресурсы с программными страницами. mode: 'text' | 'exact'. versions — ограничение по версиям
+// (где реально есть страницы); без него — все версии.
+const RESOURCES = [
+  { key: 'conditions', urlParent: 'rules-glossary/conditions', mode: 'text' },
+  { key: 'spells', urlParent: 'spells', mode: 'exact', versions: ['srd-5.2'] },
+];
 
-// Доп. имена-синонимы: `${game}/${lang}` → { [slug]: [alias, …] }.
-// RU-состояния — прилагательные; SRD-перевод часто использует КРАТКУЮ форму как ключевое слово
-// («получаете состояние Недееспособен», «состояние «Ослеплён»»). Номинатив («…ный») там не
-// встречается, поэтому базовый матчинг их не ловит → страдает паритет EN/RU. Литералы защищены
-// границами слова (ловят ровно краткую муж. форму, не длинную и не «Невидимость»). Каждое слово
-// проверено в корпусе src/dnd/srd-5.2/ru. Женский/средний/мн. краткие формы намеренно не добавляем
-// (реже, риск ложных срабатываний) — остаток покрывает allowlist в e2e-тесте паритета.
+// Заголовок первой колонки таблицы спелл-листа класса (по языку) — сигнал линковать её ячейки.
+const SPELL_TABLE_HEAD = new Set(['Заклинание', 'Spell']);
+
+// Доп. имена-синонимы (краткие формы состояний): `${game}/${lang}` → { [slug]: [alias, …] }.
 const ALIASES = {
   'dnd/ru': {
-    blinded: ['Ослеплён'],
-    charmed: ['Очарован'],
-    frightened: ['Испуган'],
-    grappled: ['Схвачен'],
-    incapacitated: ['Недееспособен'],
-    invisible: ['Невидим'],
-    paralyzed: ['Парализован'],
-    poisoned: ['Отравлен'],
-    restrained: ['Опутан'],
-    stunned: ['Ошеломлён'],
+    blinded: ['Ослеплён'], charmed: ['Очарован'], frightened: ['Испуган'], grappled: ['Схвачен'],
+    incapacitated: ['Недееспособен'], invisible: ['Невидим'], paralyzed: ['Парализован'],
+    poisoned: ['Отравлен'], restrained: ['Опутан'], stunned: ['Ошеломлён'],
   },
 };
 
@@ -46,68 +40,66 @@ const SKIP_TAGS = new Set(['a', 'code', 'pre', 'kbd', 'h1', 'h2', 'h3', 'h4', 'h
 const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const verKeyOf = (version) => version.replace(/[.\-]/g, ''); // srd-5.2 → srd52
 
-// Кэш карт совпадений: `${game}/${version}/${lang}` → { regexSource, byName, verKey } | null
+// Кэш: `${game}/${version}/${lang}` → { text: {regexSource, byName} | null, exact: Map, verKey } | null
 const mapCache = new Map();
 
 function loadMap(game, version, lang) {
   const cacheKey = `${game}/${version}/${lang}`;
   if (mapCache.has(cacheKey)) return mapCache.get(cacheKey);
   const verKey = verKeyOf(version);
-  const entries = [];
-  for (const { key, urlParent } of RESOURCES) {
+  const aliases = ALIASES[`${game}/${lang}`] || {};
+  const textEntries = [];
+  const exact = new Map();
+  for (const { key, urlParent, mode, versions } of RESOURCES) {
+    if (versions && !versions.includes(version)) continue;
     const file = path.join(DATA_ROOT, game, verKey, lang, key, 'all.json');
     let data;
     try {
       data = JSON.parse(fs.readFileSync(file, 'utf8'));
     } catch {
-      continue; // ресурса нет для этой игры/версии/языка — просто пропускаем
+      continue; // ресурса нет для игры/версии/языка
     }
-    const aliases = ALIASES[`${game}/${lang}`] || {};
     for (const e of data) {
       if (!e || !e.name || !e.slug) continue;
-      entries.push({ name: e.name, slug: e.slug, resource: key, urlParent });
-      for (const alias of aliases[e.slug] || [])
-        entries.push({ name: alias, slug: e.slug, resource: key, urlParent });
+      const entry = { name: e.name, slug: e.slug, resource: key, urlParent };
+      if (mode === 'exact') {
+        // Ключ в lowercase: SRD размечает курсивом ссылки на заклинания и СТРОЧНЫМИ
+        // («*лечение ран*»), и с заглавной («*Благословение*») — ловим оба. Внутри <em>/ячейки
+        // спелл-таблицы полное совпадение фразы с именем безопасно и без учёта регистра.
+        const k = e.name.toLowerCase();
+        if (!exact.has(k)) exact.set(k, entry);
+      } else {
+        textEntries.push(entry);
+        for (const alias of aliases[e.slug] || []) textEntries.push({ ...entry, name: alias });
+      }
     }
   }
-  if (!entries.length) {
-    mapCache.set(cacheKey, null);
-    return null;
+  let text = null;
+  if (textEntries.length) {
+    // Длинные имена раньше коротких: в альтернации побеждает первый матч, а не самый длинный.
+    textEntries.sort((a, b) => b.name.length - a.name.length);
+    const byName = new Map(textEntries.map((e) => [e.name, e]));
+    const alt = textEntries.map((e) => escapeRegExp(e.name)).join('|');
+    text = { regexSource: `(?<![\\p{L}\\p{N}_])(${alt})(?![\\p{L}\\p{N}_])`, byName };
   }
-  // Длинные имена раньше коротких: в JS-альтернации побеждает первый матч, а не самый длинный.
-  entries.sort((a, b) => b.name.length - a.name.length);
-  const byName = new Map(entries.map((e) => [e.name, e]));
-  const alt = entries.map((e) => escapeRegExp(e.name)).join('|');
-  const regexSource = `(?<![\\p{L}\\p{N}_])(${alt})(?![\\p{L}\\p{N}_])`;
-  const result = { regexSource, byName, verKey };
+  const result = text || exact.size ? { text, exact, verKey } : null;
   mapCache.set(cacheKey, result);
   return result;
 }
 
-function linkifyText(value, map, skip, ctx) {
-  const re = new RegExp(map.regexSource, 'gu');
+function linkifyText(value, textMap, skip, ctx) {
+  const re = new RegExp(textMap.regexSource, 'gu');
   const nodes = [];
   let last = 0;
   let changed = false;
   let match;
   while ((match = re.exec(value))) {
     const name = match[1];
-    const entry = map.byName.get(name);
-    if (!entry || skip.has(entry.slug)) continue; // самоссылка (selfSlug) — оставляем текстом
+    const entry = textMap.byName.get(name);
+    if (!entry || skip.has(entry.slug)) continue;
     changed = true;
     if (match.index > last) nodes.push({ type: 'text', value: value.slice(last, match.index) });
-    const href = `/${ctx.lang}/${ctx.game}/${ctx.verSlug}/${entry.urlParent}/${entry.slug}/`;
-    nodes.push({
-      type: 'element',
-      tagName: 'a',
-      properties: {
-        className: ['ent-link'],
-        href,
-        // Ключ для hovercard (PR B): game/verKey/lang/resource/slug.
-        'data-hc': `${ctx.game}/${map.verKey}/${ctx.lang}/${entry.resource}/${entry.slug}`,
-      },
-      children: [{ type: 'text', value: name }],
-    });
+    nodes.push(linkNode(entry, name, ctx));
     last = match.index + name.length;
   }
   if (!changed) return null;
@@ -115,25 +107,91 @@ function linkifyText(value, map, skip, ctx) {
   return nodes;
 }
 
-// Ядро: линкует имена сущностей прямо в hast-дереве. Используется и rehype-обёрткой (главы Astro),
-// и страницами сущностей (marked → hast → toHtml), поэтому логика одна. Линкуем ВСЕ вхождения
-// каждого имени (не только первое). game/version/lang — контекст; selfSlug — не линковать саму
-// сущность на её же странице.
+function linkNode(entry, text, ctx) {
+  return {
+    type: 'element',
+    tagName: 'a',
+    properties: {
+      className: ['ent-link'],
+      href: `/${ctx.lang}/${ctx.game}/${ctx.verSlug}/${entry.urlParent}/${entry.slug}/`,
+      // Ключ для hovercard: game/verKey/lang/resource/slug.
+      'data-hc': `${ctx.game}/${ctx.verKey}/${ctx.lang}/${entry.resource}/${entry.slug}`,
+    },
+    children: [{ type: 'text', value: text }],
+  };
+}
+
+// Полный текст элемента, только если ВСЕ прямые потомки — текстовые (иначе null).
+function directText(el) {
+  if (!el.children || !el.children.length) return null;
+  if (!el.children.every((c) => c.type === 'text')) return null;
+  return el.children.map((c) => c.value).join('');
+}
+
+// Все <tr> внутри таблицы (thead/tbody прозрачны).
+function collectRows(node, out) {
+  for (const c of node.children || []) {
+    if (c.type !== 'element') continue;
+    if (c.tagName === 'tr') out.push(c);
+    else collectRows(c, out);
+  }
+}
+
+// Ядро: линкует имена сущностей прямо в hast-дереве. Общая логика для глав (rehype) и страниц
+// сущностей (marked → hast). selfSlug — не линковать саму сущность на её же странице.
 export function autolinkTree(tree, { game, version, lang, selfSlug }) {
   const map = loadMap(game, version, lang);
   if (!map) return tree;
   const skip = new Set();
-  if (selfSlug) skip.add(selfSlug); // самоссылку не ставим
-  const ctx = { game, lang, verSlug: version };
+  if (selfSlug) skip.add(selfSlug);
+  const ctx = { game, lang, verSlug: version, verKey: map.verKey };
+
+  const exactEntry = (rawText) => {
+    if (rawText == null) return null;
+    const t = rawText.trim();
+    const entry = map.exact.get(t.toLowerCase()); // регистро-независимо (текст ссылки — как в оригинале)
+    return entry && !skip.has(entry.slug) ? { entry, text: t } : null;
+  };
+
+  const isSpellTable = (table) => {
+    const rows = [];
+    collectRows(table, rows);
+    if (!rows.length) return false;
+    const first = rows[0].children.find((c) => c.type === 'element' && (c.tagName === 'th' || c.tagName === 'td'));
+    const head = first && directText(first);
+    return head != null && SPELL_TABLE_HEAD.has(head.trim());
+  };
+
+  const linkSpellTable = (table) => {
+    const rows = [];
+    collectRows(table, rows);
+    for (const tr of rows) {
+      const cell = tr.children.find((c) => c.type === 'element' && c.tagName === 'td'); // только данные (не th)
+      if (!cell) continue;
+      const hit = exactEntry(directText(cell));
+      if (hit) cell.children = [linkNode(hit.entry, hit.text, ctx)];
+    }
+  };
 
   const walk = (node, insideSkip) => {
     if (!node.children) return;
     for (let i = 0; i < node.children.length; i++) {
       const child = node.children[i];
       if (child.type === 'element') {
-        walk(child, insideSkip || SKIP_TAGS.has(child.tagName));
-      } else if (child.type === 'text' && !insideSkip) {
-        const replaced = linkifyText(child.value, map, skip, ctx);
+        const tag = child.tagName;
+        // Спелл-таблица класса: линкуем первую колонку (данные), затем обычный обход остального.
+        if (tag === 'table' && map.exact.size && isSpellTable(child)) linkSpellTable(child);
+        // Курсивная ссылка на заклинание: <em>Имя</em> целиком.
+        if (tag === 'em' && !insideSkip && map.exact.size) {
+          const hit = exactEntry(directText(child));
+          if (hit) {
+            child.children = [linkNode(hit.entry, hit.text, ctx)];
+            continue; // уже ссылка — внутрь не идём
+          }
+        }
+        walk(child, insideSkip || SKIP_TAGS.has(tag));
+      } else if (child.type === 'text' && !insideSkip && map.text) {
+        const replaced = linkifyText(child.value, map.text, skip, ctx);
         if (replaced) {
           node.children.splice(i, 1, ...replaced);
           i += replaced.length - 1;


### PR DESCRIPTION
Slice B: имена заклинаний в тексте → ссылки на страницы заклинаний.

## Как избегаем переусердствования
SRD размечает ссылки на заклинания **курсивом** — на это и опираемся:
- **Курсив** `<em>Имя</em>` (полное совпадение с именем заклинания) → ссылка. Регистро-независимо, т.к. SRD пишет и «*Благословение*», и «*лечение ран*».
- **Спелл-таблицы классов** (`Заклинание | Школа | Особое`) → линкуем первую колонку.
- Обычное слово в прозе («свет») **не трогаем** — только явные курсивные упоминания.

## Охват
| Где | Ссылок (RU) |
|---|---|
| Классы (таблицы + проза) | ~116 на страницу класса |
| Монстры (бестиарий A–Z) | 321 (+ 554 состояния) |
| Маг. предметы | 127 |

Заклинания — только **srd52** (страницы есть). Состояния линкуются как раньше (plain-keyword).

## Реализация
- `rehype-entity-autolink`: режим `exact` (em + первая колонка спелл-таблицы) рядом с `text` (состояния). Работает и в главах (build), и на страницах сущностей.
- `data-hc` для заклинаний проставлен — карточки заклинаний включим позже (пока hover по заклинанию карточку не показывает, ссылка работает).

## Проверки
- 32/32 e2e. Новый тест спелл-линков в классах (таблица + курсив + «свет» не линкуется).
- Паритетный allowlist почищен: `invisible` у bard/warlock/wizard снят — «Невидимость» теперь спелл-линк, не состояние, расхождение исчезло.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP