### PR TITLE
feat(rules): автолинки на монстров в тексте (issue #20)

### DIFF
--- a/web/e2e/autolink.spec.ts
+++ b/web/e2e/autolink.spec.ts
@@ -9,9 +9,9 @@ test('глава: автоссылки ведут на страницы сущн
   await page.goto(CHAPTER);
   const links = page.locator('.rd-doc a.ent-link');
   expect(await links.count()).toBeGreaterThan(0);
-  // Все ent-link ведут на программную страницу сущности: состояние или заклинание.
+  // Все ent-link ведут на программную страницу сущности: состояние / заклинание / монстр.
   for (const href of await links.evaluateAll((els) => els.map((e) => e.getAttribute('href')))) {
-    expect(href).toMatch(/\/(rules-glossary\/conditions|spells)\/[a-z-]+\/$/);
+    expect(href).toMatch(/\/(rules-glossary\/conditions|spells|monsters-a-z)\/[a-z-]+\/$/);
   }
 });
 
@@ -25,6 +25,20 @@ test('заклинания: имена в спелл-таблицах класс
   await expect(page.locator('.rd-doc em a.ent-link[href*="/spells/"]').first()).toBeVisible();
   // обычное слово (не курсив, не в спелл-таблице) НЕ линкуется: «свет» строчным в прозе
   await expect(page.locator('.rd-doc a.ent-link', { hasText: /^свет$/ })).toHaveCount(0);
+});
+
+test('монстры: имя в жирном линкуется на страницу монстра; генеричное слово в прозе — нет', async ({ page }) => {
+  // Animate Dead: «becomes an Undead creature: a **Skeleton** … or a **Zombie**» — жирный = ссылка
+  // на статблок (сигнал SRD «see Monsters»).
+  await page.goto('/en/dnd/srd-5.2/spells/animate-dead/');
+  await expect(
+    page.locator('.rd-doc strong a.ent-link[href$="/monsters-a-z/skeleton/"]'),
+  ).toBeVisible();
+  await expect(
+    page.locator('.rd-doc strong a.ent-link[href$="/monsters-a-z/zombie/"]'),
+  ).toBeVisible();
+  // «Undead», «creature», «Humanoid» в прозе (не жирные имена монстров) НЕ линкуются на монстров.
+  await expect(page.locator('.rd-doc a.ent-link[href*="/monsters-a-z/humanoid/"]')).toHaveCount(0);
 });
 
 test('автолинк не попадает в заголовки и не вкладывается в другие ссылки', async ({ page }) => {
@@ -58,7 +72,7 @@ test('страница состояния: тело линкует другие 
 test('автоссылка несёт data-hc для будущего hovercard', async ({ page }) => {
   await page.goto(CHAPTER);
   const first = page.locator('.rd-doc a.ent-link').first();
-  await expect(first).toHaveAttribute('data-hc', /^dnd\/srd52\/en\/(conditions|spells)\//);
+  await expect(first).toHaveAttribute('data-hc', /^dnd\/srd52\/en\/(conditions|spells|monsters)\//);
 });
 
 // Паритет EN/RU: страницы одной главы — зеркальный перевод, значит НАБОР слинкованных состояний

--- a/web/e2e/hovercard.spec.ts
+++ b/web/e2e/hovercard.spec.ts
@@ -61,6 +61,18 @@ test('карточка скрывается, когда курсор уходи�
   await expect(page.locator('#ent-hovercard')).toBeHidden();
 });
 
+test('карточка монстра: источник, строка типа + мета (КД · хиты · ПО)', async ({ page }) => {
+  await page.goto('/en/dnd/srd-5.2/spells/animate-dead/');
+  const mon = page.locator('.rd-doc strong a.ent-link[href$="/monsters-a-z/skeleton/"]').first();
+  await mon.scrollIntoViewIfNeeded();
+  await mon.hover();
+  const card = page.locator('#ent-hovercard');
+  await expect(card).toBeVisible();
+  await expect(card.locator('.ent-hc-src')).toHaveText('SRD 5.2.1');
+  await expect(card.locator('.ent-hc-body .hc-sub')).toContainText('Undead'); // строка типа
+  await expect(card.locator('.ent-hc-body .hc-meta')).toContainText('CR'); // КД · хиты · ПО
+});
+
 test('карточка заклинания: EN-имя, источник, «уровень, школа» + мета', async ({ page }) => {
   await page.goto('/ru/dnd/srd-5.2/classes/cleric/');
   const spell = page.locator('.rd-doc td a.ent-link[href*="/spells/"]', { hasText: 'Лечение ран' }).first();

--- a/web/src/lib/rehype-entity-autolink.mjs
+++ b/web/src/lib/rehype-entity-autolink.mjs
@@ -4,9 +4,11 @@
 // Два режима матчинга (по ресурсу):
 //  • text  — состояния: plain-текст, case-sensitive keyword с границами слова (SRD капитализирует
 //    имена состояний; строчное «prone» не ловим). Синонимы-краткие формы — в ALIASES.
-//  • exact — заклинания: линкуем ТОЛЬКО там, где SRD сам разметил ссылку — курсив `<em>Свет</em>`
-//    (полный текст = имя) ИЛИ первая колонка таблиц спелл-листов классов. Слово «свет» в прозе
-//    не трогаем — только явные курсивные упоминания. Так снимается переусердствование.
+//  • exact — заклинания/монстры: линкуем ТОЛЬКО там, где SRD сам разметил ссылку. Контейнер
+//    задаётся ресурсом: заклинания — курсив `<em>Свет</em>` (полный текст = имя) ИЛИ первая
+//    колонка спелл-таблиц классов; монстры — жирный `<strong>Скелет</strong>` (сигнал SRD
+//    «см. Монстры»). Строчное «свет» / генеричное «Стражник» в прозе не трогаем — только
+//    явную разметку. Так снимается переусердствование.
 //
 // Не трогаем текст внутри <a>/<code>/<pre>/<kbd> и заголовков <h1>…<h6>.
 import fs from 'node:fs';
@@ -16,11 +18,13 @@ import path from 'node:path';
 // (страницы сущностей). import.meta.url под Vite указывает не туда.
 const DATA_ROOT = path.resolve(process.cwd(), 'src/data/api');
 
-// Ресурсы с программными страницами. mode: 'text' | 'exact'. versions — ограничение по версиям
-// (где реально есть страницы); без него — все версии.
+// Ресурсы с программными страницами. mode: 'text' | 'exact'. container (для exact) — тег-обёртка
+// разметки-сигнала SRD: 'em' (курсив, заклинания) или 'strong' (жирный, монстры). versions —
+// ограничение по версиям (где реально есть страницы); без него — все версии.
 const RESOURCES = [
   { key: 'conditions', urlParent: 'rules-glossary/conditions', mode: 'text' },
-  { key: 'spells', urlParent: 'spells', mode: 'exact', versions: ['srd-5.2'] },
+  { key: 'spells', urlParent: 'spells', mode: 'exact', container: 'em', versions: ['srd-5.2'] },
+  { key: 'monsters', urlParent: 'monsters-a-z', mode: 'exact', container: 'strong', versions: ['srd-5.2'] },
 ];
 
 // Заголовок первой колонки таблицы спелл-листа класса (по языку) — сигнал линковать её ячейки.
@@ -49,8 +53,10 @@ function loadMap(game, version, lang) {
   const verKey = verKeyOf(version);
   const aliases = ALIASES[`${game}/${lang}`] || {};
   const textEntries = [];
-  const exact = new Map();
-  for (const { key, urlParent, mode, versions } of RESOURCES) {
+  // exact-карты по контейнеру: em (заклинания) и strong (монстры) — держим раздельно, чтобы
+  // имя монстра в курсиве / имя заклинания в жирном не матчились не в своём контексте.
+  const exact = { em: new Map(), strong: new Map() };
+  for (const { key, urlParent, mode, container, versions } of RESOURCES) {
     if (versions && !versions.includes(version)) continue;
     const file = path.join(DATA_ROOT, game, verKey, lang, key, 'all.json');
     let data;
@@ -63,11 +69,12 @@ function loadMap(game, version, lang) {
       if (!e || !e.name || !e.slug) continue;
       const entry = { name: e.name, slug: e.slug, resource: key, urlParent };
       if (mode === 'exact') {
-        // Ключ в lowercase: SRD размечает курсивом ссылки на заклинания и СТРОЧНЫМИ
-        // («*лечение ран*»), и с заглавной («*Благословение*») — ловим оба. Внутри <em>/ячейки
-        // спелл-таблицы полное совпадение фразы с именем безопасно и без учёта регистра.
+        // Ключ в lowercase: SRD размечает ссылки и СТРОЧНЫМИ («*лечение ран*»), и с заглавной
+        // («*Благословение*», «**Скелет**») — ловим оба. Внутри разметки-контейнера полное
+        // совпадение фразы с именем безопасно и без учёта регистра.
+        const m = exact[container];
         const k = e.name.toLowerCase();
-        if (!exact.has(k)) exact.set(k, entry);
+        if (m && !m.has(k)) m.set(k, entry);
       } else {
         textEntries.push(entry);
         for (const alias of aliases[e.slug] || []) textEntries.push({ ...entry, name: alias });
@@ -82,7 +89,7 @@ function loadMap(game, version, lang) {
     const alt = textEntries.map((e) => escapeRegExp(e.name)).join('|');
     text = { regexSource: `(?<![\\p{L}\\p{N}_])(${alt})(?![\\p{L}\\p{N}_])`, byName };
   }
-  const result = text || exact.size ? { text, exact, verKey } : null;
+  const result = text || exact.em.size || exact.strong.size ? { text, exact, verKey } : null;
   mapCache.set(cacheKey, result);
   return result;
 }
@@ -146,10 +153,10 @@ export function autolinkTree(tree, { game, version, lang, selfSlug }) {
   if (selfSlug) skip.add(selfSlug);
   const ctx = { game, lang, verSlug: version, verKey: map.verKey };
 
-  const exactEntry = (rawText) => {
+  const exactEntry = (rawText, container) => {
     if (rawText == null) return null;
     const t = rawText.trim();
-    const entry = map.exact.get(t.toLowerCase()); // регистро-независимо (текст ссылки — как в оригинале)
+    const entry = map.exact[container].get(t.toLowerCase()); // регистро-независимо (текст ссылки — как в оригинале)
     return entry && !skip.has(entry.slug) ? { entry, text: t } : null;
   };
 
@@ -168,7 +175,7 @@ export function autolinkTree(tree, { game, version, lang, selfSlug }) {
     for (const tr of rows) {
       const cell = tr.children.find((c) => c.type === 'element' && c.tagName === 'td'); // только данные (не th)
       if (!cell) continue;
-      const hit = exactEntry(directText(cell));
+      const hit = exactEntry(directText(cell), 'em');
       if (hit) cell.children = [linkNode(hit.entry, hit.text, ctx)];
     }
   };
@@ -180,13 +187,17 @@ export function autolinkTree(tree, { game, version, lang, selfSlug }) {
       if (child.type === 'element') {
         const tag = child.tagName;
         // Спелл-таблица класса: линкуем первую колонку (данные), затем обычный обход остального.
-        if (tag === 'table' && map.exact.size && isSpellTable(child)) linkSpellTable(child);
-        // Курсивная ссылка на заклинание: <em>Имя</em> целиком.
-        if (tag === 'em' && !insideSkip && map.exact.size) {
-          const hit = exactEntry(directText(child));
-          if (hit) {
-            child.children = [linkNode(hit.entry, hit.text, ctx)];
-            continue; // уже ссылка — внутрь не идём
+        if (tag === 'table' && map.exact.em.size && isSpellTable(child)) linkSpellTable(child);
+        // Курсивная ссылка на заклинание <em>Имя</em> / жирная на монстра <strong>Имя</strong> —
+        // полный текст элемента = имя. Внутрь уже-ссылки не идём.
+        if (!insideSkip && (tag === 'em' || tag === 'strong')) {
+          const container = tag === 'em' ? 'em' : 'strong';
+          if (map.exact[container].size) {
+            const hit = exactEntry(directText(child), container);
+            if (hit) {
+              child.children = [linkNode(hit.entry, hit.text, ctx)];
+              continue;
+            }
           }
         }
         walk(child, insideSkip || SKIP_TAGS.has(tag));

--- a/web/src/pages/hc/[game]/[ver]/[lang].json.ts
+++ b/web/src/pages/hc/[game]/[ver]/[lang].json.ts
@@ -59,10 +59,35 @@ function spellHtml(e: Record<string, unknown>, lang: string): string {
   );
 }
 
+// Карточка монстра: строка типа (размер тип, мировоззрение) + компактная мета (КД · хиты · ПО).
+function monsterHtml(e: Record<string, unknown>, lang: string): string {
+  const size = (e.size as string) ?? '';
+  const type = (e.type as string) ?? '';
+  const subtype = e.subtype as string | null;
+  const alignment = e.alignment as string | null;
+  const typeLine = [
+    [size, type].filter(Boolean).join(' ') + (subtype ? ` (${subtype})` : ''),
+    alignment,
+  ].filter(Boolean).join(', ');
+  const ac = (e.ac as { value?: number })?.value;
+  const hp = (e.hp as { average?: number })?.average;
+  const cr = (e.cr as { value?: string })?.value;
+  const meta = [
+    ac != null ? `${lang === 'ru' ? 'КД' : 'AC'} ${ac}` : '',
+    hp != null ? (lang === 'ru' ? `${hp} хитов` : `${hp} HP`) : '',
+    cr ? `${lang === 'ru' ? 'ПО' : 'CR'} ${cr}` : '',
+  ].filter(Boolean).join(' · ');
+  return (
+    (typeLine ? `<p class="hc-sub">${escapeHtml(typeLine)}</p>` : '') +
+    (meta ? `<p class="hc-meta">${escapeHtml(meta)}</p>` : '')
+  );
+}
+
 // resource → { urlParent, build(entity) → HTML тела карточки }.
 const RESOURCES: { key: string; urlParent: string; body: (e: Record<string, unknown>, lang: string) => string }[] = [
   { key: 'conditions', urlParent: 'rules-glossary/conditions', body: (e) => conditionHtml(e.description_md as string) },
   { key: 'spells', urlParent: 'spells', body: (e, lang) => spellHtml(e, lang) },
+  { key: 'monsters', urlParent: 'monsters-a-z', body: (e, lang) => monsterHtml(e, lang) },
 ];
 
 // Согласовано со сборкой страниц сущностей: пока только srd52 (en/ru).


### PR DESCRIPTION
## Что

Имена монстров в тексте становятся ссылками на страницы бестиария — **только там, где SRD сам разметил ссылку на статблок жирным** («**Skeleton**», «summon a **Fire Elemental**», «has the statistics of a **Roc**»). Это сигнал SRD «see Monsters», аналог курсива у заклинаний.

Генеричные слова (**Guard, Mage, Shadow, Druid, Knight, Noble, Priest…**), которых полно в прозе, **не трогаем** — они не выделены жирным → **0 переусердствования**.

## Проверка фактического dist (перепроверены ВСЕ места)

| | Ссылок | Монстров | Ложных |
|---|---|---|---|
| **EN** | 30 | 22 | **0** |
| **RU** | 8 | 7 | **0** |

Каждая EN-ссылка — реальный жирный ref: Skeleton/Zombie (*Animate Dead*, *Finger of Death*, *Create Undead*), Awakened Shrub/Tree (*Awaken*), Air/Earth/Fire/Water Elemental / Berserker / Bulette / Djinni / Efreeti / Griffon / Knight / Nightmare / Roc / Treant (маг. предметы), Bugbear Warrior / Ogre / Warhorse Skeleton / Wight (encounter-примеры toolbox).

⚠️ **EN/RU асимметрия:** RU-перевод у большинства упоминаний **сбросил жирный** и склонял имена («…становится существом-нежитью: **скелетом**…» вместо «**Скелет**»), сохранив разметку лишь в 7 местах. Это не баг линкера — консистентность перевода; чинится правкой RU-markdown отдельной задачей (см. ниже).

## Механизм
- У exact-ресурсов появился `container`: `em` (заклинания) / `strong` (монстры); раздельные exact-карты, чтобы имя монстра в курсиве / заклинания в жирном не матчились вне своего контекста.
- Bold-italic имена трейтов (`**_Имя._**`) не задеваются.
- Карточки монстров добавлены в `/hc` (тип · КД · хиты · ПО) — hovercard работает.

## Осталось / следующая задача
Пропагация жирного на RU-упоминания монстров (terminology-consistency), чтобы RU-покрытие догнало EN. Инфлекция («скелетом») — отдельный нюанс.

## Проверка
`astro check` — 0 ошибок · e2e 40 passed (новые: жирный→ссылка + генеричное не линкуется, карточка монстра) · паритет состояний EN/RU не затронут.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP