### PR TITLE
fix(rules): консистентность подсветки — списки навыков + «Требование» черт #20

### DIFF
--- a/web/e2e/feats.spec.ts
+++ b/web/e2e/feats.spec.ts
@@ -13,6 +13,15 @@ test('страница черты: заголовок, EN-имя, категор
   await expect(stat.locator('.item-row', { hasText: 'Категория' })).toContainText('происхождения');
 });
 
+test('стат-блок черты: хар-ки в «Требовании» подсвечены span.kw (как в теле)', async ({ page }) => {
+  // Борец (grappler): «Требование: Уровень 4+, Сила или Ловкость 13+» — Сила/Ловкость должны
+  // быть красными, как в описании ниже (консистентность стат-блок ↔ тело).
+  await page.goto('/ru/dnd/srd-5.2/feats/grappler/');
+  const req = page.locator('.item-stat .item-row', { hasText: 'Требование' });
+  await expect(req.locator('.kw', { hasText: 'Сила' }).first()).toBeVisible();
+  await expect(req.locator('.kw', { hasText: 'Ловкость' }).first()).toBeVisible();
+});
+
 test('в теле черты — автоссылка на состояние (Недееспособный) + hovercard-таргет', async ({ page }) => {
   await page.goto('/ru/dnd/srd-5.2/feats/alert/');
   const link = page.locator('.rd-doc a.ent-link[href*="/rules-glossary/conditions/incapacitated/"]').first();

--- a/web/e2e/keyword-highlight.spec.ts
+++ b/web/e2e/keyword-highlight.spec.ts
@@ -23,6 +23,25 @@ test('монстр: хар-ки в тексте действий подсвеч�
   await expect(kw.filter({ hasText: /^Харизму$/ }).first()).toBeVisible();
 });
 
+test('список навыков класса: подсвечены ВСЕ, включая первый и последний', async ({ page }) => {
+  // Таблица черт Варвара: «Выберите 2: Уход за животными, Атлетика, …, Внимательность или
+  // Выживание». Раньше первый (после «2:») и последний (после «или») выпадали — навык
+  // подсвечивался только после запятой. Список — единая группа: подсвечены все 6.
+  await page.goto('/ru/dnd/srd-5.2/classes/barbarian/');
+  const kw = page.locator('.rd-doc .kw');
+  for (const skill of ['Уход за животными', 'Атлетика', 'Запугивание', 'Природа', 'Внимательность', 'Выживание']) {
+    await expect(kw.filter({ hasText: new RegExp(`^${skill}$`) }).first()).toBeVisible();
+  }
+});
+
+test('список навыков EN: первый и последний тоже подсвечены (Animal Handling … or Survival)', async ({ page }) => {
+  await page.goto('/en/dnd/srd-5.2/classes/barbarian/');
+  const kw = page.locator('.rd-doc .kw');
+  for (const skill of ['Animal Handling', 'Survival']) {
+    await expect(kw.filter({ hasText: new RegExp(`^${skill}$`) }).first()).toBeVisible();
+  }
+});
+
 test('подсветка НЕ трогает главы-определения (Как играть)', async ({ page }) => {
   // Глава «Как играть» определяет термины — там подсветки быть не должно (был бы ковёр).
   await page.goto('/ru/dnd/srd-5.2/playing-the-game/');

--- a/web/src/lib/keyword-highlight.mjs
+++ b/web/src/lib/keyword-highlight.mjs
@@ -52,6 +52,11 @@ const SKILL_CTX = {
   en: /(?:proficiency|proficient|check|save|saving throw|skill|Skills|\bin)\s*$/iu,
 };
 
+// Разделитель списка навыков: запятая и/или союз («A, B, or C», «A, B … или F»). Если два
+// соседних навыка разделены только им — они члены одного перечисления. Пустой зазор (только
+// пробел) НЕ считается разделителем — иначе слиплись бы случайные соседние слова.
+const SKILL_LIST_SEP = /^\s*(?:,\s*(?:или|и|or|and)?|(?:или|и|or|and))\s*$/iu;
+
 const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const cache = new Map(); // lang → { re, abil:Set, skill:Set, ctx }
 
@@ -75,23 +80,44 @@ function spanNode(text) {
 
 function highlightText(value, m) {
   m.re.lastIndex = 0;
+  const matches = [];
+  let match;
+  while ((match = m.re.exec(value))) {
+    matches.push({
+      term: match[1], idx: match.index, end: match.index + match[1].length,
+      skill: m.skill.has(match[1]),
+    });
+  }
+  if (!matches.length) return null;
+
+  // Индивидуальная легитимность навыка: «(Навык)» / после запятой или контекст-слова.
+  // Характеристики подсвечиваем всегда (заглавная форма уже отсеяла обычные слова).
+  const decide = matches.map((mt) => {
+    if (!mt.skill) return true;
+    const before = value.slice(0, mt.idx);
+    return /[(,]\s*$/.test(before) || m.ctx.test(before);
+  });
+
+  // Список навыков — единая группа: соседние навыки, разделённые только запятой/союзом,
+  // связаны. Если хоть один член легитимен, подсвечиваем весь список (иначе первый после
+  // «Выберите N:» и последний после «или» выпадали — issue #20). Прямой проход тянет «ок»
+  // вперёд по цепочке, обратный — назад; для непрерывного списка этого достаточно.
+  const linked = (a, b) => a.skill && b.skill && SKILL_LIST_SEP.test(value.slice(a.end, b.idx));
+  for (let i = 1; i < matches.length; i++)
+    if (decide[i - 1] && linked(matches[i - 1], matches[i])) decide[i] = true;
+  for (let i = matches.length - 2; i >= 0; i--)
+    if (decide[i + 1] && linked(matches[i], matches[i + 1])) decide[i] = true;
+
   const nodes = [];
   let last = 0;
   let changed = false;
-  let match;
-  while ((match = m.re.exec(value))) {
-    const term = match[1];
-    const idx = match.index;
-    if (m.skill.has(term)) {
-      // Навык — только в игромеханическом контексте: «(Навык)» или после контекст-слова.
-      const before = value.slice(0, idx);
-      const inParen = /[(,]\s*$/.test(before);
-      if (!inParen && !m.ctx.test(before)) continue;
-    }
+  for (let i = 0; i < matches.length; i++) {
+    if (!decide[i]) continue;
+    const mt = matches[i];
     changed = true;
-    if (idx > last) nodes.push({ type: 'text', value: value.slice(last, idx) });
-    nodes.push(spanNode(term));
-    last = idx + term.length;
+    if (mt.idx > last) nodes.push({ type: 'text', value: value.slice(last, mt.idx) });
+    nodes.push(spanNode(mt.term));
+    last = mt.end;
   }
   if (!changed) return null;
   if (last < value.length) nodes.push({ type: 'text', value: value.slice(last) });

--- a/web/src/pages/[lang]/dnd/[version]/feats/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/feats/[slug].astro
@@ -60,6 +60,15 @@ const render = (md: string | undefined | null) => {
 const bodyHtml = render(entity.description_md as string);
 const description = excerpt(entity.description_md as string);
 
+// Подсветка хар-к в стат-блоке (чтобы «Сила»/«Ловкость» в «Требовании» были красными, как в
+// теле): прогоняем plain-строку через тот же highlightKeywords по текстовому узлу.
+const hl = (text: string) => {
+  if (!text) return '';
+  const tree = { type: 'root', children: [{ type: 'text', value: text }] } as Parameters<typeof toHtml>[0];
+  highlightKeywords(tree, { lang });
+  return toHtml(tree);
+};
+
 const rawCat = (entity.category as string) ?? '';
 const catPair = CATEGORY[rawCat];
 const catLabel = catPair ? (lang === 'ru' ? catPair[0] : catPair[1]) : rawCat;
@@ -99,7 +108,7 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
       <div class="item-row"><dt>{t('Категория', 'Category')}</dt><dd>{catLabel}</dd></div>
     )}
     {prerequisite && (
-      <div class="item-row"><dt>{t('Требование', 'Prerequisite')}</dt><dd>{prerequisite}</dd></div>
+      <div class="item-row"><dt>{t('Требование', 'Prerequisite')}</dt><dd set:html={hl(prerequisite)} /></div>
     )}
     {repeatable && (
       <div class="item-row"><dt>{t('Повторяемость', 'Repeatable')}</dt><dd>{t('да', 'yes')}</dd></div>


### PR DESCRIPTION
Два дефекта консистентности подсветки ключевых слов (`span.kw`), замечены при просмотре страниц классов и черт.

## 1. Списки навыков — первый и последний выпадали

**Баг** (страница Варвара): «Выберите 2: Уход за животными, Атлетика, …, Внимательность **или** Выживание» — средние навыки красные, а первый (после «2:») и последний (после «или») — нет. Так же в EN (Animal Handling / Survival).

**Причина:** навык легитимировался только запятой/скобкой/контекст-словом непосредственно перед ним; у крайних членов списка их нет (двоеточие / союз).

**Фикс:** навыки, разделённые только запятой/союзом (`,` / или / и / or / and), — единая группа. Если хоть один член легитимен, подсвечиваем весь список (прямой + обратный проход). Пустой зазор (только пробел) разделителем не считается. Консервативность сохранена: список без единого легитимного члена (проза «История или Магия») не горит.

## 2. Стат-блок «Требование» черты не подсвечивался

**Баг** (страница Борца/grappler): в теле «Силу или Ловкость» красные, а в стат-блоке «Требование: Уровень 4+, Сила или Ловкость 13+» — нет (строка рендерилась plain-текстом).

**Фикс:** prerequisite прогоняется через тот же `highlightKeywords`. Характеристики подсвечиваются всегда (заглавная форма отсеивает обычные слова).

## Проверки
- e2e: +3 теста (RU/EN списки навыков Варвара; grappler «Требование»). **Полный прогон: 68 passed.**
- Проверено в dist: Варвар — все 6 навыков RU+EN; grappler — Сила/Ловкость в «Требовании».

🤖 Generated with [Claude Code](https://claude.com/claude-code)