### PR TITLE
feat(rules): hovercard-карточки заклинаний (issue #20)

### DIFF
--- a/web/e2e/hovercard.spec.ts
+++ b/web/e2e/hovercard.spec.ts
@@ -60,3 +60,16 @@ test('карточка скрывается, когда курсор уходи�
   await page.mouse.move(0, 0);
   await expect(page.locator('#ent-hovercard')).toBeHidden();
 });
+
+test('карточка заклинания: EN-имя, источник, «уровень, школа» + мета', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/classes/cleric/');
+  const spell = page.locator('.rd-doc td a.ent-link[href*="/spells/"]', { hasText: 'Лечение ран' }).first();
+  await spell.scrollIntoViewIfNeeded();
+  await spell.hover();
+  const card = page.locator('#ent-hovercard');
+  await expect(card).toBeVisible();
+  await expect(card.locator('.ent-hc-src')).toHaveText('SRD 5.2.1');
+  await expect(card.locator('.ent-hc-en')).toHaveText('Cure Wounds'); // оригинальное имя
+  await expect(card.locator('.ent-hc-body .hc-sub')).toContainText('уровень'); // «1-й уровень, …»
+  await expect(card.locator('.ent-hc-body .hc-meta')).toContainText('·'); // время · дистанция · длительность
+});

--- a/web/src/pages/hc/[game]/[ver]/[lang].json.ts
+++ b/web/src/pages/hc/[game]/[ver]/[lang].json.ts
@@ -1,12 +1,15 @@
 import type { APIRoute } from 'astro';
-import { loadEntities, VERSION_SLUG } from '../../../../lib/entities';
+import { loadEntities, excerpt, VERSION_SLUG } from '../../../../lib/entities';
+
+// Hovercard-данные для автоссылок (issue #20, вариант B: fetch-on-hover served JSON).
+// Бакет `game/verKey/lang` → карта `resource/slug` → { name, name_en, effect(HTML), href }.
+// Ключ бакета = префикс `data-hc` из rehype-entity-autolink. Клиент рендерит name_en + источник
+// + effect(HTML). Собираем только там, где реально существуют страницы сущностей.
 
 const escapeHtml = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
-// Эффект состояния → компактный форматированный HTML для карточки.
-// Выкидываем вводную «Пока вы находитесь в состоянии …» / «While you have the … condition» —
-// имя состояния уже в заголовке карточки. Жирные ярлыки подэффектов сохраняем.
-function effectHtml(md: string | undefined): string {
+// ── Состояния: эффект → компактный HTML (вводная «Пока вы находитесь…» выкинута, ярлыки жирным).
+function conditionHtml(md: string | undefined): string {
   if (!md) return '';
   const blocks = md.split(/\n{2,}/).map((b) => b.trim()).filter(Boolean);
   const isIntro = (b: string) => /^(Пока вы находитесь в состоянии|While you have the .* condition)/.test(b);
@@ -14,7 +17,7 @@ function effectHtml(md: string | undefined): string {
   return body
     .map((b) => {
       const html = escapeHtml(b)
-        .replace(/\*\*_([^*]+?)_\*\*/g, '<strong>$1</strong>') // bold-italic ярлык
+        .replace(/\*\*_([^*]+?)_\*\*/g, '<strong>$1</strong>')
         .replace(/\*\*([^*]+?)\*\*/g, '<strong>$1</strong>')
         .replace(/(?<![\w*])_([^_]+?)_(?![\w*])/g, '<em>$1</em>')
         .replace(/(?<![\w*])\*([^*]+?)\*(?![\w*])/g, '<em>$1</em>');
@@ -23,14 +26,46 @@ function effectHtml(md: string | undefined): string {
     .join('');
 }
 
-// Hovercard-данные для автоссылок (issue #20, вариант B: fetch-on-hover served JSON).
-// На каждый бакет `game/verKey/lang` отдаём карту `resource/slug` → { name, name_en, excerpt, href }.
-// Ключ бакета совпадает с префиксом `data-hc` из rehype-entity-autolink (game/verKey/lang/...).
-// Бакеты собираем только там, где реально существуют страницы сущностей (см. [slug].astro).
+// ── Заклинания: школа в RU JSON переведена наполовину — нормализуем двусторонним мапом.
+const SCHOOLS: [string, string][] = [
+  ['Abjuration', 'Ограждения'], ['Conjuration', 'Вызова'], ['Divination', 'Прорицания'],
+  ['Enchantment', 'Очарования'], ['Evocation', 'Воплощения'], ['Illusion', 'Иллюзии'],
+  ['Necromancy', 'Некромантии'], ['Transmutation', 'Преобразования'],
+];
+const schoolLabel = (raw: string, lang: string) => {
+  const p = SCHOOLS.find(([en, ru]) => en === raw || ru === raw);
+  return p ? (lang === 'ru' ? p[1] : p[0]) : raw;
+};
+const ordinalEn = (n: string) => {
+  const s = ['th', 'st', 'nd', 'rd'], v = Number(n) % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
+};
 
-const RESOURCES = [{ key: 'conditions', urlParent: 'rules-glossary/conditions' }];
+// Карточка заклинания: «уровень, школа» + компактная мета (время · дистанция · длительность)
+// + короткая выдержка описания.
+function spellHtml(e: Record<string, unknown>, lang: string): string {
+  const lvl = String(e.level ?? '');
+  const school = schoolLabel(e.school as string, lang);
+  const levelLine = lvl === '0'
+    ? (lang === 'ru' ? `Заговор, ${school}` : `${school} cantrip`)
+    : (lang === 'ru' ? `${lvl}-й уровень, ${school}` : `${ordinalEn(lvl)}-level ${school}`);
+  const val = (o: unknown) => (o as Record<string, unknown> | undefined)?.value as string | undefined;
+  const meta = [val(e.casting_time), val(e.range), val(e.duration)].filter(Boolean).join(' · ');
+  const ex = excerpt(e.description_md as string | undefined, 190);
+  return (
+    `<p class="hc-sub">${escapeHtml(levelLine)}</p>` +
+    (meta ? `<p class="hc-meta">${escapeHtml(meta)}</p>` : '') +
+    (ex ? `<p>${escapeHtml(ex)}</p>` : '')
+  );
+}
 
-// Согласовано со сборкой страниц состояний: пока только srd52 (en/ru).
+// resource → { urlParent, build(entity) → HTML тела карточки }.
+const RESOURCES: { key: string; urlParent: string; body: (e: Record<string, unknown>, lang: string) => string }[] = [
+  { key: 'conditions', urlParent: 'rules-glossary/conditions', body: (e) => conditionHtml(e.description_md as string) },
+  { key: 'spells', urlParent: 'spells', body: (e, lang) => spellHtml(e, lang) },
+];
+
+// Согласовано со сборкой страниц сущностей: пока только srd52 (en/ru).
 const BUILDS = [
   { game: 'dnd', ver: 'srd52', lang: 'en' },
   { game: 'dnd', ver: 'srd52', lang: 'ru' },
@@ -44,12 +79,12 @@ export const GET: APIRoute = ({ params }) => {
   const { ver, lang, game } = params as { game: string; ver: string; lang: string };
   const verSlug = VERSION_SLUG[ver];
   const map: Record<string, { name: string; name_en: string | null; effect: string; href: string }> = {};
-  for (const { key, urlParent } of RESOURCES) {
+  for (const { key, urlParent, body } of RESOURCES) {
     for (const e of loadEntities(ver, lang, key)) {
       map[`${key}/${e.slug}`] = {
         name: e.name,
         name_en: (e.name_en as string) ?? null,
-        effect: effectHtml(e.description_md as string | undefined),
+        effect: body(e as unknown as Record<string, unknown>, lang),
         href: `/${lang}/${game}/${verSlug}/${urlParent}/${e.slug}/`,
       };
     }

--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -219,6 +219,9 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 .ent-hc-body p:last-child { margin-bottom: 0; }
 .ent-hc-body strong { color: var(--og-text); font-weight: 600; }
 .ent-hc-body em { font-style: italic; }
+/* Карточка заклинания: подзаголовок «уровень, школа» + компактная мета (время·дистанция·длительность). */
+.ent-hc-body .hc-sub { font-style: italic; color: var(--og-text-muted); }
+.ent-hc-body .hc-meta { font-family: var(--font-mono); font-size: 11.5px; letter-spacing: 0.2px; color: var(--og-text-2); }
 @media (prefers-reduced-motion: reduce) { .ent-hovercard { transition: opacity 0.12s ease, visibility 0s linear 0.12s; transform: none; } }
 
 /* Таблицы: Astro рендерит <table>; оборачиваем в .rd-doc для скролла на узких экранах */


### PR DESCRIPTION
Карточки заклинаний при наведении на спелл-автоссылки (задел `data-hc` уже стоял из Slice B).

## Что показывает
Шапка: **EN-имя** + **SRD 5.2.1**. Тело: «уровень, школа» + компактная мета (**время · дистанция · длительность**) + короткая выдержка описания. В едином стиле с карточками состояний.

## Реализация
- `/hc`-эндпоинт: 339 карточек заклинаний рядом с 15 состояниями. `RESOURCES` с per-resource билдером тела карточки; школа нормализована (в JSON вперемешку EN/RU).
- Клиент **без изменений** — рендерит `name_en` + источник + `effect`-HTML (эндпоинт строит тело под тип сущности).
- `reader.css`: `.hc-sub` (уровень/школа), `.hc-meta` (мета).

## Проверки
- 33/33 e2e (новый тест карточки заклинания: Cure Wounds → EN-имя, источник, «уровень», мета).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP