### PR TITLE
feat(rules): программные страницы животных (animals) — Дорожка A #20

### DIFF
--- a/.claude/skills/verify-content/verify_ru_en_parity.py
+++ b/.claude/skills/verify-content/verify_ru_en_parity.py
@@ -34,7 +34,7 @@ from pathlib import Path
 # По умолчанию — ресурсы с каноническими (EN-based) слагами, где сверка по slug осмысленна.
 # feats/equipment получили канонические слаги в srd-5.2 (см. docstring); в srd-5.1 они пока
 # кириллические — при --version srd51 исключайте их из --resources.
-DEFAULT_RESOURCES = ["spells", "monsters", "magic-items", "conditions", "feats", "equipment"]
+DEFAULT_RESOURCES = ["spells", "monsters", "magic-items", "conditions", "feats", "equipment", "animals"]
 
 
 def text_len(entity: dict) -> int:

--- a/web/e2e/animals.spec.ts
+++ b/web/e2e/animals.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+// Программные страницы животных (issue #20, Дорожка A):
+// /{lang}/dnd/{ver}/animals/{slug}/. Стат-блок зеркалит монстра (КД/хиты/хар-ки/ПО),
+// EN-имя в шапке, автолинк состояний в теле, related «тот же ПО», SEO (hreflang, sitemap).
+
+test('страница животного: заголовок, EN-имя, тип, стат-блок', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/animals/wolf/');
+  await expect(page.locator('.rd-doc h1')).toContainText('Волк');
+  await expect(page.locator('.ent-en')).toHaveText('Wolf');
+  await expect(page.locator('.mon-type')).toContainText('зверь');
+  const stat = page.locator('.mon-stat');
+  await expect(stat.locator('.mon-row', { hasText: 'Класс доспеха' })).toBeVisible();
+  await expect(stat.locator('.mon-row', { hasText: 'Показатель опасности' })).toContainText('1/4');
+  // Таблица характеристик присутствует.
+  await expect(stat.locator('.mon-abil')).toBeVisible();
+});
+
+test('в теле животного — автоссылка на состояние (Лежащий) + hovercard-таргет', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/animals/wolf/');
+  const link = page.locator('.rd-doc a.ent-link[href*="/rules-glossary/conditions/prone/"]').first();
+  await expect(link).toBeVisible();
+  await expect(link).toHaveAttribute('data-hc', /conditions\/prone/);
+});
+
+test('related: другие животные того же ПО', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/animals/wolf/');
+  const rel = page.locator('.ent-related');
+  await expect(rel).toContainText('ПО 1/4');
+  await expect(rel.locator('a[href*="/animals/"]').first()).toBeVisible();
+});
+
+test('SEO: hreflang-тройка, индексируема, в sitemap', async ({ page, request }) => {
+  const res = await page.goto('/en/dnd/srd-5.2/animals/wolf/');
+  expect(res?.status()).toBe(200);
+  await expect(page.locator('link[rel="alternate"][hreflang="en"]')).toHaveCount(1);
+  await expect(page.locator('link[rel="alternate"][hreflang="ru"]')).toHaveCount(1);
+  await expect(page.locator('link[rel="alternate"][hreflang="x-default"]')).toHaveCount(1);
+  await expect(page.locator('meta[name="robots"][content*="noindex"]')).toHaveCount(0);
+  const sm = await (await request.get('/sitemap-0.xml')).text();
+  expect(sm).toContain('/dnd/srd-5.2/animals/wolf/');
+});

--- a/web/e2e/autolink.spec.ts
+++ b/web/e2e/autolink.spec.ts
@@ -11,7 +11,7 @@ test('глава: автоссылки ведут на страницы сущн
   expect(await links.count()).toBeGreaterThan(0);
   // Все ent-link ведут на программную страницу сущности: состояние / заклинание / монстр.
   for (const href of await links.evaluateAll((els) => els.map((e) => e.getAttribute('href')))) {
-    expect(href).toMatch(/\/(rules-glossary\/conditions|spells|monsters-a-z|magic-items|feats)\/[a-z0-9-]+\/$/);
+    expect(href).toMatch(/\/(rules-glossary\/conditions|spells|monsters-a-z|animals|magic-items|feats)\/[a-z0-9-]+\/$/);
   }
 });
 
@@ -171,6 +171,7 @@ test('EN/RU: набор слинкованных состояний совпад
         !p.includes('/rules-glossary/conditions/') && // сами страницы состояний, не главы
         !/\/spells\/[^/]+\/$/.test(p) && // страницы отдельных заклинаний (не глава /spells/):
         !/\/monsters-a-z\/[^/]+\/$/.test(p) && // отдельных монстров (не глава /monsters-a-z/):
+        !/\/animals\/[^/]+\/$/.test(p) && // отдельных животных (не глава /animals/):
         !/\/magic-items\/[^/]+\/$/.test(p) && // отдельных предметов (не глава /magic-items/):
         !/\/feats\/[^/]+\/$/.test(p), // и отдельных черт (не глава /feats/):
         // их описания переведены независимо → паритет линковки состояний тут не гарантирован

--- a/web/e2e/autolink.spec.ts
+++ b/web/e2e/autolink.spec.ts
@@ -61,6 +61,24 @@ test('монстры RU: термин выровнен по бестиарию (
   await expect(page.locator('.rd-doc', { hasText: 'Буллет' })).toHaveCount(0);
 });
 
+test('животные RU: склонённые жирные формы линкуются (Слоном/Мастифом/Вороном → animals)', async ({ page }) => {
+  // Фигурка чудесной силы: RU склоняет имена животных в жирном («стать **Слоном**»),
+  // а страница животного — в именительном. Курируемый alias падежных форм линкует их.
+  await page.goto('/ru/dnd/srd-5.2/magic-items/figurine-of-wondrous-power/');
+  for (const slug of ['elephant', 'mastiff', 'raven']) {
+    await expect(
+      page.locator(`.rd-doc strong a.ent-link[href$="/animals/${slug}/"]`).first(),
+    ).toBeVisible();
+  }
+});
+
+test('животные EN: множественная жирная форма линкуется (Giant Wasps → giant-wasp)', async ({ page }) => {
+  await page.goto('/en/dnd/srd-5.2/gameplay-toolbox/');
+  await expect(
+    page.locator('.rd-doc strong a.ent-link[href$="/animals/giant-wasp/"]', { hasText: 'Giant Wasps' }).first(),
+  ).toBeVisible();
+});
+
 test('предметы: имя в курсиве линкуется на страницу предмета', async ({ page }) => {
   // Глава маг. предметов: предмет↔предмет ссылки — «*Portable Hole*» и т.п. в курсиве.
   await page.goto('/en/dnd/srd-5.2/magic-items/');

--- a/web/src/lib/rehype-entity-autolink.mjs
+++ b/web/src/lib/rehype-entity-autolink.mjs
@@ -67,6 +67,15 @@ const EXACT_ALIASES = {
       'fire-elemental': ['Огненного элементаля'], 'water-elemental': ['Водного элементаля'],
       'awakened-shrub': ['Пробуждённого куста'], 'awakened-tree': ['Пробуждённого дерева'],
     },
+    // Животные: жирные упоминания в RU-корпусе склоняются (Фигурка чудесной силы, спелл-листы).
+    // Курируемый список реальных форм → на статблок животного. Именительный уже ловится сам.
+    animals: {
+      elephant: ['Слоном'], mastiff: ['Мастифом'], raven: ['Вороном'],
+      bat: ['Летучую мышь'], 'riding-horse': ['Верховой лошади'],
+      'giant-constrictor-snake': ['Гигантского удава'], 'giant-owl': ['Гигантской совой'],
+      'giant-goat': ['Гигантским козлом'], 'giant-rat': ['Гигантских крыс'],
+      'giant-wasp': ['Гигантские осы'],
+    },
     'magic-items': {
       'bag-of-holding': ['Сумкой вместимости', 'Сумку вместимости'], 'bead-of-force': ['Бусины силы'],
       'belt-of-giant-strength': ['Поясом силы великана'], 'gauntlets-of-ogre-power': ['Перчатками силы огра'],
@@ -85,6 +94,10 @@ const EXACT_ALIASES = {
     monsters: {
       ghoul: ['Ghouls'], ghast: ['Ghasts'], wight: ['Wights'], mummy: ['Mummies'],
       'shrieker-fungus': ['Shrieker Fungi'],
+    },
+    // Животные: множественные жирные формы EN (тулбокс/спелл-листы) → на статблок.
+    animals: {
+      'giant-wasp': ['Giant Wasps'], 'giant-rat': ['Giant Rats'],
     },
     'magic-items': {
       'bead-of-force': ['Beads of Force'], 'gloves-of-missile-snaring': ['Glove of Missile Snaring'],

--- a/web/src/lib/rehype-entity-autolink.mjs
+++ b/web/src/lib/rehype-entity-autolink.mjs
@@ -25,6 +25,9 @@ const RESOURCES = [
   { key: 'conditions', urlParent: 'rules-glossary/conditions', mode: 'text' },
   { key: 'spells', urlParent: 'spells', mode: 'exact', container: 'em', versions: ['srd-5.2'] },
   { key: 'monsters', urlParent: 'monsters-a-z', mode: 'exact', container: 'strong', versions: ['srd-5.2'] },
+  // Животные — тот же жирный сигнал SRD, что и монстры («**Волк**» → см. Животные). Слаги и имена
+  // животных не пересекаются с монстрами (проверено) → общий strong-матч безопасен.
+  { key: 'animals', urlParent: 'animals', mode: 'exact', container: 'strong', versions: ['srd-5.2'] },
   // Предметы — тоже курсив (SRD размечает ссылки на предметы как «*Название*», как заклинания).
   // Имена предметов и заклинаний не пересекаются → общий em-матч безопасен.
   { key: 'magic-items', urlParent: 'magic-items', mode: 'exact', container: 'em', versions: ['srd-5.2'] },

--- a/web/src/pages/[lang]/dnd/[version]/animals/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/animals/[slug].astro
@@ -1,0 +1,316 @@
+---
+import { marked } from 'marked';
+import { fromHtml } from 'hast-util-from-html';
+import { toHtml } from 'hast-util-to-html';
+import ReaderShell from '../../../../../components/ReaderShell.astro';
+import { autolinkTree } from '../../../../../lib/rehype-entity-autolink.mjs';
+import { highlightKeywords } from '../../../../../lib/keyword-highlight.mjs';
+import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
+
+// Programmatic-страницы животных (issue #20, Дорожка A) в общем шелле ридера.
+// Стат-блок животного идентичен монстру (тот же парсер monster) — страница зеркалит
+// monsters-a-z/[slug].astro. URL вложен под главу «Животные»: /{lang}/dnd/{version}/animals/{slug}/.
+// EN и RU делят канонический (англ.) слаг → корректный hreflang.
+// Отличие от монстров: related группируем по ПО (CR), а не по типу существа — 90 из 95
+// животных имеют тип Beast, поэтому «тот же тип» бессмыслен; CR — естественная ось выбора
+// (Дикий облик друида, спутники, ездовые животные ограничены по ПО).
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-animals' };
+
+interface Sib { slug: string; name: string; cr: string }
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as const },
+    { ver: 'srd52', lang: 'ru' as const },
+  ];
+  const paths = [];
+  for (const { ver, lang } of BUILDS) {
+    const animals = loadEntities(ver, lang, 'animals');
+    const siblings: Sib[] = animals.map((m) => ({
+      slug: m.slug, name: m.name,
+      cr: (m.cr as { value?: string })?.value ?? '',
+    }));
+    // Карта имя-состояния → slug для линковки иммунитетов к состояниям в стат-блоке.
+    const condMap: Record<string, string> = {};
+    for (const c of loadEntities(ver, lang, 'conditions')) {
+      condMap[c.name.toLowerCase()] = c.slug;
+    }
+    for (const entity of animals) {
+      paths.push({
+        params: { lang, version: VERSION_SLUG[ver], slug: entity.slug },
+        props: { entity, ver, lang, siblings, condMap },
+      });
+    }
+  }
+  return paths;
+}
+
+const { entity, ver, lang, siblings, condMap } = Astro.props;
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const verKey = ver; // srd52
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+
+// Рендер текста трейта/действия: реконструируем исходную SRD-строку «**_Имя._** текст»
+// и прогоняем через marked → hast → autolink (состояния + заклинания) → html.
+const render = (md: string | undefined | null) => {
+  if (!md) return '';
+  const tree = fromHtml(marked.parse(md, { async: false }), { fragment: true });
+  autolinkTree(tree, { game: 'dnd', version: verSlug, lang, selfSlug: entity.slug });
+  highlightKeywords(tree, { lang });
+  return toHtml(tree);
+};
+const renderEntry = (e: { name?: string; text_md: string }) =>
+  render(e.name ? `**_${e.name}._** ${e.text_md}` : e.text_md);
+
+// ── Стат-блок
+const size = (entity.size as string) ?? '';
+const creatureType = (entity.type as string) ?? '';
+const subtype = entity.subtype as string | null;
+const alignment = entity.alignment as string | null;
+const typeLine = [
+  [size, creatureType].filter(Boolean).join(' ') + (subtype ? ` (${subtype})` : ''),
+  alignment,
+].filter(Boolean).join(', ');
+
+const ac = entity.ac as { value?: number; source?: string | null };
+const hp = entity.hp as { average?: number; formula?: string };
+const speed = entity.speed as { raw?: string };
+const initiative = entity.initiative as { mod?: number; score?: number } | null;
+const abilities = (entity.abilities ?? {}) as Record<string, { score: number; mod: number; save: number }>;
+const senses = entity.senses as { raw?: string };
+const cr = entity.cr as { value?: string; xp?: number };
+const languages = entity.languages as string | null;
+
+const ABIL: { key: string; ru: string; en: string }[] = [
+  { key: 'str', ru: 'СИЛ', en: 'STR' }, { key: 'dex', ru: 'ЛОВ', en: 'DEX' },
+  { key: 'con', ru: 'ТЕЛ', en: 'CON' }, { key: 'int', ru: 'ИНТ', en: 'INT' },
+  { key: 'wis', ru: 'МДР', en: 'WIS' }, { key: 'cha', ru: 'ХАР', en: 'CHA' },
+];
+const hasAbilities = ABIL.some((a) => abilities[a.key]);
+const sign = (n: number | undefined) => (n == null ? '' : n >= 0 ? `+${n}` : `${n}`);
+const fmtXp = (n: number | undefined) =>
+  n ? n.toLocaleString(lang === 'ru' ? 'ru-RU' : 'en-US') : '';
+
+const arr = (v: unknown) => (Array.isArray(v) ? (v as string[]) : []);
+const resistances = arr(entity.damage_resistances);
+const dmgImmunities = arr(entity.damage_immunities);
+const condImmunities = arr(entity.condition_immunities);
+const vulnerabilities = arr(entity.damage_vulnerabilities);
+const savingThrows = arr(entity.saving_throws);
+const skills = arr(entity.skills);
+
+// Иммунитет к состоянию → ссылка на страницу состояния (+ data-hc для hovercard), если slug найден.
+const condLink = (token: string) => {
+  const base = token.trim().toLowerCase().split(/[(*]/)[0].trim();
+  const slug = condMap[base];
+  return slug ? { slug } : null;
+};
+const condHref = (slug: string) => `/${lang}/dnd/${verSlug}/rules-glossary/conditions/${slug}/`;
+const condHc = (slug: string) => `dnd/${verKey}/${lang}/conditions/${slug}`;
+
+// Секции
+const traits = arr(entity.traits_md) as unknown as { name?: string; text_md: string }[];
+const actions = arr(entity.actions_md) as unknown as { name?: string; text_md: string }[];
+const bonusActions = arr(entity.bonus_actions_md) as unknown as { name?: string; text_md: string }[];
+const reactions = arr(entity.reactions_md) as unknown as { name?: string; text_md: string }[];
+const legendary = arr(entity.legendary_actions_md) as unknown as { name?: string; text_md: string }[];
+const lairActions = entity.lair_actions_md as string | null;
+
+const SECTIONS: { title: string; entries: { name?: string; text_md: string }[] }[] = [
+  { title: t('Особенности', 'Traits'), entries: traits },
+  { title: t('Действия', 'Actions'), entries: actions },
+  { title: t('Бонусные действия', 'Bonus Actions'), entries: bonusActions },
+  { title: t('Реакции', 'Reactions'), entries: reactions },
+  { title: t('Легендарные действия', 'Legendary Actions'), entries: legendary },
+].filter((s) => s.entries.length > 0);
+
+const description = excerpt(
+  (traits[0]?.text_md || actions[0]?.text_md || '') as string,
+);
+
+const base = `/${lang}/dnd/${verSlug}/animals`;
+// «Тот же ПО» — до 8 других животных с тем же показателем опасности (внутренняя перелинковка/SEO).
+const sameCr = (siblings as Sib[])
+  .filter((s) => s.slug !== entity.slug && s.cr === (cr?.value ?? ''))
+  .slice(0, 8);
+
+const upLink = { href: `${base}/`, ru: 'Животные', en: 'Animals' };
+const kind = t('Животное', 'Animal');
+const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel} ${kind}`)} · OmnisGM Rules`;
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={entity.name}
+  description={description}
+  headings={[]}
+  upLink={upLink}
+>
+  <h1>
+    {entity.name}
+    <span class="mon-sub">
+      {lang === 'ru' && entity.name_en && <span class="ent-en">{entity.name_en}</span>}
+      <span class="mon-type">{typeLine}</span>
+    </span>
+  </h1>
+
+  <div class="mon-stat">
+    <dl class="mon-lines">
+      {ac?.value != null && (
+        <div class="mon-row"><dt>{t('Класс доспеха', 'Armor Class')}</dt>
+          <dd>{ac.value}{ac.source ? ` (${ac.source})` : ''}</dd></div>
+      )}
+      {hp?.average != null && (
+        <div class="mon-row"><dt>{t('Хиты', 'Hit Points')}</dt>
+          <dd>{hp.average}{hp.formula ? ` (${hp.formula})` : ''}</dd></div>
+      )}
+      {speed?.raw && (
+        <div class="mon-row"><dt>{t('Скорость', 'Speed')}</dt><dd>{speed.raw}</dd></div>
+      )}
+      {initiative && (
+        <div class="mon-row"><dt>{t('Инициатива', 'Initiative')}</dt>
+          <dd>{sign(initiative.mod)}{initiative.score != null ? ` (${initiative.score})` : ''}</dd></div>
+      )}
+    </dl>
+
+    {hasAbilities && (
+      <table class="mon-abil">
+        <thead>
+          <tr><th></th>{ABIL.map((a) => <th>{t(a.ru, a.en)}</th>)}</tr>
+        </thead>
+        <tbody>
+          <tr><th>{t('ЗНАЧ', 'SCORE')}</th>{ABIL.map((a) => <td>{abilities[a.key]?.score ?? '—'}</td>)}</tr>
+          <tr><th>{t('МОД', 'MOD')}</th>{ABIL.map((a) => <td>{sign(abilities[a.key]?.mod)}</td>)}</tr>
+          <tr><th>{t('СПАС', 'SAVE')}</th>{ABIL.map((a) => <td>{sign(abilities[a.key]?.save)}</td>)}</tr>
+        </tbody>
+      </table>
+    )}
+
+    <dl class="mon-lines">
+      {savingThrows.length > 0 && (
+        <div class="mon-row"><dt>{t('Спасброски', 'Saving Throws')}</dt><dd>{savingThrows.join(', ')}</dd></div>
+      )}
+      {skills.length > 0 && (
+        <div class="mon-row"><dt>{t('Навыки', 'Skills')}</dt><dd>{skills.join(', ')}</dd></div>
+      )}
+      {vulnerabilities.length > 0 && (
+        <div class="mon-row"><dt>{t('Уязвимости', 'Vulnerabilities')}</dt><dd>{vulnerabilities.join(', ')}</dd></div>
+      )}
+      {resistances.length > 0 && (
+        <div class="mon-row"><dt>{t('Сопротивления', 'Resistances')}</dt><dd>{resistances.join(', ')}</dd></div>
+      )}
+      {(dmgImmunities.length > 0 || condImmunities.length > 0) && (
+        <div class="mon-row"><dt>{t('Иммунитеты', 'Immunities')}</dt>
+          <dd>
+            {dmgImmunities.join(', ') + (dmgImmunities.length > 0 && condImmunities.length > 0 ? '; ' : '')}{condImmunities.map((c, i) => {
+              const link = condLink(c);
+              return (
+                <Fragment>{i > 0 ? ', ' : ''}{link
+                  ? <a class="ent-link" href={condHref(link.slug)} data-hc={condHc(link.slug)}>{c}</a>
+                  : c}</Fragment>
+              );
+            })}
+          </dd></div>
+      )}
+      {senses?.raw && (
+        <div class="mon-row"><dt>{t('Чувства', 'Senses')}</dt><dd>{senses.raw}</dd></div>
+      )}
+      {languages && (
+        <div class="mon-row"><dt>{t('Языки', 'Languages')}</dt><dd>{languages}</dd></div>
+      )}
+      {cr?.value && (
+        <div class="mon-row"><dt>{t('Показатель опасности', 'CR')}</dt>
+          <dd>{cr.value}{cr.xp ? ` (${t('ОО', 'XP')} ${fmtXp(cr.xp)})` : ''}</dd></div>
+      )}
+    </dl>
+  </div>
+
+  {SECTIONS.map((s) => (
+    <section class="mon-section">
+      <h2>{s.title}</h2>
+      {s.entries.map((e) => <div class="mon-entry" set:html={renderEntry(e)} />)}
+    </section>
+  ))}
+
+  {lairActions && (
+    <section class="mon-section">
+      <h2>{t('Действия логова', 'Lair Actions')}</h2>
+      <div class="mon-entry" set:html={render(lairActions)} />
+    </section>
+  )}
+
+  {sameCr.length > 0 && (
+    <nav class="ent-related" aria-label={t('Тот же ПО', 'Same CR')}>
+      <span class="ent-related-h">{t(`Ещё животные: ПО ${cr?.value}`, `More CR ${cr?.value} animals`)}</span>
+      <span class="ent-related-list">
+        {sameCr.map((r) => (
+          <a href={`${base}/${r.slug}/`}><strong>{r.name}</strong></a>
+        ))}
+      </span>
+    </nav>
+  )}
+</ReaderShell>
+
+<style>
+  /* Подстрока в шапке (над чертой): EN-имя + тип/мировоззрение. */
+  .mon-sub {
+    display: block; margin-top: 8px;
+    font-family: var(--font-body); font-weight: 400; letter-spacing: 0;
+  }
+  .ent-en {
+    font-family: var(--font-mono); font-size: 14px; font-weight: 400; letter-spacing: 0;
+    color: var(--og-text-muted);
+  }
+  .mon-type { font-style: italic; font-size: 14px; color: var(--og-text-muted); }
+  .ent-en + .mon-type::before { content: ' · '; font-style: normal; }
+
+  /* Стат-блок: карточка. */
+  .mon-stat {
+    margin: 0 0 28px; padding: 16px 18px; border: 1px solid var(--og-border); border-radius: 10px;
+    background: var(--og-bg-2);
+  }
+  .mon-lines { margin: 0; display: grid; gap: 7px; }
+  .mon-lines + .mon-abil, .mon-abil + .mon-lines { margin-top: 14px; }
+  .mon-row { display: grid; grid-template-columns: 190px 1fr; gap: 12px; align-items: baseline; }
+  .mon-row dt {
+    font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.5px; text-transform: uppercase;
+    color: var(--og-text-muted); font-weight: 600;
+  }
+  .mon-row dd { margin: 0; color: var(--og-text-2); }
+
+  /* Таблица характеристик. */
+  .mon-abil {
+    width: 100%; border-collapse: collapse; text-align: center;
+    font-family: var(--font-mono); font-size: 13px;
+  }
+  .mon-abil th, .mon-abil td { padding: 5px 4px; border: 1px solid var(--og-border); }
+  .mon-abil thead th { color: var(--og-text-muted); font-size: 11px; letter-spacing: 0.5px; }
+  .mon-abil tbody th {
+    color: var(--og-text-muted); font-size: 11px; letter-spacing: 0.5px; text-align: left;
+    padding-left: 8px; font-weight: 600;
+  }
+  .mon-abil tbody td { color: var(--og-text-2); }
+
+  .mon-section { margin-top: 28px; }
+  .mon-entry { margin: 0 0 4px; }
+
+  .ent-related { display: block; margin-top: 40px; padding-top: 20px; border-top: 1px solid var(--og-border); }
+  .ent-related-h {
+    display: block; font-size: 13px; text-transform: uppercase; letter-spacing: 1px;
+    color: var(--og-text-muted); margin-bottom: 10px;
+  }
+  .ent-related-list { display: flex; flex-wrap: wrap; gap: 6px 14px; }
+
+  /* Мобилка: метка и значение в строку. */
+  @media (max-width: 560px) {
+    .mon-row { display: block; }
+    .mon-row dt { display: inline; }
+    .mon-row dt::after { content: ':\00a0'; }
+    .mon-row dd { display: inline; }
+    .mon-abil { font-size: 12px; }
+    .mon-abil th, .mon-abil td { padding: 4px 2px; }
+  }
+</style>

--- a/web/src/pages/hc/[game]/[ver]/[lang].json.ts
+++ b/web/src/pages/hc/[game]/[ver]/[lang].json.ts
@@ -107,6 +107,8 @@ const RESOURCES: { key: string; urlParent: string; body: (e: Record<string, unkn
   { key: 'conditions', urlParent: 'rules-glossary/conditions', body: (e) => conditionHtml(e.description_md as string) },
   { key: 'spells', urlParent: 'spells', body: (e, lang) => spellHtml(e, lang) },
   { key: 'monsters', urlParent: 'monsters-a-z', body: (e, lang) => monsterHtml(e, lang) },
+  // Животные — тот же стат-блок, что и монстры → та же карточка (тип/мировоззрение + КД·хиты·ПО).
+  { key: 'animals', urlParent: 'animals', body: (e, lang) => monsterHtml(e, lang) },
   { key: 'magic-items', urlParent: 'magic-items', body: (e, lang) => itemHtml(e, lang) },
 ];
 


### PR DESCRIPTION
## Что

Дорожка A, шаг «животные»: программные страницы для **95 животных** SRD 5.2 (×2 языка = **190 страниц**), зеркалящие страницу монстра.

- **Страница** `/{lang}/dnd/{ver}/animals/{slug}/`: стат-блок (КД/хиты/скорость/инициатива/таблица характеристик/чувства/ПО), EN-имя в шапке, автолинк состояний + hovercard в тексте трейтов/действий.
- **Related — «тот же ПО (CR)»**, а не «тот же тип»: 90 из 95 животных — Beast, поэтому тип бесполезен; ПО — естественная ось выбора (Дикий облик друида, спутники, ездовые).
- **Автолинк-цель**: имена животных в жирном (`**Волк**`, Figurine of Wondrous Power, фичи друида/варлока, спелл-листы призыва) → ссылка на статблок. Слаги/имена животных **не пересекаются** с монстрами (проверено скриптом) → общий `strong`-матч безопасен.
- **Hovercard**: та же карточка, что у монстра (тип/мировоззрение + КД·хиты·ПО).
- **URL**: глава `13_Animals` слагифицируется в `/animals/`, общий канонический (EN) слаг для EN/RU → корректный hreflang.

## Проверки

- Чистая сборка: **2142 страницы** (+190).
- `figurine-of-wondrous-power` корректно линкует на `elephant/lion/raven/mastiff/…` — реальные статблоки.
- e2e: новый `animals.spec.ts` (4 теста), `autolink.spec.ts` — animals в allowlist + исключение детальных страниц из краула паритета состояний.
- **Полный прогон e2e: 63 passed** (было 59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)