### PR TITLE
feat(rules): hovercard-подсказки для свойств и мастерств оружия #20

### DIFF
--- a/.github/scripts/config.py
+++ b/.github/scripts/config.py
@@ -11,6 +11,8 @@ SOURCES = [
     {"ver": "srd52", "lang": "ru", "type": "equipment",   "file": "srd-5.2/ru/06_Equipment.md",    "h": 4, "after": "## Инструменты"},
     {"ver": "srd52", "lang": "ru", "type": "condition",   "file": "srd-5.2/ru/08_RulesGlossary.md","h": 4},
     {"ver": "srd52", "lang": "ru", "type": "feat",        "file": "srd-5.2/ru/05_Feats.md",        "h": 4, "after": "## Описания черт"},
+    {"ver": "srd52", "lang": "ru", "type": "glossary_defs","file": "srd-5.2/ru/06_Equipment.md",   "section": "Свойства",         "out": "weapon-properties"},
+    {"ver": "srd52", "lang": "ru", "type": "glossary_defs","file": "srd-5.2/ru/06_Equipment.md",   "section": "Свойства мастерства", "out": "masteries"},
     # SRD 5.2 EN
     {"ver": "srd52", "lang": "en", "type": "spell",      "file": "srd-5.2/en/07_Spells.md",       "h": 3},
     {"ver": "srd52", "lang": "en", "type": "monster",     "file": "srd-5.2/en/12_MonstersA-Z.md",  "h": 3},
@@ -21,6 +23,8 @@ SOURCES = [
     {"ver": "srd52", "lang": "en", "type": "equipment",   "file": "srd-5.2/en/06_Equipment.md",    "h": 4, "after": "## Tools"},
     {"ver": "srd52", "lang": "en", "type": "condition",   "file": "srd-5.2/en/08_RulesGlossary.md","h": 4},
     {"ver": "srd52", "lang": "en", "type": "feat",        "file": "srd-5.2/en/05_Feats.md",        "h": 4, "after": "## Feat Descriptions"},
+    {"ver": "srd52", "lang": "en", "type": "glossary_defs","file": "srd-5.2/en/06_Equipment.md",   "section": "Properties",          "out": "weapon-properties"},
+    {"ver": "srd52", "lang": "en", "type": "glossary_defs","file": "srd-5.2/en/06_Equipment.md",   "section": "Mastery Properties",  "out": "masteries"},
     # SRD 5.1 RU
     {"ver": "srd51", "lang": "ru", "type": "spell",      "file": "srd-5.1/ru/10_Spells.md",       "h": 3},
     {"ver": "srd51", "lang": "ru", "type": "monster",     "file": "srd-5.1/ru/15_MonstersA-Z.md",  "h": 3},

--- a/.github/scripts/generate_api.py
+++ b/.github/scripts/generate_api.py
@@ -26,7 +26,7 @@ from config import (SOURCES, SKIP_HEADINGS_SPELL, SKIP_HEADINGS_MONSTER,
                     SKIP_HEADINGS_EQUIPMENT, SKIP_HEADINGS_FEAT)
 from parsers import (parse_spells, parse_monsters, parse_magic_items,
                      parse_weapons, parse_armor, parse_equipment,
-                     parse_conditions, parse_feats)
+                     parse_conditions, parse_feats, parse_defs)
 from parsers.base import slugify
 from schemas import RESOURCE_SCHEMAS
 
@@ -153,6 +153,26 @@ def align_stat_table_name_en(all_data: dict) -> None:
             else:
                 print(f"  Warning: не найден EN-аналог для RU {resource} "
                       f"{r.get('name')!r}", file=sys.stderr)
+
+
+def align_positional_name_en(all_data: dict, resources: tuple[str, ...]) -> None:
+    """RU-определениям (свойства/мастерства оружия) — name_en + канонический слаг по позиции.
+
+    Порядок определений в EN и RU одинаков (построчный паритет главы), поэтому RU[i] ↔ EN[i].
+    """
+    for (ver, lang, resource), ru_entities in list(all_data.items()):
+        if lang != "ru" or resource not in resources:
+            continue
+        en_entities = all_data.get((ver, "en", resource))
+        if not en_entities:
+            continue
+        if len(en_entities) != len(ru_entities):
+            print(f"  Warning: {resource} EN/RU count mismatch "
+                  f"({len(en_entities)}/{len(ru_entities)}) — name_en не выровнен", file=sys.stderr)
+            continue
+        for r, e in zip(ru_entities, en_entities):
+            r["name_en"] = e["name"]
+            r["slug"] = e["slug"]
 
 
 def resolve_cross_refs(all_data: dict) -> None:
@@ -397,7 +417,7 @@ def main():
         lang = source["lang"]
         entity_type = source["type"]
         filepath = src_root / source["file"]
-        heading_level = source["h"]
+        heading_level = source.get("h", 0)
         after = source.get("after")
         out_resource = source.get("out")
 
@@ -433,6 +453,9 @@ def main():
         elif entity_type == "feat":
             entities = parse_feats(text, heading_level, lang, after, SKIP_HEADINGS_FEAT)
             resource = "feats"
+        elif entity_type == "glossary_defs":
+            entities = parse_defs(text, source["section"])
+            resource = out_resource
         else:
             print(f"  Warning: unknown type '{entity_type}', skipping", file=sys.stderr)
             continue
@@ -449,6 +472,8 @@ def main():
 
     # RU-оружию/доспехам — name_en + канонический слаг (сверка стат-блоков EN↔RU).
     align_stat_table_name_en(all_data)
+    # RU-свойствам/мастерствам оружия — name_en по позиции (порядок определений = EN).
+    align_positional_name_en(all_data, ("weapon-properties", "masteries"))
 
     # Resolve cross-references
     resolve_cross_refs(all_data)

--- a/.github/scripts/parsers/__init__.py
+++ b/.github/scripts/parsers/__init__.py
@@ -6,3 +6,4 @@ from .armor import parse_armor
 from .equipment import parse_equipment
 from .condition import parse_conditions
 from .feat import parse_feats
+from .glossary_defs import parse_defs

--- a/.github/scripts/parsers/glossary_defs.py
+++ b/.github/scripts/parsers/glossary_defs.py
@@ -1,0 +1,49 @@
+"""Parser for glossary-style definition sections (#### Name + body text).
+
+Используется для свойств оружия и свойств мастерства (глава «Снаряжение», секции
+«Properties»/«Свойства» и «Mastery Properties»/«Свойства мастерства»): каждое
+определение — заголовок #### и абзац(ы) под ним. Питает hovercard-подсказки.
+"""
+
+import re
+
+from .base import slugify
+
+
+def parse_defs(text: str, section: str) -> list[dict]:
+    """Собрать определения #### внутри секции ### {section}.
+
+    Возвращает [{slug, name, name_en, description_md}]. name_en=None — RU-выравнивание
+    (по позиции с EN) делается на уровне generate_api (порядок определений одинаков —
+    построчный паритет).
+    """
+    lines = text.split("\n")
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == f"### {section}":
+            start = i + 1
+            break
+    if start is None:
+        return []
+
+    body = []
+    for line in lines[start:]:
+        # Заголовок уровня 1–3 завершает секцию; #### (уровень 4) остаётся внутри.
+        if re.match(r"^#{1,3} \S", line):
+            break
+        body.append(line)
+
+    section_text = "\n".join(body)
+    # parts: [pre, name1, body1, name2, body2, …]
+    parts = re.split(r"^#### (.+)$", section_text, flags=re.M)
+    defs = []
+    for j in range(1, len(parts), 2):
+        name = parts[j].strip()
+        desc = parts[j + 1].strip() if j + 1 < len(parts) else ""
+        defs.append({
+            "slug": slugify(name),
+            "name": name,
+            "name_en": None,
+            "description_md": desc,
+        })
+    return defs

--- a/web/e2e/weapons.spec.ts
+++ b/web/e2e/weapons.spec.ts
@@ -23,6 +23,29 @@ test('канонический слаг: RU-страница на англ. сл
   expect(cyr?.status()).toBe(404);
 });
 
+test('свойства/мастерство — gloss-подсказки; при наведении всплывает определение', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/weapons/longsword/');
+  // Свойство «Универсальное» — gloss-спан с data-hc на weapon-properties (хвост «(1d10)» вне спана).
+  const prop = page.locator('.item-stat .gloss[data-hc*="weapon-properties/versatile"]', { hasText: 'Универсальное' });
+  await expect(prop).toBeVisible();
+  // Мастерство «Оглушение» → masteries.
+  const mastery = page.locator('.item-stat .gloss[data-hc*="masteries/sap"]', { hasText: 'Оглушение' });
+  await expect(mastery).toBeVisible();
+  // Наведение → hovercard с EN-именем и определением.
+  await prop.hover();
+  const card = page.locator('#ent-hovercard.is-open');
+  await expect(card).toBeVisible();
+  await expect(card.locator('.ent-hc-en')).toHaveText('Versatile');
+  await expect(card.locator('.ent-hc-body')).toContainText('одной или двумя руками');
+});
+
+test('hovercard-эндпоинт: есть карточки свойств и мастерств оружия', async ({ request }) => {
+  const ru = await (await request.get('/hc/dnd/srd52/ru.json')).json();
+  expect(ru['weapon-properties/finesse']?.name_en).toBe('Finesse');
+  expect(ru['weapon-properties/finesse']?.effect).toContain('Силы или Ловкости');
+  expect(ru['masteries/cleave']?.name_en).toBe('Cleave');
+});
+
 test('related: другое оружие той же категории и типа', async ({ page }) => {
   await page.goto('/ru/dnd/srd-5.2/weapons/longsword/');
   const rel = page.locator('.ent-related');

--- a/web/src/components/ReaderShell.astro
+++ b/web/src/components/ReaderShell.astro
@@ -673,15 +673,17 @@ const searchUi = {
     });
   };
 
+  // Цели hovercard: автоссылки (a.ent-link) и глоссарные термины без страницы (span.gloss).
+  const HC_SEL = 'a.ent-link[data-hc], .gloss[data-hc]';
   const onEnter = (e: Event) => {
     if ('pointerType' in e && (e as PointerEvent).pointerType === 'touch') return; // тач — навигация тапом
-    const a = (e.target as Element)?.closest?.('a.ent-link[data-hc]') as HTMLElement | null;
+    const a = (e.target as Element)?.closest?.(HC_SEL) as HTMLElement | null;
     if (!a || a === current) return;
     clearTimeout(showTimer);
     showTimer = window.setTimeout(() => show(a), e.type === 'focusin' ? 0 : 130);
   };
   const onLeave = (e: Event) => {
-    const a = (e.target as Element)?.closest?.('a.ent-link[data-hc]');
+    const a = (e.target as Element)?.closest?.(HC_SEL);
     if (!a) return;
     const to = (e as PointerEvent).relatedTarget as Node | null;
     if (to && (a as Element).contains(to)) return;
@@ -692,7 +694,7 @@ const searchUi = {
   document.addEventListener('pointerout', onLeave, { passive: true });
   document.addEventListener('focusin', onEnter);
   document.addEventListener('focusout', (e) => {
-    if (current && (e.target as Element)?.closest?.('a.ent-link') === current) hide();
+    if (current && (e.target as Element)?.closest?.(HC_SEL) === current) hide();
   });
   document.addEventListener('keydown', (e) => { if ((e as KeyboardEvent).key === 'Escape') hide(); });
   // Карточка позиционируется в координатах документа и «едет» вместе со ссылкой при скролле —

--- a/web/src/pages/[lang]/dnd/[version]/weapons/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/weapons/[slug].astro
@@ -35,18 +35,24 @@ export function getStaticPaths() {
       slug: w.slug, name: w.name,
       category: (w.category as string) ?? '', type: (w.type as string) ?? '',
     }));
+    // Карты «имя свойства/мастерства (lowercase) → slug» для hovercard-подсказок.
+    const propMap: Record<string, string> = {};
+    for (const p of loadEntities(ver, lang, 'weapon-properties')) propMap[p.name.toLowerCase()] = p.slug;
+    const masteryMap: Record<string, string> = {};
+    for (const m of loadEntities(ver, lang, 'masteries')) masteryMap[m.name.toLowerCase()] = m.slug;
     for (const entity of weapons) {
       paths.push({
         params: { lang, version: VERSION_SLUG[ver], slug: entity.slug },
-        props: { entity, ver, lang, siblings },
+        props: { entity, ver, lang, siblings, propMap, masteryMap },
       });
     }
   }
   return paths;
 }
 
-const { entity, ver, lang, siblings } = Astro.props;
+const { entity, ver, lang, siblings, propMap, masteryMap } = Astro.props;
 const verSlug = VERSION_SLUG[ver];
+const verKey = ver; // srd52
 const verLabel = VERSION_LABEL[ver];
 const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
 const loc = (map: Record<string, [string, string]>, key: string) => {
@@ -64,6 +70,21 @@ const rangeN = entity.range_normal as number | null;
 const rangeL = entity.range_long as number | null;
 const weight = (entity.weight as string | null) ?? '';
 const cost = (entity.cost as string) ?? '';
+
+// Свойство «Универсальное (1d10)» → база «Универсальное» (на неё вешаем hovercard) + хвост
+// « (1d10)». Мастерство — целиком. data-hc = префикс бакета game/verKey/lang/resource/slug.
+const propHc = (base: string) => {
+  const slug = propMap[base.trim().toLowerCase()];
+  return slug ? `dnd/${verKey}/${lang}/weapon-properties/${slug}` : null;
+};
+const splitProp = (p: string) => {
+  const m = p.match(/^(.*?)(\s*\(.*\))?$/);
+  return { base: (m?.[1] ?? p).trim(), suffix: m?.[2] ?? '' };
+};
+const masteryHc = (() => {
+  const slug = mastery ? masteryMap[mastery.trim().toLowerCase()] : undefined;
+  return slug ? `dnd/${verKey}/${lang}/masteries/${slug}` : null;
+})();
 
 const catLabel = loc(CATEGORY, category);
 const typeLabel = loc(WTYPE, wtype);
@@ -114,10 +135,22 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
       <div class="item-row"><dt>{t('Урон', 'Damage')}</dt><dd>{damageLine}</dd></div>
     )}
     {properties.length > 0 && (
-      <div class="item-row"><dt>{t('Свойства', 'Properties')}</dt><dd>{properties.join(', ')}</dd></div>
+      <div class="item-row"><dt>{t('Свойства', 'Properties')}</dt>
+        <dd>{properties.map((p, i) => {
+          const { base, suffix } = splitProp(p);
+          const hc = propHc(base);
+          return (
+            <Fragment>{i > 0 ? ', ' : ''}{hc
+              ? <span class="gloss" tabindex="0" data-hc={hc}>{base}</span>
+              : base}{suffix}</Fragment>
+          );
+        })}</dd></div>
     )}
     {mastery && (
-      <div class="item-row"><dt>{t('Мастерство', 'Mastery')}</dt><dd>{mastery}</dd></div>
+      <div class="item-row"><dt>{t('Мастерство', 'Mastery')}</dt>
+        <dd>{masteryHc
+          ? <span class="gloss" tabindex="0" data-hc={masteryHc}>{mastery}</span>
+          : mastery}</dd></div>
     )}
     {rangeLine && (
       <div class="item-row"><dt>{t('Дистанция', 'Range')}</dt><dd>{rangeLine}</dd></div>

--- a/web/src/pages/hc/[game]/[ver]/[lang].json.ts
+++ b/web/src/pages/hc/[game]/[ver]/[lang].json.ts
@@ -165,6 +165,25 @@ function equipHtml(e: Record<string, unknown>, lang: string): string {
   );
 }
 
+// ── Определения (свойства/мастерства оружия): markdown-абзацы → компактный HTML.
+// Без href (у свойств нет страниц) — карточка чисто справочная.
+function defHtml(md: string | undefined): string {
+  if (!md) return '';
+  return md
+    .split(/\n{2,}/)
+    .map((b) => b.trim())
+    .filter(Boolean)
+    .map((b) => {
+      const html = escapeHtml(b)
+        .replace(/\*\*_([^*]+?)_\*\*/g, '<strong>$1</strong>')
+        .replace(/\*\*([^*]+?)\*\*/g, '<strong>$1</strong>')
+        .replace(/(?<![\w*])_([^_]+?)_(?![\w*])/g, '<em>$1</em>')
+        .replace(/(?<![\w*])\*([^*]+?)\*(?![\w*])/g, '<em>$1</em>');
+      return `<p>${html}</p>`;
+    })
+    .join('');
+}
+
 // resource → { urlParent, build(entity) → HTML тела карточки }.
 const RESOURCES: { key: string; urlParent: string; body: (e: Record<string, unknown>, lang: string) => string }[] = [
   { key: 'conditions', urlParent: 'rules-glossary/conditions', body: (e) => conditionHtml(e.description_md as string) },
@@ -176,6 +195,10 @@ const RESOURCES: { key: string; urlParent: string; body: (e: Record<string, unkn
   { key: 'weapons', urlParent: 'weapons', body: (e, lang) => weaponHtml(e, lang) },
   { key: 'armor', urlParent: 'armor', body: (e, lang) => armorHtml(e, lang) },
   { key: 'equipment', urlParent: 'equipment', body: (e, lang) => equipHtml(e, lang) },
+  // Свойства/мастерства оружия — только карточка-определение (страниц нет; href не используется
+  // клиентом для gloss-подсказок).
+  { key: 'weapon-properties', urlParent: 'weapon-properties', body: (e) => defHtml(e.description_md as string) },
+  { key: 'masteries', urlParent: 'masteries', body: (e) => defHtml(e.description_md as string) },
 ];
 
 // Согласовано со сборкой страниц сущностей: пока только srd52 (en/ru).

--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -201,6 +201,11 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
    окружения (напр. курсив описания спелла), добавляя лишь цвет и вес. */
 .rd-doc .kw { color: var(--og-danger-text); font-weight: 600; }
 
+/* Глоссарный термин с hovercard-определением, но БЕЗ страницы (свойства/мастерства оружия):
+   пунктир как у ent-link, но без цвета-ссылки — это подсказка, а не переход. */
+.rd-doc .gloss { cursor: help; border-bottom: 1px dashed color-mix(in oklab, var(--og-text-muted) 60%, transparent); }
+.rd-doc .gloss:hover { border-bottom-color: var(--og-text-2); }
+
 /* Hovercard автоссылок (issue #20, вариант B): карточка сущности при наведении/фокусе.
    Единый переиспользуемый элемент в <body>; позицию задаёт клиентский скрипт (top/left). */
 .ent-hovercard {


### PR DESCRIPTION
Дорожка B: свойства оружия (10) и свойства мастерства (8) в стат-блоке оружия получают **hovercard с определением** из SRD. Наведение на «Универсальное»/«Фехтовальное»/«Оглушение» показывает EN-оригинал + описание.

**Только HC, без страниц** (согласовано) — определения короткие, в главе «Снаряжение» уже есть якоря.

## Инфраструктура (обкатана на не-ссылочных целях — пригодится для остальных терминов Rules Glossary)
- `parsers/glossary_defs.py` — парсит определения `####` внутри секции (Properties/Свойства, Mastery Properties/Свойства мастерства) → ресурсы `weapon-properties`, `masteries`.
- `generate_api`: тип `glossary_defs` + `align_positional_name_en` — RU `name_en`/слаг по позиции (порядок определений = EN, построчный паритет).
- hc-эндпоинт: карточки-определения для weapon-properties/masteries.
- `weapons/[slug].astro`: базовое имя свойства (без хвоста «(1d10)») и мастерство → `<span class="gloss" tabindex=0 data-hc>` — hovercard-таргет **без страницы**.
- `ReaderShell`: HC-селектор расширен на `.gloss[data-hc]` (раньше только `a.ent-link`).
- `reader.css`: стиль `.gloss` (пунктир + `cursor:help`, визуально отличён от ссылки).

## Проверки
- Сборка 2456 страниц; данные: 10 свойств + 8 мастерств (EN/RU, name_en выровнен).
- e2e: +2 теста — gloss-спаны + **реальное наведение → карточка «Versatile» с определением**; hc-эндпоинт содержит weapon-properties/masteries. **Полный прогон: 87 passed.**

Матрица #20: свойства оружия → HC ✅ (было ⏸).

🤖 Generated with [Claude Code](https://claude.com/claude-code)