### PR TITLE
feat(rules): страницы магических предметов (issue #20)

### DIFF
--- a/.github/scripts/parsers/base.py
+++ b/.github/scripts/parsers/base.py
@@ -28,12 +28,16 @@ def extract_names(heading: str, lang: str) -> tuple[str, str | None, str]:
     EN headings: "Magic Missile" → name, None, slug
     """
     if lang != "en":
-        # RU headings: extract EN name from parentheses (Latin characters)
-        m = re.match(r"^(.+?)\s*\(([A-Za-z][\w\s,'+\-:]*)\)\s*$", heading)
+        # RU headings: extract EN name from parentheses (Latin characters). EN-имя может само
+        # содержать вложенную скобку — «Камень удачи (Камень везения) (Stone of Good Luck
+        # (Luckstone))»: жадный первый захват + один уровень вложенности во внутренней группе.
+        m = re.match(r"^(.+)\s*\(([A-Za-z][^()]*(?:\([^()]*\)[^()]*)*)\)\s*$", heading)
         if m:
             name_local = m.group(1).strip()
             name_en = m.group(2).strip()
-            return name_local, name_en, slugify(name_en)
+            # Слаг — как в EN-ветке: без хвостовой «(...)», чтобы EN/RU слаги совпали (hreflang).
+            slug_base = re.sub(r"\s*\([^)]*\)\s*$", "", name_en).strip()
+            return name_local, name_en, slugify(slug_base)
     # EN headings or RU without parentheses: use full heading as name
     # Strip parenthetical suffixes for slug (e.g., "Young Red Dragon (Chromatic)")
     full_name = heading.strip()

--- a/web/e2e/autolink.spec.ts
+++ b/web/e2e/autolink.spec.ts
@@ -136,9 +136,10 @@ test('EN/RU: набор слинкованных состояний совпад
         !p.includes('/glossary/') && // справочные таблицы вне индекса
         !p.includes('/rules-glossary/conditions/') && // сами страницы состояний, не главы
         !/\/spells\/[^/]+\/$/.test(p) && // страницы отдельных заклинаний (не глава /spells/):
-        !/\/monsters-a-z\/[^/]+\/$/.test(p), // и отдельных монстров (не глава /monsters-a-z/):
+        !/\/monsters-a-z\/[^/]+\/$/.test(p) && // отдельных монстров (не глава /monsters-a-z/):
+        !/\/magic-items\/[^/]+\/$/.test(p), // и отдельных предметов (не глава /magic-items/):
         // их описания переведены независимо → паритет линковки состояний тут не гарантирован
-        // (главы /spells/ и /monsters-a-z/ остаются в наборе).
+        // (главы /spells/, /monsters-a-z/, /magic-items/ остаются в наборе).
     );
   expect(chapters.length).toBeGreaterThan(10);
 

--- a/web/e2e/magic-items.spec.ts
+++ b/web/e2e/magic-items.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+// Программные страницы магических предметов (issue #20, волна 3):
+// /{lang}/dnd/{ver}/magic-items/{slug}/. Стат-блок (тип/редкость/настройка), автоссылки в теле,
+// related «тот же тип», SEO (hreflang, sitemap), фикс канонического слага для вложенных скобок.
+
+test('страница предмета: заголовок, EN-имя, тип·редкость, стат-блок', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/magic-items/dwarven-thrower/');
+  await expect(page.locator('.rd-doc h1')).toContainText('Дварфийский метатель');
+  await expect(page.locator('.ent-en')).toHaveText('Dwarven Thrower');
+  await expect(page.locator('.item-meta-line')).toContainText('очень редкий'); // редкость локализована
+  const stat = page.locator('.item-stat');
+  await expect(stat).toContainText('Тип');
+  await expect(stat).toContainText('Редкость');
+  // настройка с условием
+  await expect(stat.locator('.item-row', { hasText: 'Настройка' })).toContainText('требуется');
+  await expect(stat.locator('.item-row', { hasText: 'Настройка' })).toContainText('Пояс силы великанов');
+});
+
+test('related: другие предметы того же типа', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/magic-items/dwarven-thrower/');
+  const rel = page.locator('.ent-related');
+  await expect(rel).toContainText('Оружие');
+  await expect(rel.locator('a[href*="/magic-items/"]').first()).toBeVisible();
+});
+
+test('канонический слаг для вложенных скобок (Stone of Good Luck) — EN и RU совпадают', async ({ page }) => {
+  // RU-заголовок «Камень удачи (Камень везения) (Stone of Good Luck (Luckstone))» — вложенная
+  // скобка ломала извлечение EN-имени; фикс сводит слаг к канону «stone-of-good-luck» на обоих языках.
+  for (const lang of ['en', 'ru']) {
+    const res = await page.goto(`/${lang}/dnd/srd-5.2/magic-items/stone-of-good-luck/`);
+    expect(res?.status(), `${lang} страница существует`).toBe(200);
+  }
+  await expect(page.locator('link[rel="alternate"][hreflang="en"]')).toHaveCount(1);
+  await expect(page.locator('link[rel="alternate"][hreflang="ru"]')).toHaveCount(1);
+});
+
+test('SEO: hreflang-тройка, индексируема, в sitemap', async ({ page, request }) => {
+  const res = await page.goto('/en/dnd/srd-5.2/magic-items/bag-of-holding/');
+  expect(res?.status()).toBe(200);
+  await expect(page.locator('link[rel="alternate"][hreflang="en"]')).toHaveCount(1);
+  await expect(page.locator('link[rel="alternate"][hreflang="ru"]')).toHaveCount(1);
+  await expect(page.locator('link[rel="alternate"][hreflang="x-default"]')).toHaveCount(1);
+  await expect(page.locator('meta[name="robots"][content*="noindex"]')).toHaveCount(0);
+  const sm = await (await request.get('/sitemap-0.xml')).text();
+  expect(sm).toContain('/dnd/srd-5.2/magic-items/bag-of-holding/');
+});

--- a/web/src/pages/[lang]/dnd/[version]/magic-items/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/magic-items/[slug].astro
@@ -1,0 +1,162 @@
+---
+import { marked } from 'marked';
+import { fromHtml } from 'hast-util-from-html';
+import { toHtml } from 'hast-util-to-html';
+import ReaderShell from '../../../../../components/ReaderShell.astro';
+import { autolinkTree } from '../../../../../lib/rehype-entity-autolink.mjs';
+import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
+
+// Programmatic-страницы магических предметов (issue #20, волна 3) в общем шелле ридера.
+// URL: /{lang}/dnd/{version}/magic-items/{slug}/. EN и RU делят канонический (англ.) слаг → hreflang.
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-magicitems' };
+
+// Редкость: в данных ключ по-английски (обе локали) — нормализуем двусторонним мапом.
+const RARITY: Record<string, [string, string]> = {
+  common: ['обычный', 'common'], uncommon: ['необычный', 'uncommon'], rare: ['редкий', 'rare'],
+  'very rare': ['очень редкий', 'very rare'], legendary: ['легендарный', 'legendary'],
+  artifact: ['артефакт', 'artifact'],
+};
+
+interface Sib { slug: string; name: string; type: string; rarity: string }
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as const },
+    { ver: 'srd52', lang: 'ru' as const },
+  ];
+  const paths = [];
+  for (const { ver, lang } of BUILDS) {
+    const items = loadEntities(ver, lang, 'magic-items');
+    const siblings: Sib[] = items.map((m) => ({
+      slug: m.slug, name: m.name,
+      type: (m.type as string) ?? '', rarity: (m.rarity as string) ?? '',
+    }));
+    for (const entity of items) {
+      paths.push({
+        params: { lang, version: VERSION_SLUG[ver], slug: entity.slug },
+        props: { entity, ver, lang, siblings },
+      });
+    }
+  }
+  return paths;
+}
+
+const { entity, ver, lang, siblings } = Astro.props;
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+
+// Тело с автоссылками на состояния/заклинания/монстров (issue #20): marked → hast → autolink → html.
+const render = (md: string | undefined | null) => {
+  if (!md || md === 'None') return '';
+  const tree = fromHtml(marked.parse(md, { async: false }), { fragment: true });
+  autolinkTree(tree, { game: 'dnd', version: verSlug, lang, selfSlug: entity.slug });
+  return toHtml(tree);
+};
+const bodyHtml = render(entity.description_md as string);
+const description = excerpt(entity.description_md as string);
+
+const itemType = (entity.type as string) ?? '';
+const rawRarity = (entity.rarity as string) ?? '';
+const rarityPair = RARITY[rawRarity];
+const rarityLabel = rarityPair ? (lang === 'ru' ? rarityPair[0] : rarityPair[1]) : rawRarity;
+const attune = (entity.attunement ?? {}) as { required?: boolean; condition?: string | null };
+const attuneLabel = attune.required
+  ? t('требует настройки', 'requires attunement') + (attune.condition ? ` (${attune.condition})` : '')
+  : '';
+// Подстрока в шапке: тип · редкость.
+const subParts = [itemType, rarityLabel].filter(Boolean);
+
+const base = `/${lang}/dnd/${verSlug}/magic-items`;
+// «Похожие предметы» — до 8 того же типа (внутренняя перелинковка/SEO).
+const sameType = (siblings as Sib[])
+  .filter((s) => s.slug !== entity.slug && s.type === itemType)
+  .slice(0, 8);
+
+const upLink = { href: `${base}/`, ru: 'Магические предметы', en: 'Magic Items' };
+const kind = t('Магический предмет', 'Magic Item');
+const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel} ${kind}`)} · OmnisGM Rules`;
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={entity.name}
+  description={description}
+  headings={[]}
+  upLink={upLink}
+>
+  <h1>
+    {entity.name}
+    <span class="ent-head-sub">
+      {lang === 'ru' && entity.name_en && <span class="ent-en">{entity.name_en}</span>}
+      {subParts.length > 0 && <span class="item-meta-line">{subParts.join(', ')}</span>}
+    </span>
+  </h1>
+
+  <dl class="item-stat">
+    {itemType && (
+      <div class="item-row"><dt>{t('Тип', 'Type')}</dt><dd>{itemType}</dd></div>
+    )}
+    {rarityLabel && (
+      <div class="item-row"><dt>{t('Редкость', 'Rarity')}</dt><dd>{rarityLabel}</dd></div>
+    )}
+    {attune.required && (
+      <div class="item-row"><dt>{t('Настройка', 'Attunement')}</dt>
+        <dd>{t('требуется', 'required')}{attune.condition ? ` (${attune.condition})` : ''}</dd></div>
+    )}
+  </dl>
+
+  <Fragment set:html={bodyHtml} />
+
+  {sameType.length > 0 && (
+    <nav class="ent-related" aria-label={t('Похожие предметы', 'Similar items')}>
+      <span class="ent-related-h">{t(`Ещё: ${itemType}`, `More ${itemType}`)}</span>
+      <span class="ent-related-list">
+        {sameType.map((r) => (
+          <a href={`${base}/${r.slug}/`}><strong>{r.name}</strong></a>
+        ))}
+      </span>
+    </nav>
+  )}
+</ReaderShell>
+
+<style>
+  /* Подстрока в шапке: EN-имя + тип/редкость. */
+  .ent-head-sub {
+    display: block; margin-top: 8px;
+    font-family: var(--font-body); font-weight: 400; letter-spacing: 0;
+  }
+  .ent-en {
+    font-family: var(--font-mono); font-size: 14px; font-weight: 400; letter-spacing: 0;
+    color: var(--og-text-muted);
+  }
+  .item-meta-line { font-style: italic; font-size: 14px; color: var(--og-text-muted); }
+  .ent-en + .item-meta-line::before { content: ' · '; font-style: normal; }
+
+  .item-stat {
+    margin: 0 0 24px; padding: 14px 16px; border: 1px solid var(--og-border); border-radius: 10px;
+    background: var(--og-bg-2); display: grid; gap: 8px;
+  }
+  .item-row { display: grid; grid-template-columns: 160px 1fr; gap: 12px; align-items: baseline; }
+  .item-row dt {
+    font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.6px; text-transform: uppercase;
+    color: var(--og-text-muted); font-weight: 600;
+  }
+  .item-row dd { margin: 0; color: var(--og-text-2); }
+
+  .ent-related { display: block; margin-top: 40px; padding-top: 20px; border-top: 1px solid var(--og-border); }
+  .ent-related-h {
+    display: block; font-size: 13px; text-transform: uppercase; letter-spacing: 1px;
+    color: var(--og-text-muted); margin-bottom: 10px;
+  }
+  .ent-related-list { display: flex; flex-wrap: wrap; gap: 6px 14px; }
+
+  @media (max-width: 560px) {
+    .item-row { display: block; }
+    .item-row dt { display: inline; }
+    .item-row dt::after { content: ':\00a0'; }
+    .item-row dd { display: inline; }
+  }
+</style>


### PR DESCRIPTION
## Что

Programmatic-страницы `/{lang}/dnd/srd-5.2/magic-items/{slug}/` — **258 предметов × EN/RU = 516 страниц** в общем шелле ридера (по образцу заклинаний/монстров).

- Стат-блок: **тип · редкость** (локализована) · **настройка** (+ условие, напр. «требуется (дварфом или существом, настроенным на Пояс силы великанов)»)
- Тело описания → autolink (состояния/заклинания/монстры кликаются + hovercard)
- EN-имя в шапке (RU), related «тот же тип», hreflang EN/RU, sitemap

## Фикс парсера (влияет на весь `/api`)

EN-имя во **вложенных скобках** — «Камень удачи (Камень везения) (Stone of Good Luck (Luckstone))» — ломало извлечение → RU-слаг был кириллической кашей `камень-удачи-...-luckstone`, hreflang рвался.

→ `extract_names` теперь допускает один уровень вложенности и сводит слаг к канону (без хвостовой «(...)») на обоих языках. **Слаг-паритет magic-items: 257 → 258/258.** Регрессий по spells/monsters/conditions нет.

## Проверка
`astro check` 0 ошибок · e2e 46 passed (новый `magic-items.spec.ts`: стат-блок с настройкой-условием, фикс слага Stone of Good Luck EN=RU, related, SEO) · визуальные снапшоты целы.

## Дальше по волне 3
- Автолинки предметов в тексте (курсив «*Зелье лечения*» — но коллизия с заклинаниями, нужен разбор сигнала).
- Черты (17): RU-заголовки без «(English)» → нужен data-фикс канонических слагов.
- Оружие/броня/снаряжение: табличные, thin — вероятно автолинки в главы, не отдельные страницы.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP