### PR TITLE
feat(rules): автолинки магических предметов в тексте (issue #20)

### DIFF
--- a/web/e2e/autolink.spec.ts
+++ b/web/e2e/autolink.spec.ts
@@ -11,7 +11,7 @@ test('глава: автоссылки ведут на страницы сущн
   expect(await links.count()).toBeGreaterThan(0);
   // Все ent-link ведут на программную страницу сущности: состояние / заклинание / монстр.
   for (const href of await links.evaluateAll((els) => els.map((e) => e.getAttribute('href')))) {
-    expect(href).toMatch(/\/(rules-glossary\/conditions|spells|monsters-a-z)\/[a-z-]+\/$/);
+    expect(href).toMatch(/\/(rules-glossary\/conditions|spells|monsters-a-z|magic-items)\/[a-z0-9-]+\/$/);
   }
 });
 
@@ -61,6 +61,14 @@ test('монстры RU: термин выровнен по бестиарию (
   await expect(page.locator('.rd-doc', { hasText: 'Буллет' })).toHaveCount(0);
 });
 
+test('предметы: имя в курсиве линкуется на страницу предмета', async ({ page }) => {
+  // Глава маг. предметов: предмет↔предмет ссылки — «*Portable Hole*» и т.п. в курсиве.
+  await page.goto('/en/dnd/srd-5.2/magic-items/');
+  const link = page.locator('.rd-doc em a.ent-link[href*="/dnd/srd-5.2/magic-items/"]').first();
+  await expect(link).toBeVisible();
+  await expect(link).toHaveAttribute('data-hc', /^dnd\/srd52\/en\/magic-items\//);
+});
+
 test('автолинк не попадает в заголовки и не вкладывается в другие ссылки', async ({ page }) => {
   await page.goto(CHAPTER);
   await expect(page.locator('.rd-doc :is(h1,h2,h3,h4,h5,h6) a.ent-link')).toHaveCount(0);
@@ -92,7 +100,7 @@ test('страница состояния: тело линкует другие 
 test('автоссылка несёт data-hc для будущего hovercard', async ({ page }) => {
   await page.goto(CHAPTER);
   const first = page.locator('.rd-doc a.ent-link').first();
-  await expect(first).toHaveAttribute('data-hc', /^dnd\/srd52\/en\/(conditions|spells|monsters)\//);
+  await expect(first).toHaveAttribute('data-hc', /^dnd\/srd52\/en\/(conditions|spells|monsters|magic-items)\//);
 });
 
 // Паритет EN/RU: страницы одной главы — зеркальный перевод, значит НАБОР слинкованных состояний

--- a/web/e2e/hovercard.spec.ts
+++ b/web/e2e/hovercard.spec.ts
@@ -61,6 +61,17 @@ test('карточка скрывается, когда курсор уходи�
   await expect(page.locator('#ent-hovercard')).toBeHidden();
 });
 
+test('карточка предмета: источник, тип·редкость + выдержка', async ({ page }) => {
+  await page.goto('/en/dnd/srd-5.2/magic-items/');
+  const item = page.locator('.rd-doc em a.ent-link[href*="/magic-items/"][data-hc]').first();
+  await item.scrollIntoViewIfNeeded();
+  await item.hover();
+  const card = page.locator('#ent-hovercard');
+  await expect(card).toBeVisible();
+  await expect(card.locator('.ent-hc-src')).toHaveText('SRD 5.2.1');
+  await expect(card.locator('.ent-hc-body .hc-sub')).not.toBeEmpty(); // «тип, редкость»
+});
+
 test('карточка монстра: источник, строка типа + мета (КД · хиты · ПО)', async ({ page }) => {
   await page.goto('/en/dnd/srd-5.2/spells/animate-dead/');
   const mon = page.locator('.rd-doc strong a.ent-link[href$="/monsters-a-z/skeleton/"]').first();

--- a/web/src/lib/rehype-entity-autolink.mjs
+++ b/web/src/lib/rehype-entity-autolink.mjs
@@ -25,6 +25,9 @@ const RESOURCES = [
   { key: 'conditions', urlParent: 'rules-glossary/conditions', mode: 'text' },
   { key: 'spells', urlParent: 'spells', mode: 'exact', container: 'em', versions: ['srd-5.2'] },
   { key: 'monsters', urlParent: 'monsters-a-z', mode: 'exact', container: 'strong', versions: ['srd-5.2'] },
+  // Предметы — тоже курсив (SRD размечает ссылки на предметы как «*Название*», как заклинания).
+  // Имена предметов и заклинаний не пересекаются → общий em-матч безопасен.
+  { key: 'magic-items', urlParent: 'magic-items', mode: 'exact', container: 'em', versions: ['srd-5.2'] },
 ];
 
 // Заголовок первой колонки таблицы спелл-листа класса (по языку) — сигнал линковать её ячейки.
@@ -54,11 +57,25 @@ const EXACT_ALIASES = {
       'fire-elemental': ['Огненного элементаля'], 'water-elemental': ['Водного элементаля'],
       'awakened-shrub': ['Пробуждённого куста'], 'awakened-tree': ['Пробуждённого дерева'],
     },
+    'magic-items': {
+      'bag-of-holding': ['Сумкой вместимости'], 'bead-of-force': ['Бусин силы'],
+      'dragon-orb': ['Сфера драконов'], 'gloves-of-missile-snaring': ['Перчатку похищения снарядов'],
+      'horn-of-valhalla': ['Рога Валгаллы'], 'oil-of-etherealness': ['Масла эфирности'],
+      'oil-of-slipperiness': ['Маслом скольжения'],
+      'potions-of-healing': ['Зелье лечения'], 'ring-of-djinni-summoning': ['Кольца призыва джинна'],
+      'spell-scroll': ['Свитке заклинания', 'Свитки заклинаний', 'Свитков заклинаний'],
+      'sphere-of-annihilation': ['Сферу уничтожения', 'Сферы уничтожения'],
+      'sun-blade': ['Солнечным клинком'], 'universal-solvent': ['Универсального растворителя'],
+    },
   },
   'dnd/en': {
     monsters: {
       ghoul: ['Ghouls'], ghast: ['Ghasts'], wight: ['Wights'], mummy: ['Mummies'],
       'shrieker-fungus': ['Shrieker Fungi'],
+    },
+    'magic-items': {
+      'bead-of-force': ['Beads of Force'], 'gloves-of-missile-snaring': ['Glove of Missile Snaring'],
+      'ring-of-djinni-summoning': ['Rings of Djinni Summoning'],
     },
   },
 };

--- a/web/src/pages/hc/[game]/[ver]/[lang].json.ts
+++ b/web/src/pages/hc/[game]/[ver]/[lang].json.ts
@@ -83,11 +83,31 @@ function monsterHtml(e: Record<string, unknown>, lang: string): string {
   );
 }
 
+// Карточка предмета: «тип · редкость» + короткая выдержка описания.
+const RARITY: Record<string, [string, string]> = {
+  common: ['обычный', 'common'], uncommon: ['необычный', 'uncommon'], rare: ['редкий', 'rare'],
+  'very rare': ['очень редкий', 'very rare'], legendary: ['легендарный', 'legendary'],
+  artifact: ['артефакт', 'artifact'],
+};
+function itemHtml(e: Record<string, unknown>, lang: string): string {
+  const type = (e.type as string) ?? '';
+  const rawR = (e.rarity as string) ?? '';
+  const rp = RARITY[rawR];
+  const rarity = rp ? (lang === 'ru' ? rp[0] : rp[1]) : rawR;
+  const sub = [type, rarity].filter(Boolean).join(', ');
+  const ex = excerpt(e.description_md as string | undefined, 190);
+  return (
+    (sub ? `<p class="hc-sub">${escapeHtml(sub)}</p>` : '') +
+    (ex ? `<p>${escapeHtml(ex)}</p>` : '')
+  );
+}
+
 // resource → { urlParent, build(entity) → HTML тела карточки }.
 const RESOURCES: { key: string; urlParent: string; body: (e: Record<string, unknown>, lang: string) => string }[] = [
   { key: 'conditions', urlParent: 'rules-glossary/conditions', body: (e) => conditionHtml(e.description_md as string) },
   { key: 'spells', urlParent: 'spells', body: (e, lang) => spellHtml(e, lang) },
   { key: 'monsters', urlParent: 'monsters-a-z', body: (e, lang) => monsterHtml(e, lang) },
+  { key: 'magic-items', urlParent: 'magic-items', body: (e, lang) => itemHtml(e, lang) },
 ];
 
 // Согласовано со сборкой страниц сущностей: пока только srd52 (en/ru).


### PR DESCRIPTION
## Что

Имена предметов в тексте (курсив «*Bag of Holding*» — та же разметка, что у заклинаний) → ссылки на страницы предметов + hovercard.

**Коллизий с заклинаниями нет** (имена предметов и спеллов не пересекаются), поэтому предметы добавлены в тот же `em`-матч. Основная масса упоминаний — **предмет↔предмет внутри главы маг. предметов** (навигация по кластеру), плюс снаряжение/классы/спеллы.

Карточки предметов добавлены в `/hc` (тип · редкость + выдержка).

## Покрытие
| | Предметов слинковано |
|---|---|
| **EN** | 30 → **33** |
| **RU** | 18 → **28** |

RU/EN инфлекция закрыта курируемыми alias падежных/мн. форм (как у монстров). Остаток (6 EN-only / 1 RU-only) — предметы, которые **один язык выделяет курсивом, а другой нет** (контентный хвост перевода, не алиасится).

## Проверка
`astro check` 0 ошибок · e2e 48 passed (курсивное имя предмета → ссылка + data-hc; карточка предмета: источник, тип·редкость) · паритет состояний не затронут.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP