### PR TITLE
docs(rules): актуализировать комментарий порядка rehype-плагинов

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -120,7 +120,9 @@ export default defineConfig({
   },
   markdown: {
     // Нормализуем уровни заголовков ДО сбора TOC (headings) Astro — чтобы titled h1 не попадал в TOC.
-    // rehypeEntityAutolink — последним: линкует имена сущностей в готовом дереве (issue #20).
+    // Порядок важен (issue #20): rehypeEntityAutolink оборачивает имена сущностей в <a>, затем
+    // rehypeKeywordHighlight красит ключевые слова — последним, чтобы не лезть внутрь ссылок
+    // (<a> в его SKIP_TAGS) и работать по уже готовому дереву.
     rehypePlugins: [rehypePromoteHeadings, rehypeWrapTables, rehypeEntityAutolink, rehypeKeywordHighlight],
   },
 });


### PR DESCRIPTION
Нит из [пост-мерж ревью #107](https://github.com/OmnisGM-App/OmnisGM-Rules/pull/107#issuecomment-4952859569): комментарий в `astro.config.mjs` «rehypeEntityAutolink — последним» устарел — теперь последним идёт `rehypeKeywordHighlight` (подсветка после автолинка, чтобы не лезть внутрь `<a>`). Только комментарий, поведение не меняется.

🤖 Generated with [Claude Code](https://claude.com/claude-code)