### PR TITLE
fix(ci): IndexNow-пинг падал «Argument list too long» при росте sitemap #20

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,11 +122,14 @@ jobs:
           urls=$(grep -ohE '<loc>[^<]+</loc>' web/dist/sitemap-[0-9]*.xml 2>/dev/null | sed -E 's#</?loc>##g')
           n=$(printf '%s\n' "$urls" | grep -c . || true)
           if [ "$n" -eq 0 ]; then echo "::warning::IndexNow: sitemap пуст — пинг пропущен."; exit 0; fi
-          payload=$(printf '%s\n' "$urls" | grep . | jq -R . \
+          # Payload в файл (не в аргумент curl): при >~1500 URL строка --data "$payload"
+          # перешагивает ARG_MAX → «curl: Argument list too long» (грабли #20, sitemap вырос
+          # на страницы животных). --data-binary @file снимает лимит.
+          printf '%s\n' "$urls" | grep . | jq -R . \
             | jq -sc --arg h "$host" --arg k "$KEY" --arg kl "https://$host/$KEY.txt" \
-                '{host:$h,key:$k,keyLocation:$kl,urlList:.}')
+                '{host:$h,key:$k,keyLocation:$kl,urlList:.}' > /tmp/indexnow.json
           resp=$(curl -s -w '\n%{http_code}' -X POST 'https://api.indexnow.org/indexnow' \
-            -H 'Content-Type: application/json; charset=utf-8' --data "$payload")
+            -H 'Content-Type: application/json; charset=utf-8' --data-binary @/tmp/indexnow.json)
           code=$(printf '%s' "$resp" | tail -n1)
           body=$(printf '%s\n' "$resp" | sed '$d')
           echo "IndexNow: $n URL, HTTP $code"


### PR DESCRIPTION
## Проблема

[Деплой после мёржа #112](https://github.com/OmnisGM-App/OmnisGM-Rules/actions/runs/29234876775) стал красным. **Сам Firebase-деплой прошёл** (`✔ Deploy complete!`) — животные в проде; упал только последующий шаг **IndexNow ping**:

```
/usr/bin/curl: Argument list too long
##[error]Process completed with exit code 126.
```

Страницы животных добавили ~190 URL в sitemap. Шаг собирал JSON в переменную и передавал его как **аргумент** `curl --data "$payload"` — при ~1600 URL командная строка перешагнула `ARG_MAX`. Под `bash -e` упавший curl уронил весь шаг.

## Фикс

Payload пишем в `/tmp/indexnow.json` и отправляем `curl --data-binary @file` — лимит длины аргументов снят, число URL больше не важно (лимит самого IndexNow 10 000/запрос — с запасом).

CF-purge рядом шлёт фиксированный список ~16 файлов → ARG_MAX не грозит, не трогаю.

## Проверка

`deploy.yml` срабатывает только на push в `main`, поэтому проверить можно лишь следующим реальным деплоем после мёржа. Синтаксис jq/curl не менялся, только источник тела запроса (переменная → файл).

🤖 Generated with [Claude Code](https://claude.com/claude-code)