### PR TITLE
feat(rules): страницы оружия и доспехов + слаг-фикс парсера — Дорожка A #20

### DIFF
--- a/.github/scripts/generate_api.py
+++ b/.github/scripts/generate_api.py
@@ -79,6 +79,82 @@ def backfill_name_en(entities: list[dict], src_root: Path) -> None:
             entity["slug"] = slugify(en)
 
 
+def _num_key(s: str | None) -> str | None:
+    """Языко-инвариантный числовой ключ: только цифры («10 GP»/«10 зм» → «10»,
+    «1,500 GP»/«1500 зм» → «1500», «4 lb.»/«4 фнт.» → «4»)."""
+    if not s:
+        return None
+    digits = re.sub(r"[^\d]", "", str(s))
+    return digits or None
+
+
+def _weapon_fp(e: dict) -> tuple:
+    return (e["category"], e["type"], e["damage_dice"], e["damage_type"],
+            _num_key(e.get("weight")), _num_key(e.get("cost")),
+            e.get("range_normal"), e.get("range_long"))
+
+
+def _armor_fp(e: dict) -> tuple:
+    return (e["category"], e["ac_base"], e.get("ac_dex_bonus"), e.get("ac_max_dex"),
+            e.get("strength_req"), e.get("stealth_disadvantage"),
+            _num_key(e.get("weight")), _num_key(e.get("cost")))
+
+
+_STAT_TABLE_FP = {"weapons": _weapon_fp, "armor": _armor_fp}
+
+
+def align_stat_table_name_en(all_data: dict) -> None:
+    """Проставить RU-оружию/доспехам name_en + канонический (англ.) слаг.
+
+    Их имена — в ячейках таблиц (не в заголовках со скобкой «(English)»), а таблицы
+    отсортированы по алфавиту КАЖДОГО языка отдельно → позиционная сверка EN↔RU неверна,
+    в словаре имён нет. Зато стат-блок языко-инвариантен: сверяем RU→EN по «отпечатку»
+    (категория/урон/вес/цена-число/…). Механически-идентичные пары (Glaive/Halberd — один
+    отпечаток) разводим по мастерству: 1-й проход учит карту «RU-мастерство → EN» на
+    однозначных строках (Greatsword→Graze, Greataxe→Cleave), 2-й — разрешает коллизии.
+    """
+    for (ver, lang, resource), ru_entities in all_data.items():
+        if lang != "ru" or resource not in _STAT_TABLE_FP:
+            continue
+        en_entities = all_data.get((ver, "en", resource))
+        if not en_entities:
+            continue
+        fp = _STAT_TABLE_FP[resource]
+        en_by_fp: dict[tuple, list[dict]] = {}
+        for e in en_entities:
+            en_by_fp.setdefault(fp(e), []).append(e)
+
+        mastery_ru_en: dict[str, str] = {}
+        pending: list[dict] = []
+        for r in ru_entities:
+            bucket = en_by_fp.get(fp(r), [])
+            if len(bucket) == 1:
+                e = bucket[0]
+                r["name_en"] = e["name"]
+                r["slug"] = e["slug"]
+                if resource == "weapons" and r.get("mastery") and e.get("mastery"):
+                    mastery_ru_en[r["mastery"]] = e["mastery"]
+            else:
+                pending.append(r)
+
+        for r in pending:
+            bucket = en_by_fp.get(fp(r), [])
+            target = None
+            if resource == "weapons":
+                want = mastery_ru_en.get(r.get("mastery"))
+                target = next((e for e in bucket if e.get("mastery") == want), None)
+            if target is None:
+                target = bucket[0] if bucket else None
+                print(f"  Warning: неоднозначный name_en для RU {resource} "
+                      f"{r.get('name')!r} — взят первый кандидат", file=sys.stderr)
+            if target:
+                r["name_en"] = target["name"]
+                r["slug"] = target["slug"]
+            else:
+                print(f"  Warning: не найден EN-аналог для RU {resource} "
+                      f"{r.get('name')!r}", file=sys.stderr)
+
+
 def resolve_cross_refs(all_data: dict) -> None:
     """Resolve spell name → slug cross-references for monsters and magic items."""
     spell_lookup: dict[tuple[str, str], dict[str, str]] = {}
@@ -370,6 +446,9 @@ def main():
         count = len(entities)
         total_entities += count
         print(f"  {ver}/{lang}/{resource}: {count} entities from {source['file']}")
+
+    # RU-оружию/доспехам — name_en + канонический слаг (сверка стат-блоков EN↔RU).
+    align_stat_table_name_en(all_data)
 
     # Resolve cross-references
     resolve_cross_refs(all_data)

--- a/web/e2e/armor.spec.ts
+++ b/web/e2e/armor.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+// Программные страницы доспехов (issue #20, Дорожка A): /{lang}/dnd/{ver}/armor/{slug}/.
+// Тонкий стат-блок (КД/категория/требование Силы/скрытность/вес/цена). RU получает
+// канонический (англ.) слаг + name_en через сверку стат-блоков EN↔RU → общий слаг, hreflang.
+
+test('доспех: заголовок, EN-имя, категория, КД + требование Силы', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/armor/plate-armor/');
+  await expect(page.locator('.rd-doc h1')).toContainText('Латы');
+  await expect(page.locator('.ent-en')).toHaveText('Plate Armor');
+  const stat = page.locator('.item-stat');
+  await expect(stat.locator('.item-row', { hasText: 'Класс доспеха' })).toContainText('18');
+  await expect(stat.locator('.item-row', { hasText: 'Требование Силы' })).toContainText('Сила 15');
+  await expect(stat.locator('.item-row', { hasText: 'Скрытность' })).toContainText('помеха');
+});
+
+test('средний доспех: КД с модификатором Ловкости и капом', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/armor/breastplate/');
+  await expect(page.locator('.item-stat .item-row', { hasText: 'Класс доспеха' }))
+    .toContainText('14 + мод. Ловкости (макс. 2)');
+});
+
+test('щит: КД как бонус (+2 к КД)', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/armor/shield/');
+  await expect(page.locator('.ent-en')).toHaveText('Shield');
+  await expect(page.locator('.item-stat .item-row', { hasText: 'Класс доспеха' })).toContainText('+2 к КД');
+});
+
+test('канонический слаг: RU-доспех на англ. слаге, кириллического нет', async ({ page }) => {
+  const ok = await page.goto('/ru/dnd/srd-5.2/armor/plate-armor/');
+  expect(ok?.status()).toBe(200);
+  // «Латы» кириллицей
+  const cyr = await page.goto('/ru/dnd/srd-5.2/armor/%D0%BB%D0%B0%D1%82%D1%8B/');
+  expect(cyr?.status()).toBe(404);
+});
+
+test('SEO: hreflang-тройка, индексируема, в sitemap', async ({ page, request }) => {
+  const res = await page.goto('/en/dnd/srd-5.2/armor/plate-armor/');
+  expect(res?.status()).toBe(200);
+  await expect(page.locator('link[rel="alternate"][hreflang="en"]')).toHaveCount(1);
+  await expect(page.locator('link[rel="alternate"][hreflang="ru"]')).toHaveCount(1);
+  await expect(page.locator('link[rel="alternate"][hreflang="x-default"]')).toHaveCount(1);
+  await expect(page.locator('meta[name="robots"][content*="noindex"]')).toHaveCount(0);
+  const sm = await (await request.get('/sitemap-0.xml')).text();
+  expect(sm).toContain('/dnd/srd-5.2/armor/plate-armor/');
+});

--- a/web/e2e/weapons.spec.ts
+++ b/web/e2e/weapons.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+// Программные страницы оружия (issue #20, Дорожка A): /{lang}/dnd/{ver}/weapons/{slug}/.
+// Тонкий стат-блок (урон/свойства/мастерство/категория/вес/цена). RU получает канонический
+// (англ.) слаг + name_en через сверку стат-блоков EN↔RU в generate_api → общий слаг, hreflang.
+
+test('оружие: заголовок, EN-имя, категория, урон (тип переведён)', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/weapons/longsword/');
+  await expect(page.locator('.rd-doc h1')).toContainText('Длинный меч');
+  await expect(page.locator('.ent-en')).toHaveText('Longsword');
+  await expect(page.locator('.item-meta-line')).toContainText('Воинское оружие ближнего боя');
+  const stat = page.locator('.item-stat');
+  // Тип урона переведён на русский (в данных хранится «Slashing»).
+  await expect(stat.locator('.item-row', { hasText: 'Урон' })).toContainText('1d8 рубящий');
+  await expect(stat.locator('.item-row', { hasText: 'Мастерство' })).toContainText('Оглушение');
+});
+
+test('канонический слаг: RU-страница на англ. слаге, кириллического слага нет', async ({ page }) => {
+  // RU оружие теперь на /weapons/longsword/ (не /weapons/длинный-меч/).
+  const ok = await page.goto('/ru/dnd/srd-5.2/weapons/longsword/');
+  expect(ok?.status()).toBe(200);
+  const cyr = await page.goto('/ru/dnd/srd-5.2/weapons/%D0%B4%D0%BB%D0%B8%D0%BD%D0%BD%D1%8B%D0%B9-%D0%BC%D0%B5%D1%87/');
+  expect(cyr?.status()).toBe(404);
+});
+
+test('related: другое оружие той же категории и типа', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/weapons/longsword/');
+  const rel = page.locator('.ent-related');
+  await expect(rel).toContainText('Воинское оружие ближнего боя');
+  await expect(rel.locator('a[href*="/weapons/"]').first()).toBeVisible();
+});
+
+test('SEO: hreflang-тройка, индексируема, в sitemap', async ({ page, request }) => {
+  const res = await page.goto('/en/dnd/srd-5.2/weapons/longsword/');
+  expect(res?.status()).toBe(200);
+  await expect(page.locator('link[rel="alternate"][hreflang="en"]')).toHaveCount(1);
+  await expect(page.locator('link[rel="alternate"][hreflang="ru"]')).toHaveCount(1);
+  await expect(page.locator('link[rel="alternate"][hreflang="x-default"]')).toHaveCount(1);
+  await expect(page.locator('meta[name="robots"][content*="noindex"]')).toHaveCount(0);
+  const sm = await (await request.get('/sitemap-0.xml')).text();
+  expect(sm).toContain('/dnd/srd-5.2/weapons/longsword/');
+});

--- a/web/src/pages/[lang]/dnd/[version]/armor/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/armor/[slug].astro
@@ -1,0 +1,170 @@
+---
+import ReaderShell from '../../../../../components/ReaderShell.astro';
+import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
+
+// Programmatic-страницы доспехов (issue #20, Дорожка A) — тонкий стат-блок (данные табличные).
+// URL: /{lang}/dnd/{version}/armor/{slug}/. Своей главы нет — доспехи в «Снаряжении», туда и
+// ведёт навигация/upLink. RU получает канонический слаг + name_en (сверка стат-блоков) → hreflang.
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-equipment' };
+
+const CATEGORY: Record<string, [string, string]> = {
+  light: ['Лёгкий', 'Light'], medium: ['Средний', 'Medium'],
+  heavy: ['Тяжёлый', 'Heavy'], shield: ['Щит', 'Shield'],
+};
+
+interface Sib { slug: string; name: string; category: string }
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as const },
+    { ver: 'srd52', lang: 'ru' as const },
+  ];
+  const paths = [];
+  for (const { ver, lang } of BUILDS) {
+    const armor = loadEntities(ver, lang, 'armor');
+    const siblings: Sib[] = armor.map((a) => ({
+      slug: a.slug, name: a.name, category: (a.category as string) ?? '',
+    }));
+    for (const entity of armor) {
+      paths.push({
+        params: { lang, version: VERSION_SLUG[ver], slug: entity.slug },
+        props: { entity, ver, lang, siblings },
+      });
+    }
+  }
+  return paths;
+}
+
+const { entity, ver, lang, siblings } = Astro.props;
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+
+const category = (entity.category as string) ?? '';
+const isShield = category === 'shield';
+const acBase = entity.ac_base as number;
+const acDexBonus = entity.ac_dex_bonus === true;
+const acMaxDex = entity.ac_max_dex as number | null;
+const strengthReq = entity.strength_req as number | null;
+const stealthDis = entity.stealth_disadvantage === true;
+const weight = (entity.weight as string | null) ?? '';
+const cost = (entity.cost as string) ?? '';
+
+const catPair = CATEGORY[category];
+const catLabel = catPair ? (lang === 'ru' ? catPair[0] : catPair[1]) : category;
+
+// Строка КД: щит — бонус «+2 к КД»; доспех — база (+ мод. Ловкости, макс. для среднего).
+let acLine: string;
+if (isShield) {
+  acLine = t(`+${acBase} к КД`, `+${acBase} AC`);
+} else {
+  acLine = String(acBase);
+  if (acDexBonus) {
+    acLine += t(' + мод. Ловкости', ' + Dex modifier');
+    if (acMaxDex != null) acLine += t(` (макс. ${acMaxDex})`, ` (max ${acMaxDex})`);
+  }
+}
+
+// Подстрока в шапке: «Средний доспех» / «Medium armor»; для щита — просто «Щит»/«Shield».
+const subLine = isShield ? catLabel : t(`${catLabel} доспех`, `${catLabel} armor`);
+const description = isShield
+  ? t(`${entity.name} — щит, +${acBase} к КД. D&D ${verLabel}.`,
+      `${entity.name} — shield, +${acBase} AC. D&D ${verLabel}.`)
+  : t(`${entity.name} — ${catLabel.toLowerCase()} доспех, КД ${acLine}. D&D ${verLabel}.`,
+      `${entity.name} — ${catLabel.toLowerCase()} armor, AC ${acLine}. D&D ${verLabel}.`);
+
+const base = `/${lang}/dnd/${verSlug}/armor`;
+// «Похожие доспехи» — до 8 той же категории (внутренняя перелинковка/SEO).
+const similar = (siblings as Sib[])
+  .filter((s) => s.slug !== entity.slug && s.category === category)
+  .slice(0, 8);
+
+const upLink = { href: `/${lang}/dnd/${verSlug}/equipment/`, ru: 'Снаряжение', en: 'Equipment' };
+const kind = isShield ? t('Щит', 'Shield') : t('Доспех', 'Armor');
+const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel} ${kind}`)} · OmnisGM Rules`;
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={entity.name}
+  description={description}
+  headings={[]}
+  upLink={upLink}
+>
+  <h1>
+    {entity.name}
+    <span class="ent-head-sub">
+      {lang === 'ru' && entity.name_en && <span class="ent-en">{entity.name_en}</span>}
+      <span class="item-meta-line">{subLine}</span>
+    </span>
+  </h1>
+
+  <dl class="item-stat">
+    <div class="item-row"><dt>{t('Класс доспеха', 'Armor Class')}</dt><dd>{acLine}</dd></div>
+    <div class="item-row"><dt>{t('Категория', 'Category')}</dt>
+      <dd>{isShield ? catLabel : t(`${catLabel} доспех`, `${catLabel} armor`)}</dd></div>
+    {strengthReq != null && (
+      <div class="item-row"><dt>{t('Требование Силы', 'Strength')}</dt><dd>{t(`Сила ${strengthReq}`, `Str ${strengthReq}`)}</dd></div>
+    )}
+    {stealthDis && (
+      <div class="item-row"><dt>{t('Скрытность', 'Stealth')}</dt><dd>{t('помеха', 'Disadvantage')}</dd></div>
+    )}
+    {weight && (
+      <div class="item-row"><dt>{t('Вес', 'Weight')}</dt><dd>{weight}</dd></div>
+    )}
+    {cost && (
+      <div class="item-row"><dt>{t('Цена', 'Cost')}</dt><dd>{cost}</dd></div>
+    )}
+  </dl>
+
+  {similar.length > 0 && (
+    <nav class="ent-related" aria-label={t('Похожие доспехи', 'Similar armor')}>
+      <span class="ent-related-h">{isShield ? t('Ещё доспехи', 'More armor') : t(`Ещё: ${catLabel} доспех`, `More ${catLabel} armor`)}</span>
+      <span class="ent-related-list">
+        {similar.map((r) => (
+          <a href={`${base}/${r.slug}/`}><strong>{r.name}</strong></a>
+        ))}
+      </span>
+    </nav>
+  )}
+</ReaderShell>
+
+<style>
+  .ent-head-sub {
+    display: block; margin-top: 8px;
+    font-family: var(--font-body); font-weight: 400; letter-spacing: 0;
+  }
+  .ent-en {
+    font-family: var(--font-mono); font-size: 14px; font-weight: 400; letter-spacing: 0;
+    color: var(--og-text-muted);
+  }
+  .item-meta-line { font-style: italic; font-size: 14px; color: var(--og-text-muted); }
+  .ent-en + .item-meta-line::before { content: ' · '; font-style: normal; }
+
+  .item-stat {
+    margin: 0 0 24px; padding: 14px 16px; border: 1px solid var(--og-border); border-radius: 10px;
+    background: var(--og-bg-2); display: grid; gap: 8px;
+  }
+  .item-row { display: grid; grid-template-columns: 160px 1fr; gap: 12px; align-items: baseline; }
+  .item-row dt {
+    font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.6px; text-transform: uppercase;
+    color: var(--og-text-muted); font-weight: 600;
+  }
+  .item-row dd { margin: 0; color: var(--og-text-2); }
+
+  .ent-related { display: block; margin-top: 40px; padding-top: 20px; border-top: 1px solid var(--og-border); }
+  .ent-related-h {
+    display: block; font-size: 13px; text-transform: uppercase; letter-spacing: 1px;
+    color: var(--og-text-muted); margin-bottom: 10px;
+  }
+  .ent-related-list { display: flex; flex-wrap: wrap; gap: 6px 14px; }
+
+  @media (max-width: 560px) {
+    .item-row { display: block; }
+    .item-row dt { display: inline; }
+    .item-row dt::after { content: ':\00a0'; }
+    .item-row dd { display: inline; }
+  }
+</style>

--- a/web/src/pages/[lang]/dnd/[version]/weapons/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/weapons/[slug].astro
@@ -1,0 +1,182 @@
+---
+import ReaderShell from '../../../../../components/ReaderShell.astro';
+import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
+
+// Programmatic-страницы оружия (issue #20, Дорожка A) — тонкий стат-блок (данные табличные,
+// описания нет). URL: /{lang}/dnd/{version}/weapons/{slug}/. Своей главы у оружия нет —
+// оно в главе «Снаряжение», поэтому родитель навигации и upLink ведут туда.
+// RU получает канонический (англ.) слаг + name_en через сверку стат-блоков в generate_api →
+// EN и RU делят слаг → корректный hreflang.
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-equipment' };
+
+const CATEGORY: Record<string, [string, string]> = {
+  simple: ['Простое', 'Simple'], martial: ['Воинское', 'Martial'],
+};
+const WTYPE: Record<string, [string, string]> = {
+  melee: ['ближнего боя', 'Melee'], ranged: ['дальнобойное', 'Ranged'],
+};
+// Тип урона в данных хранится по-английски (обе локали) — переводим для показа.
+const DMG: Record<string, [string, string]> = {
+  Bludgeoning: ['дробящий', 'Bludgeoning'], Piercing: ['колющий', 'Piercing'],
+  Slashing: ['рубящий', 'Slashing'],
+};
+
+interface Sib { slug: string; name: string; category: string; type: string }
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as const },
+    { ver: 'srd52', lang: 'ru' as const },
+  ];
+  const paths = [];
+  for (const { ver, lang } of BUILDS) {
+    const weapons = loadEntities(ver, lang, 'weapons');
+    const siblings: Sib[] = weapons.map((w) => ({
+      slug: w.slug, name: w.name,
+      category: (w.category as string) ?? '', type: (w.type as string) ?? '',
+    }));
+    for (const entity of weapons) {
+      paths.push({
+        params: { lang, version: VERSION_SLUG[ver], slug: entity.slug },
+        props: { entity, ver, lang, siblings },
+      });
+    }
+  }
+  return paths;
+}
+
+const { entity, ver, lang, siblings } = Astro.props;
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+const loc = (map: Record<string, [string, string]>, key: string) => {
+  const p = map[key];
+  return p ? (lang === 'ru' ? p[0] : p[1]) : key;
+};
+
+const category = (entity.category as string) ?? '';
+const wtype = (entity.type as string) ?? '';
+const damageDice = (entity.damage_dice as string) ?? '';
+const damageType = (entity.damage_type as string) ?? '';
+const properties = Array.isArray(entity.properties) ? (entity.properties as string[]) : [];
+const mastery = (entity.mastery as string | null) ?? '';
+const rangeN = entity.range_normal as number | null;
+const rangeL = entity.range_long as number | null;
+const weight = (entity.weight as string | null) ?? '';
+const cost = (entity.cost as string) ?? '';
+
+const catLabel = loc(CATEGORY, category);
+const typeLabel = loc(WTYPE, wtype);
+const dmgLabel = damageType ? loc(DMG, damageType) : '';
+const damageLine = [damageDice, dmgLabel].filter(Boolean).join(' ');
+const rangeLine = rangeN ? `${rangeN}${rangeL ? `/${rangeL}` : ''} ${t('фт', 'ft')}` : '';
+
+// Подстрока в шапке: «Воинское оружие ближнего боя» / «Martial melee weapon».
+const subLine = t(
+  `${catLabel} оружие ${typeLabel}`,
+  `${catLabel} ${typeLabel.toLowerCase()} weapon`,
+);
+const description = t(
+  `${entity.name} — ${catLabel.toLowerCase()} оружие ${typeLabel}, урон ${damageLine}. D&D ${verLabel}.`,
+  `${entity.name} — ${catLabel.toLowerCase()} ${typeLabel.toLowerCase()} weapon, ${damageLine} damage. D&D ${verLabel}.`,
+);
+
+const base = `/${lang}/dnd/${verSlug}/weapons`;
+// «Похожее оружие» — до 8 той же категории и типа (внутренняя перелинковка/SEO).
+const similar = (siblings as Sib[])
+  .filter((s) => s.slug !== entity.slug && s.category === category && s.type === wtype)
+  .slice(0, 8);
+
+const upLink = { href: `/${lang}/dnd/${verSlug}/equipment/`, ru: 'Снаряжение', en: 'Equipment' };
+const kind = t('Оружие', 'Weapon');
+const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel} ${kind}`)} · OmnisGM Rules`;
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={entity.name}
+  description={description}
+  headings={[]}
+  upLink={upLink}
+>
+  <h1>
+    {entity.name}
+    <span class="ent-head-sub">
+      {lang === 'ru' && entity.name_en && <span class="ent-en">{entity.name_en}</span>}
+      <span class="item-meta-line">{subLine}</span>
+    </span>
+  </h1>
+
+  <dl class="item-stat">
+    {damageLine && (
+      <div class="item-row"><dt>{t('Урон', 'Damage')}</dt><dd>{damageLine}</dd></div>
+    )}
+    {properties.length > 0 && (
+      <div class="item-row"><dt>{t('Свойства', 'Properties')}</dt><dd>{properties.join(', ')}</dd></div>
+    )}
+    {mastery && (
+      <div class="item-row"><dt>{t('Мастерство', 'Mastery')}</dt><dd>{mastery}</dd></div>
+    )}
+    {rangeLine && (
+      <div class="item-row"><dt>{t('Дистанция', 'Range')}</dt><dd>{rangeLine}</dd></div>
+    )}
+    <div class="item-row"><dt>{t('Категория', 'Category')}</dt><dd>{t(`${catLabel} оружие ${typeLabel}`, `${catLabel} ${typeLabel} weapon`)}</dd></div>
+    {weight && (
+      <div class="item-row"><dt>{t('Вес', 'Weight')}</dt><dd>{weight}</dd></div>
+    )}
+    {cost && (
+      <div class="item-row"><dt>{t('Цена', 'Cost')}</dt><dd>{cost}</dd></div>
+    )}
+  </dl>
+
+  {similar.length > 0 && (
+    <nav class="ent-related" aria-label={t('Похожее оружие', 'Similar weapons')}>
+      <span class="ent-related-h">{t(`Ещё: ${catLabel} оружие ${typeLabel}`, `More ${catLabel} ${typeLabel} weapons`)}</span>
+      <span class="ent-related-list">
+        {similar.map((r) => (
+          <a href={`${base}/${r.slug}/`}><strong>{r.name}</strong></a>
+        ))}
+      </span>
+    </nav>
+  )}
+</ReaderShell>
+
+<style>
+  .ent-head-sub {
+    display: block; margin-top: 8px;
+    font-family: var(--font-body); font-weight: 400; letter-spacing: 0;
+  }
+  .ent-en {
+    font-family: var(--font-mono); font-size: 14px; font-weight: 400; letter-spacing: 0;
+    color: var(--og-text-muted);
+  }
+  .item-meta-line { font-style: italic; font-size: 14px; color: var(--og-text-muted); }
+  .ent-en + .item-meta-line::before { content: ' · '; font-style: normal; }
+
+  .item-stat {
+    margin: 0 0 24px; padding: 14px 16px; border: 1px solid var(--og-border); border-radius: 10px;
+    background: var(--og-bg-2); display: grid; gap: 8px;
+  }
+  .item-row { display: grid; grid-template-columns: 160px 1fr; gap: 12px; align-items: baseline; }
+  .item-row dt {
+    font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.6px; text-transform: uppercase;
+    color: var(--og-text-muted); font-weight: 600;
+  }
+  .item-row dd { margin: 0; color: var(--og-text-2); }
+
+  .ent-related { display: block; margin-top: 40px; padding-top: 20px; border-top: 1px solid var(--og-border); }
+  .ent-related-h {
+    display: block; font-size: 13px; text-transform: uppercase; letter-spacing: 1px;
+    color: var(--og-text-muted); margin-bottom: 10px;
+  }
+  .ent-related-list { display: flex; flex-wrap: wrap; gap: 6px 14px; }
+
+  @media (max-width: 560px) {
+    .item-row { display: block; }
+    .item-row dt { display: inline; }
+    .item-row dt::after { content: ':\00a0'; }
+    .item-row dd { display: inline; }
+  }
+</style>


### PR DESCRIPTION
Финальный шаг **Дорожки A**: программные страницы для **38 видов оружия + 13 доспехов** SRD 5.2 (×2 языка = **102 страницы**).

## Страницы
- Тонкий стат-блок (данные табличные, описания у оружия/доспехов нет).
- **Оружие**: урон (тип переведён), свойства, мастерство, дистанция, категория, вес, цена. Related «та же категория+тип».
- **Доспехи**: КД (база + мод. Ловкости с капом; у щита — бонус `+2 к КД`), требование Силы, скрытность, категория, вес, цена. Related «та же категория».
- URL `/{lang}/dnd/{ver}/weapons|armor/{slug}/`. Своей главы нет (оружие/доспехи внутри «Снаряжения») → навигация и upLink ведут в главу снаряжения.

## Слаг-фикс (блокер) — `align_stat_table_name_en` в generate_api
RU оружие/доспехи парсились из **ячеек таблиц** (не заголовков со скобкой «(English)»), а таблицы отсортированы по алфавиту **каждого языка отдельно** → позиционная сверка EN↔RU неверна, слаги выходили **кириллицей** с `name_en=None` (hreflang не спаривался).

**Решение:** сверяем RU→EN по языко-инвариantному «отпечатку» стат-блока (категория/урон/вес/цена-число/…). Механически-идентичные пары (Glaive/Halberd — один отпечаток) разводим по мастерству — двухпроходно: 1-й проход учит карту «RU-мастерство→EN» на однозначных строках (Greatsword→Graze, Greataxe→Cleave), 2-й разрешает коллизии.

Результат: **идеальная биекция 38/38 + 13/13**, канонические слаги (Глефа→`glaive`, Алебарда→`halberd`, Латы→`plate-armor`), общий EN/RU слаг → корректный hreflang.

## Проверки
- Сборка: **2456 страниц** (+102).
- e2e: `weapons.spec.ts` (4) + `armor.spec.ts` (5) — шапка/EN-имя/стат-блок, перевод типа урона, КД-логика (dex-кап/щит), related, SEO, **проверка канонического слага** (RU на англ. слаге; кириллический слаг → 404).
- **Полный прогон: 82 passed.**

С этим PR **Дорожка A закрыта полностью** (все ресурсы с API имеют страницы).

🤖 Generated with [Claude Code](https://claude.com/claude-code)