### PR TITLE
feat(rules): подсветка ключевых слов (хар-ки/навыки/спасы) + EN-имя в hovercard всегда

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -5,6 +5,7 @@ import AstroPWA from '@vite-pwa/astro';
 import rehypePromoteHeadings from './src/lib/rehype-promote-headings.mjs';
 import rehypeWrapTables from './src/lib/rehype-wrap-tables.mjs';
 import rehypeEntityAutolink from './src/lib/rehype-entity-autolink.mjs';
+import rehypeKeywordHighlight from './src/lib/keyword-highlight.mjs';
 
 // rules.omnisgm.com — статический (SSG) ридер SRD экосистемы OmnisGM.
 // Контент — Markdown из ../src/{game}/{version}/{en,ru}/**.md (вход контентного пайплайна),
@@ -120,6 +121,6 @@ export default defineConfig({
   markdown: {
     // Нормализуем уровни заголовков ДО сбора TOC (headings) Astro — чтобы titled h1 не попадал в TOC.
     // rehypeEntityAutolink — последним: линкует имена сущностей в готовом дереве (issue #20).
-    rehypePlugins: [rehypePromoteHeadings, rehypeWrapTables, rehypeEntityAutolink],
+    rehypePlugins: [rehypePromoteHeadings, rehypeWrapTables, rehypeEntityAutolink, rehypeKeywordHighlight],
   },
 });

--- a/web/e2e/keyword-highlight.spec.ts
+++ b/web/e2e/keyword-highlight.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+// Подсветка ключевых игромеханических слов (issue #20): характеристики/навыки/спасброски
+// в тексте заклинаний и способностей монстров получают бренд-цвет (span.kw) — БЕЗ ссылки
+// и БЕЗ hovercard (в отличие от .ent-link).
+
+test('заклинание: спасбросок хар-ки подсвечен span.kw (не ссылка)', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/fireball/');
+  const kw = page.locator('.rd-doc .kw');
+  expect(await kw.count()).toBeGreaterThan(0);
+  // «Ловкости» из «спасбросок Ловкости»
+  await expect(kw.filter({ hasText: 'Ловкости' }).first()).toBeVisible();
+  // Это НЕ ссылка и НЕ hovercard-таргет.
+  await expect(page.locator('.rd-doc a.kw')).toHaveCount(0);
+  await expect(page.locator('.rd-doc .kw[data-hc]')).toHaveCount(0);
+});
+
+test('монстр: хар-ки в тексте действий подсвечены (Ловкости, Харизму)', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/monsters-a-z/adult-red-dragon/');
+  const kw = page.locator('.rd-doc .kw');
+  expect(await kw.count()).toBeGreaterThan(0);
+  await expect(kw.filter({ hasText: /^Ловкости$/ }).first()).toBeVisible();
+  await expect(kw.filter({ hasText: /^Харизму$/ }).first()).toBeVisible();
+});
+
+test('подсветка НЕ трогает главы-определения (Как играть)', async ({ page }) => {
+  // Глава «Как играть» определяет термины — там подсветки быть не должно (был бы ковёр).
+  await page.goto('/ru/dnd/srd-5.2/playing-the-game/');
+  await expect(page.locator('.rd-doc .kw')).toHaveCount(0);
+});
+
+test('hovercard-эндпоинт: EN-имя присутствует и в en-бакете (шапка всегда с оригиналом)', async ({ request }) => {
+  const en = await (await request.get('/hc/dnd/srd52/en.json')).json();
+  const cond = en['conditions/blinded'];
+  expect(cond).toBeTruthy();
+  // Для EN-сущности оригинал = само имя (раньше было null → шапка скрывалась).
+  expect(cond.name_en).toBe(cond.name);
+});

--- a/web/src/components/ReaderShell.astro
+++ b/web/src/components/ReaderShell.astro
@@ -659,8 +659,8 @@ const searchUi = {
       if (my !== token) return;
       const c = map && map[rkey];
       if (!c) return;
-      // EN-имя — только когда отличается от имени ссылки (RU-карточка); в EN c.name_en = null → скрыто.
-      if (c.name_en && c.name_en !== c.name) { elEn.textContent = c.name_en; elEn.style.display = ''; }
+      // EN-оригинал в шапке — ВСЕГДА, независимо от языка страницы (в EN он совпадает с именем ссылки).
+      if (c.name_en) { elEn.textContent = c.name_en; elEn.style.display = ''; }
       else { elEn.textContent = ''; elEn.style.display = 'none'; }
       elSrc.textContent = SRC[ver] || '';
       elBody.innerHTML = c.effect || ''; // доверенный контент (наши SRD-данные, экранированы на билде)

--- a/web/src/lib/keyword-highlight.mjs
+++ b/web/src/lib/keyword-highlight.mjs
@@ -1,0 +1,135 @@
+// Подсветка ключевых игромеханических слов (issue #20): характеристики, навыки и спасброски
+// в тексте получают бренд-цвет (span.kw). Это НЕ ссылка и НЕ hovercard — только визуальный
+// акцент, чтобы читатель выхватывал механику («спасбросок Ловкости», «проверка Мудрости
+// (Внимательность)»). Ручной обход hast-дерева, без зависимостей.
+//
+// Точность важнее полноты:
+//  • Характеристики — по всем падежным формам, но только с Заглавной (строчное «сила» —
+//    обычное слово, не трогаем).
+//  • Навыки — многие названия омонимичны обычным словам (История, Природа, Магия, Медицина),
+//    поэтому подсвечиваем ТОЛЬКО в игромеханическом контексте: в скобках «(Внимательность)»,
+//    в строке статблока «Навыки …», после «навык…/владени…/проверк…».
+//
+// Применяется точечно: страницы заклинаний и монстров (в их render()), глава классов
+// (rehype с гейтом на /03_Classes/). НЕ на главах-определениях (Как играть, Глоссарий),
+// где термины встречаются сплошь и подсветка стала бы ковром.
+
+const SKIP_TAGS = new Set(['a', 'code', 'pre', 'kbd', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+
+// Формы характеристик (RU — по падежам; EN — одна форма). Заглавная обязательна.
+const ABILITIES = {
+  ru: [
+    'Сила', 'Силы', 'Силе', 'Силу', 'Силой', 'Силою',
+    'Ловкость', 'Ловкости', 'Ловкостью',
+    'Телосложение', 'Телосложения', 'Телосложению', 'Телосложением',
+    'Интеллект', 'Интеллекта', 'Интеллекту', 'Интеллектом', 'Интеллекте',
+    'Мудрость', 'Мудрости', 'Мудростью',
+    'Харизма', 'Харизмы', 'Харизме', 'Харизму', 'Харизмой', 'Харизмою',
+  ],
+  en: ['Strength', 'Dexterity', 'Constitution', 'Intelligence', 'Wisdom', 'Charisma'],
+};
+
+// Названия навыков (именительный — как в скобках и в статблоке). Длинные раньше коротких,
+// чтобы «Ловкость рук» победила «Ловкость».
+const SKILLS = {
+  ru: [
+    'Уход за животными', 'Ловкость рук', 'Проницательность', 'Внимательность',
+    'Выступление', 'Запугивание', 'Скрытность', 'Убеждение', 'Выживание',
+    'Акробатика', 'Атлетика', 'История', 'Медицина', 'Природа', 'Религия',
+    'Анализ', 'Магия', 'Обман',
+  ],
+  en: [
+    'Animal Handling', 'Sleight of Hand', 'Investigation', 'Intimidation',
+    'Perception', 'Persuasion', 'Performance', 'Acrobatics', 'Athletics',
+    'Deception', 'Medicine', 'Religion', 'Survival', 'History', 'Insight',
+    'Arcana', 'Nature', 'Stealth',
+  ],
+};
+
+// Контекст-слова, легитимирующие подсветку навыка (если он не в скобках).
+const SKILL_CTX = {
+  ru: /(?:навык\w*|владе\w+|проверк\w+|спасброс\w+|Навыки)\s*$/u,
+  en: /(?:proficiency|proficient|check|save|saving throw|skill|Skills|\bin)\s*$/iu,
+};
+
+const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const cache = new Map(); // lang → { re, abil:Set, skill:Set, ctx }
+
+function build(lang) {
+  if (cache.has(lang)) return cache.get(lang);
+  const abil = ABILITIES[lang] || [];
+  const skill = SKILLS[lang] || [];
+  if (!abil.length && !skill.length) { cache.set(lang, null); return null; }
+  // Длинные формы раньше коротких (в альтернации побеждает первый матч).
+  const all = [...abil, ...skill].sort((a, b) => b.length - a.length);
+  const alt = all.map(escapeRegExp).join('|');
+  const re = new RegExp(`(?<![\\p{L}\\p{N}_])(${alt})(?![\\p{L}\\p{N}_])`, 'gu');
+  const res = { re, abil: new Set(abil), skill: new Set(skill), ctx: SKILL_CTX[lang] };
+  cache.set(lang, res);
+  return res;
+}
+
+function spanNode(text) {
+  return { type: 'element', tagName: 'span', properties: { className: ['kw'] }, children: [{ type: 'text', value: text }] };
+}
+
+function highlightText(value, m) {
+  m.re.lastIndex = 0;
+  const nodes = [];
+  let last = 0;
+  let changed = false;
+  let match;
+  while ((match = m.re.exec(value))) {
+    const term = match[1];
+    const idx = match.index;
+    if (m.skill.has(term)) {
+      // Навык — только в игромеханическом контексте: «(Навык)» или после контекст-слова.
+      const before = value.slice(0, idx);
+      const inParen = /[(,]\s*$/.test(before);
+      if (!inParen && !m.ctx.test(before)) continue;
+    }
+    changed = true;
+    if (idx > last) nodes.push({ type: 'text', value: value.slice(last, idx) });
+    nodes.push(spanNode(term));
+    last = idx + term.length;
+  }
+  if (!changed) return null;
+  if (last < value.length) nodes.push({ type: 'text', value: value.slice(last) });
+  return nodes;
+}
+
+// Ядро: подсвечивает ключевые слова прямо в hast-дереве.
+export function highlightKeywords(tree, { lang }) {
+  const m = build(lang);
+  if (!m) return tree;
+  const walk = (node, insideSkip) => {
+    if (!node.children) return;
+    for (let i = 0; i < node.children.length; i++) {
+      const child = node.children[i];
+      if (child.type === 'element') {
+        walk(child, insideSkip || SKIP_TAGS.has(child.tagName));
+      } else if (child.type === 'text' && !insideSkip) {
+        const replaced = highlightText(child.value, m);
+        if (replaced) {
+          node.children.splice(i, 1, ...replaced);
+          i += replaced.length - 1;
+        }
+      }
+    }
+  };
+  walk(tree, false);
+  return tree;
+}
+
+// rehype-обёртка: подсветка ТОЛЬКО в главе классов (умения классов). Остальные главы
+// (Как играть, Глоссарий) — определения терминов, там подсветка была бы шумом.
+export default function rehypeKeywordHighlight() {
+  return (tree, file) => {
+    const p = (file && (file.path || (file.history && file.history[0]))) || '';
+    const norm = p.replace(/\\/g, '/');
+    if (!/\/03_Classes\//.test(norm)) return;
+    const m = norm.match(/\/(dnd|daggerheart|brp)\/[^/]+\/(en|ru)\//);
+    if (!m) return;
+    highlightKeywords(tree, { lang: m[2] });
+  };
+}

--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/[slug].astro
@@ -4,6 +4,7 @@ import { fromHtml } from 'hast-util-from-html';
 import { toHtml } from 'hast-util-to-html';
 import ReaderShell from '../../../../../components/ReaderShell.astro';
 import { autolinkTree } from '../../../../../lib/rehype-entity-autolink.mjs';
+import { highlightKeywords } from '../../../../../lib/keyword-highlight.mjs';
 import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
 
 // Programmatic-страницы монстров (issue #20, волна 3) в общем шелле ридера.
@@ -52,6 +53,7 @@ const render = (md: string | undefined | null) => {
   if (!md) return '';
   const tree = fromHtml(marked.parse(md, { async: false }), { fragment: true });
   autolinkTree(tree, { game: 'dnd', version: verSlug, lang, selfSlug: entity.slug });
+  highlightKeywords(tree, { lang });
   return toHtml(tree);
 };
 const renderEntry = (e: { name?: string; text_md: string }) =>

--- a/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
@@ -4,6 +4,7 @@ import { fromHtml } from 'hast-util-from-html';
 import { toHtml } from 'hast-util-to-html';
 import ReaderShell from '../../../../../components/ReaderShell.astro';
 import { autolinkTree } from '../../../../../lib/rehype-entity-autolink.mjs';
+import { highlightKeywords } from '../../../../../lib/keyword-highlight.mjs';
 import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
 
 // Programmatic-страницы заклинаний (issue #20, волна 2) в общем шелле ридера.
@@ -52,6 +53,7 @@ const render = (md: string | undefined | null) => {
   if (!md || md === 'None') return '';
   const tree = fromHtml(marked.parse(md, { async: false }), { fragment: true });
   autolinkTree(tree, { game: 'dnd', version: verSlug, lang, selfSlug: entity.slug });
+  highlightKeywords(tree, { lang });
   return toHtml(tree);
 };
 const bodyHtml = render(entity.description_md as string);

--- a/web/src/pages/hc/[game]/[ver]/[lang].json.ts
+++ b/web/src/pages/hc/[game]/[ver]/[lang].json.ts
@@ -128,7 +128,9 @@ export const GET: APIRoute = ({ params }) => {
     for (const e of loadEntities(ver, lang, key)) {
       map[`${key}/${e.slug}`] = {
         name: e.name,
-        name_en: (e.name_en as string) ?? null,
+        // EN-оригинал показываем в шапке ВСЕГДА (и в EN-карточке тоже). Для EN-сущностей
+        // name_en отсутствует → оригинал = само name (оно и есть английское).
+        name_en: (e.name_en as string) ?? (e.name as string),
         effect: body(e as unknown as Record<string, unknown>, lang),
         href: `/${lang}/${game}/${verSlug}/${urlParent}/${e.slug}/`,
       };

--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -196,6 +196,11 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 .rd-doc a.ent-link { color: inherit; border-bottom: 1px dashed color-mix(in oklab, var(--og-accent) 55%, transparent); }
 .rd-doc a.ent-link:hover { color: var(--og-accent); border-bottom-style: solid; border-bottom-color: var(--og-accent); }
 
+/* Подсветка ключевых игромеханических слов (issue #20): характеристики / навыки /
+   спасброски — только бренд-цвет, без ссылки и hovercard. Наследует курсив/жирность
+   окружения (напр. курсив описания спелла), добавляя лишь цвет и вес. */
+.rd-doc .kw { color: var(--og-danger-text); font-weight: 600; }
+
 /* Hovercard автоссылок (issue #20, вариант B): карточка сущности при наведении/фокусе.
    Единый переиспользуемый элемент в <body>; позицию задаёт клиентский скрипт (top/left). */
 .ent-hovercard {


### PR DESCRIPTION
## Подсветка ключевых игромеханических слов
Характеристики, навыки и спасброски в **тексте** получают бренд-цвет (`span.kw`, красный `--og-danger-text`). Это **не ссылка и не hovercard** — только визуальный акцент, чтобы читатель выхватывал механику: «спасбросок **Ловкости**», «используя **Харизму**…».

**Новый hast-transform** `keyword-highlight.mjs`. Точность > полнота:
- **характеристики** — по всем падежным формам, только с Заглавной (строчное «сила» не трогаем);
- **навыки** — только в игромеханическом контексте (в скобках `(Внимательность)`, после «навык…/владени…/проверк…/Навыки»), т.к. многие омонимичны обычным словам (История/Природа/Магия/Медицина).

**Где применяется** (точечно): страницы заклинаний и монстров (в их `render()`, после `autolinkTree`), глава классов (rehype с гейтом на `/03_Classes/`). **НЕ** на главах-определениях (Как играть, Глоссарий) — там подсветка стала бы ковром.

Скрины на живом ридере (Огненный шар, Взрослый красный дракон) — красный аккуратно ложится в тёмную тему, не конфликтует с фиолетовыми автолинками.

## Hovercard: EN-оригинал в шапке всегда
Раньше EN-имя показывалось только в RU-карточке (в EN совпадало с именем ссылки и скрывалось). Теперь оригинал виден в **обоих** языках: эндпоинт отдаёт `name_en = name_en ?? name`, клиент показывает всегда.

## Проверки
- `astro check`: 0 ошибок
- `astro build`: 1918 страниц
- e2e (локально): **52 passed** (48 + 4 новых)

## Не в этом PR (обсуждаемо)
- Строка статблока монстра «Навыки …» и таблица хар-к (СИЛ/ЛОВ) — подсветка идёт только по прозе трейтов/действий, не по полям статблока. Могу расширить, если нужно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)