### PR TITLE
chore(deploy): + favicon.ico в CF purge-список (#104)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,7 @@ jobs:
           fi
           base="https://rules.omnisgm.com"
           files=$(printf '"%s",' \
-            "$base/favicon.svg" "$base/icon.svg" "$base/maskable.svg" \
+            "$base/favicon.svg" "$base/favicon.ico" "$base/icon.svg" "$base/maskable.svg" \
             "$base/icon-192.png" "$base/icon-512.png" \
             "$base/maskable-192.png" "$base/maskable-512.png" \
             "$base/apple-touch-icon.png" "$base/og.png" \


### PR DESCRIPTION
Уточнение к #104: CF-purge шаг в `deploy.yml` **уже есть** и секреты `CLOUDFLARE_*` в репо заданы (проверено) — purge отрабатывал на каждом деплое. Единственная причина залипшего `favicon.ico`: файл новый (#103), его не было в списке фикс-имён → CF отдавал старый закэшированный 404.

Добавляем `favicon.ico` в purge-список. Остальные критерии #104 уже выполнены существующим шагом: точечный purge (не everything), graceful skip без секретов, HTML/хэш-ассеты не трогаются.

После мёржа деплой сбросит edge-кэш иконки. Origin уже отдаёт правильный ICO (обход кэша `?cb=` → `200 image/x-icon`).

Closes #104