### PR TITLE
feat(rules): автолинк + hovercard для оружия/доспехов/снаряжения #20

### DIFF
--- a/web/e2e/autolink.spec.ts
+++ b/web/e2e/autolink.spec.ts
@@ -11,7 +11,7 @@ test('глава: автоссылки ведут на страницы сущн
   expect(await links.count()).toBeGreaterThan(0);
   // Все ent-link ведут на программную страницу сущности: состояние / заклинание / монстр.
   for (const href of await links.evaluateAll((els) => els.map((e) => e.getAttribute('href')))) {
-    expect(href).toMatch(/\/(rules-glossary\/conditions|spells|monsters-a-z|animals|magic-items|equipment|feats)\/[a-z0-9-]+\/$/);
+    expect(href).toMatch(/\/(rules-glossary\/conditions|spells|monsters-a-z|animals|magic-items|equipment|weapons|armor|feats)\/[a-z0-9-]+\/$/);
   }
 });
 
@@ -77,6 +77,33 @@ test('животные EN: множественная жирная форма л
   await expect(
     page.locator('.rd-doc strong a.ent-link[href$="/animals/giant-wasp/"]', { hasText: 'Giant Wasps' }).first(),
   ).toBeVisible();
+});
+
+test('снаряжение: ячейки таблиц главы линкуются на страницы оружия/доспехов/снаряжения + data-hc', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/equipment/');
+  // Оружие: ячейка «Секира» в таблице → /weapons/greataxe/.
+  const w = page.locator('.rd-doc td a.ent-link[href$="/weapons/greataxe/"]').first();
+  await expect(w).toBeVisible();
+  await expect(w).toHaveAttribute('data-hc', /weapons\/greataxe/);
+  // Доспех: «Латы» → /armor/plate-armor/.
+  await expect(page.locator('.rd-doc td a.ent-link[href$="/armor/plate-armor/"]').first()).toBeVisible();
+  // Снаряжение: «Кислота» → /equipment/acid/.
+  await expect(page.locator('.rd-doc td a.ent-link[href$="/equipment/acid/"]').first()).toBeVisible();
+});
+
+test('снаряжение: имя-омоним в чужой таблице НЕ линкуется (вариант «Кнут» у Жетона пера)', async ({ page }) => {
+  // Таблица вариантов Жетона пера не размечена как перечень снаряжения (нет колонки «Цена») →
+  // ячейка «Кнут» не должна вести на страницу оружия whip.
+  await page.goto('/ru/dnd/srd-5.2/magic-items/feather-token/');
+  await expect(page.locator('.rd-doc a.ent-link[href*="/weapons/whip/"]')).toHaveCount(0);
+});
+
+test('hovercard-эндпоинт: есть карточки оружия/доспехов/снаряжения (name_en + мета)', async ({ request }) => {
+  const ru = await (await request.get('/hc/dnd/srd52/ru.json')).json();
+  expect(ru['weapons/greataxe']?.name_en).toBe('Greataxe');
+  expect(ru['weapons/greataxe']?.effect).toContain('рубящий');
+  expect(ru['armor/plate-armor']?.name_en).toBe('Plate Armor');
+  expect(ru['equipment/acid']?.name_en).toBe('Acid');
 });
 
 test('предметы: имя в курсиве линкуется на страницу предмета', async ({ page }) => {

--- a/web/src/lib/rehype-entity-autolink.mjs
+++ b/web/src/lib/rehype-entity-autolink.mjs
@@ -38,6 +38,13 @@ const RESOURCES = [
   // эпические дары «Дар …», «Посвящённый в магию»…) — они дистинктивны; одно-словные в прозе
   // не трогаем.
   { key: 'feats', urlParent: 'feats', mode: 'feats', versions: ['srd-5.2'] },
+  // Оружие/доспехи/снаряжение: имена не размечены (ни курсив, ни жирный) и часто омонимичны
+  // обычным словам («Молот», «Щит», «Верёвка»). Поэтому режим 'cells' — линкуем ТОЛЬКО ячейку
+  // таблицы, точно равную имени (таблицы главы «Снаряжение» → детальные страницы). Прозу не
+  // трогаем вовсе. Точное совпадение ячейки → 0 ложных срабатываний.
+  { key: 'weapons', urlParent: 'weapons', mode: 'cells', versions: ['srd-5.2'] },
+  { key: 'armor', urlParent: 'armor', mode: 'cells', versions: ['srd-5.2'] },
+  { key: 'equipment', urlParent: 'equipment', mode: 'cells', versions: ['srd-5.2'] },
 ];
 
 // Заголовок первой колонки таблицы спелл-листа класса (по языку) — сигнал линковать её ячейки.
@@ -126,6 +133,12 @@ function loadMap(game, version, lang) {
   const exact = { em: new Map(), strong: new Map() };
   // Черты: exact-карта «имя → сущность» (lowercase) для точечного матча ячеек таблиц.
   const feats = new Map();
+  // Оружие/доспехи/снаряжение: карта «имя → сущность» для матча точных ячеек таблиц.
+  const cells = new Map();
+  // Имена magic-items/monsters — зарезервированы: их не линкуем как cells (редкие кросс-ресурс
+  // коллизии: «Свиток заклинания» = equipment+magic-item, «Страж-щит» = magic-item+monster).
+  // magic-items/monsters идут в RESOURCES раньше оружия → к моменту cells набор полон.
+  const reserved = new Set();
   for (const { key, urlParent, mode, container, versions } of RESOURCES) {
     if (versions && !versions.includes(version)) continue;
     const file = path.join(DATA_ROOT, game, verKey, lang, key, 'all.json');
@@ -156,10 +169,14 @@ function loadMap(game, version, lang) {
         if (!feats.has(k)) feats.set(k, entry);
         // Проза — только много-словные (дистинктивные) имена; одно-словные омонимичны.
         if (e.name.trim().split(/\s+/).length >= 2) textEntries.push(entry);
+      } else if (mode === 'cells') {
+        const k = e.name.toLowerCase();
+        if (!reserved.has(k) && !cells.has(k)) cells.set(k, entry);
       } else {
         textEntries.push(entry);
         for (const alias of aliases[e.slug] || []) textEntries.push({ ...entry, name: alias });
       }
+      if (key === 'magic-items' || key === 'monsters') reserved.add(e.name.toLowerCase());
     }
   }
   let text = null;
@@ -170,7 +187,8 @@ function loadMap(game, version, lang) {
     const alt = textEntries.map((e) => escapeRegExp(e.name)).join('|');
     text = { regexSource: `(?<![\\p{L}\\p{N}_])(${alt})(?![\\p{L}\\p{N}_])`, byName };
   }
-  const result = text || exact.em.size || exact.strong.size || feats.size ? { text, exact, feats, verKey } : null;
+  const result = text || exact.em.size || exact.strong.size || feats.size || cells.size
+    ? { text, exact, feats, cells, verKey } : null;
   mapCache.set(cacheKey, result);
   return result;
 }
@@ -277,6 +295,34 @@ export function autolinkTree(tree, { game, version, lang, selfSlug }) {
     }
   };
 
+  // Таблица-перечень снаряжения: последняя колонка — Цена/Cost/Стоимость (так размечены
+  // таблицы оружия/доспехов/снаряжения в главе). Гейт нужен, чтобы не линковать ячейки в чужих
+  // таблицах, где имя совпадает случайно (напр. вариант «Кнут» у Жетона пера — там нет колонки
+  // цены), — как isSpellTable для спелл-листов.
+  const isEquipmentListing = (table) => {
+    const rows = [];
+    collectRows(table, rows);
+    if (!rows.length) return false;
+    const hcells = rows[0].children.filter((c) => c.type === 'element' && (c.tagName === 'th' || c.tagName === 'td'));
+    const last = hcells.length ? directText(hcells[hcells.length - 1]) : null;
+    return last != null && /^(Цена|Cost|Стоимость)/.test(last.trim());
+  };
+
+  // Оружие/доспехи/снаряжение: ПЕРВАЯ колонка (имя) каждой строки-данных, точно равная имени
+  // сущности → детальная страница. Точное совпадение ячейки → безопасно даже для «Молот»/«Щит».
+  const linkNameCells = (table) => {
+    const rows = [];
+    collectRows(table, rows);
+    for (const tr of rows) {
+      const cell = tr.children.find((c) => c.type === 'element' && c.tagName === 'td'); // только данные (не th)
+      if (!cell) continue;
+      const txt = directText(cell);
+      if (txt == null) continue;
+      const entry = map.cells.get(txt.trim().toLowerCase());
+      if (entry && !skip.has(entry.slug)) cell.children = [linkNode(entry, txt.trim(), ctx)];
+    }
+  };
+
   const walk = (node, insideSkip) => {
     if (!node.children) return;
     for (let i = 0; i < node.children.length; i++) {
@@ -287,6 +333,8 @@ export function autolinkTree(tree, { game, version, lang, selfSlug }) {
         if (tag === 'table' && map.exact.em.size && isSpellTable(child)) linkSpellTable(child);
         // Черты в ячейках любых таблиц (таблицы прогрессии классов и т.п.).
         if (tag === 'table' && map.feats && map.feats.size) linkFeatCells(child);
+        // Оружие/доспехи/снаряжение — первая колонка таблиц-перечней (глава «Снаряжение»).
+        if (tag === 'table' && map.cells && map.cells.size && isEquipmentListing(child)) linkNameCells(child);
         // Курсивная ссылка на заклинание <em>Имя</em> / жирная на монстра <strong>Имя</strong> —
         // полный текст элемента = имя. Внутрь уже-ссылки не идём.
         if (!insideSkip && (tag === 'em' || tag === 'strong')) {

--- a/web/src/pages/hc/[game]/[ver]/[lang].json.ts
+++ b/web/src/pages/hc/[game]/[ver]/[lang].json.ts
@@ -102,6 +102,69 @@ function itemHtml(e: Record<string, unknown>, lang: string): string {
   );
 }
 
+// ── Оружие: «категория оружие тип» + урон (тип переведён) · мастерство · цена.
+const W_CAT: Record<string, [string, string]> = { simple: ['простое', 'simple'], martial: ['воинское', 'martial'] };
+const W_TYPE: Record<string, [string, string]> = { melee: ['ближнего боя', 'melee'], ranged: ['дальнобойное', 'ranged'] };
+const W_DMG: Record<string, [string, string]> = {
+  Bludgeoning: ['дробящий', 'bludgeoning'], Piercing: ['колющий', 'piercing'], Slashing: ['рубящий', 'slashing'],
+};
+const pick = (map: Record<string, [string, string]>, k: string, lang: string) => {
+  const p = map[k];
+  return p ? (lang === 'ru' ? p[0] : p[1]) : k;
+};
+function weaponHtml(e: Record<string, unknown>, lang: string): string {
+  const cat = pick(W_CAT, (e.category as string) ?? '', lang);
+  const typ = pick(W_TYPE, (e.type as string) ?? '', lang);
+  const sub = lang === 'ru' ? `${cat} оружие ${typ}` : `${cat} ${typ} weapon`;
+  const dt = e.damage_type ? pick(W_DMG, e.damage_type as string, lang) : '';
+  const dmg = [e.damage_dice as string, dt].filter(Boolean).join(' ');
+  const meta = [dmg, e.mastery as string, e.cost as string].filter(Boolean).join(' · ');
+  return (
+    `<p class="hc-sub">${escapeHtml(sub)}</p>` +
+    (meta ? `<p class="hc-meta">${escapeHtml(meta)}</p>` : '')
+  );
+}
+
+// ── Доспехи: категория + КД (у щита бонус) · требование Силы · цена.
+const A_CAT: Record<string, [string, string]> = {
+  light: ['лёгкий доспех', 'light armor'], medium: ['средний доспех', 'medium armor'],
+  heavy: ['тяжёлый доспех', 'heavy armor'], shield: ['щит', 'shield'],
+};
+function armorHtml(e: Record<string, unknown>, lang: string): string {
+  const cat = pick(A_CAT, (e.category as string) ?? '', lang);
+  const acBase = e.ac_base as number;
+  let ac: string;
+  if (e.category === 'shield') {
+    ac = lang === 'ru' ? `+${acBase} к КД` : `+${acBase} AC`;
+  } else {
+    ac = `${lang === 'ru' ? 'КД' : 'AC'} ${acBase}`;
+    if (e.ac_dex_bonus === true) {
+      ac += lang === 'ru' ? ' + Лов' : ' + Dex';
+      if (e.ac_max_dex != null) ac += ` (${lang === 'ru' ? 'макс' : 'max'} ${e.ac_max_dex})`;
+    }
+  }
+  const str = e.strength_req != null ? (lang === 'ru' ? `Сила ${e.strength_req}` : `Str ${e.strength_req}`) : '';
+  const meta = [ac, str, e.cost as string].filter(Boolean).join(' · ');
+  return (
+    `<p class="hc-sub">${escapeHtml(cat)}</p>` +
+    (meta ? `<p class="hc-meta">${escapeHtml(meta)}</p>` : '')
+  );
+}
+
+// ── Снаряжение: категория · стоимость + короткая выдержка описания.
+const E_SECTION: Record<string, [string, string]> = {
+  adventuring_gear: ['снаряжение', 'adventuring gear'], tools: ['инструменты', 'tools'],
+};
+function equipHtml(e: Record<string, unknown>, lang: string): string {
+  const sec = pick(E_SECTION, (e.section as string) ?? '', lang);
+  const sub = [sec, e.cost as string].filter(Boolean).join(' · ');
+  const ex = excerpt(e.description_md as string | undefined, 190);
+  return (
+    (sub ? `<p class="hc-sub">${escapeHtml(sub)}</p>` : '') +
+    (ex ? `<p>${escapeHtml(ex)}</p>` : '')
+  );
+}
+
 // resource → { urlParent, build(entity) → HTML тела карточки }.
 const RESOURCES: { key: string; urlParent: string; body: (e: Record<string, unknown>, lang: string) => string }[] = [
   { key: 'conditions', urlParent: 'rules-glossary/conditions', body: (e) => conditionHtml(e.description_md as string) },
@@ -110,6 +173,9 @@ const RESOURCES: { key: string; urlParent: string; body: (e: Record<string, unkn
   // Животные — тот же стат-блок, что и монстры → та же карточка (тип/мировоззрение + КД·хиты·ПО).
   { key: 'animals', urlParent: 'animals', body: (e, lang) => monsterHtml(e, lang) },
   { key: 'magic-items', urlParent: 'magic-items', body: (e, lang) => itemHtml(e, lang) },
+  { key: 'weapons', urlParent: 'weapons', body: (e, lang) => weaponHtml(e, lang) },
+  { key: 'armor', urlParent: 'armor', body: (e, lang) => armorHtml(e, lang) },
+  { key: 'equipment', urlParent: 'equipment', body: (e, lang) => equipHtml(e, lang) },
 ];
 
 // Согласовано со сборкой страниц сущностей: пока только srd52 (en/ru).


### PR DESCRIPTION
Закрывает оставшиеся ⏸ по Дорожке A/B: **автолинк + hovercard** для оружия/доспехов/снаряжения.

## Задача и риск
У этих имён **нет разметки SRD** (ни курсив, как у предметов, ни жирный, как у монстров), и многие омонимичны обычным словам («Молот», «Щит», «Верёвка», «Копьё»). Автолинк по прозе → массовые ложные ссылки.

## Безопасный дизайн — режим `cells`
Линкуем **только первую колонку таблицы-перечня** (последняя колонка = `Цена/Cost/Стоимость`), точно равную имени сущности. Это таблицы оружия/доспехов/снаряжения в главе «Снаряжение» → детальные страницы. Точный матч ячейки + гейт по заголовку = 0 ложных срабатываний.

- **Прозу не трогаем** (класс. «Начальное снаряжение: …Секира, 4 топора…» — не точная ячейка → не линкуется).
- **Гейт по заголовку** исключает омонимы в чужих таблицах: вариант «Кнут» (Whip) у Жетона пера — там нет колонки цены → не линкуется на оружие.
- **Кросс-ресурс коллизии** зарезервированы: «Свиток заклинания» (equipment+magic-item), «Страж-щит» (magic-item+monster) не линкуются как cells.

## Результат
- **38 оружия + 13 доспехов + 80 снаряжения** ссылок в главе (SEO: глава → 131 детальная страница), **0 ложных** вне главы.
- **Hovercard-карточки**: оружие (`воинское оружие ближнего боя · 1d12 рубящий · Рассечение · 30 зм`), доспехи (`тяжёлый доспех · КД 18 · Сила 15 · 1500 зм`), снаряжение (`снаряжение · 25 зм` + выдержка).

## Проверки
- Сборка 2456 страниц; подтверждено в dist: 131 ссылка в главе, 0 вне.
- e2e: +3 теста (ячейки→страницы + data-hc; омоним «Кнут» НЕ линкуется; HC-карточки). **Полный прогон: 85 passed.**

Матрица #20: weapons/armor/equipment Autolink + HC → ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)