### PR TITLE
feat(rules): hovercard-глоссинг действий (Rules Glossary) в тексте #20

### DIFF
--- a/.github/scripts/config.py
+++ b/.github/scripts/config.py
@@ -13,6 +13,7 @@ SOURCES = [
     {"ver": "srd52", "lang": "ru", "type": "feat",        "file": "srd-5.2/ru/05_Feats.md",        "h": 4, "after": "## Описания черт"},
     {"ver": "srd52", "lang": "ru", "type": "glossary_defs","file": "srd-5.2/ru/06_Equipment.md",   "section": "Свойства",         "out": "weapon-properties"},
     {"ver": "srd52", "lang": "ru", "type": "glossary_defs","file": "srd-5.2/ru/06_Equipment.md",   "section": "Свойства мастерства", "out": "masteries"},
+    {"ver": "srd52", "lang": "ru", "type": "tagged_defs",  "file": "srd-5.2/ru/08_RulesGlossary.md","tags": ["Действие"],           "out": "actions"},
     # SRD 5.2 EN
     {"ver": "srd52", "lang": "en", "type": "spell",      "file": "srd-5.2/en/07_Spells.md",       "h": 3},
     {"ver": "srd52", "lang": "en", "type": "monster",     "file": "srd-5.2/en/12_MonstersA-Z.md",  "h": 3},
@@ -25,6 +26,7 @@ SOURCES = [
     {"ver": "srd52", "lang": "en", "type": "feat",        "file": "srd-5.2/en/05_Feats.md",        "h": 4, "after": "## Feat Descriptions"},
     {"ver": "srd52", "lang": "en", "type": "glossary_defs","file": "srd-5.2/en/06_Equipment.md",   "section": "Properties",          "out": "weapon-properties"},
     {"ver": "srd52", "lang": "en", "type": "glossary_defs","file": "srd-5.2/en/06_Equipment.md",   "section": "Mastery Properties",  "out": "masteries"},
+    {"ver": "srd52", "lang": "en", "type": "tagged_defs",  "file": "srd-5.2/en/08_RulesGlossary.md","tags": ["Action"],             "out": "actions"},
     # SRD 5.1 RU
     {"ver": "srd51", "lang": "ru", "type": "spell",      "file": "srd-5.1/ru/10_Spells.md",       "h": 3},
     {"ver": "srd51", "lang": "ru", "type": "monster",     "file": "srd-5.1/ru/15_MonstersA-Z.md",  "h": 3},

--- a/.github/scripts/generate_api.py
+++ b/.github/scripts/generate_api.py
@@ -26,7 +26,7 @@ from config import (SOURCES, SKIP_HEADINGS_SPELL, SKIP_HEADINGS_MONSTER,
                     SKIP_HEADINGS_EQUIPMENT, SKIP_HEADINGS_FEAT)
 from parsers import (parse_spells, parse_monsters, parse_magic_items,
                      parse_weapons, parse_armor, parse_equipment,
-                     parse_conditions, parse_feats, parse_defs)
+                     parse_conditions, parse_feats, parse_defs, parse_tagged_defs)
 from parsers.base import slugify
 from schemas import RESOURCE_SCHEMAS
 
@@ -456,6 +456,9 @@ def main():
         elif entity_type == "glossary_defs":
             entities = parse_defs(text, source["section"])
             resource = out_resource
+        elif entity_type == "tagged_defs":
+            entities = parse_tagged_defs(text, source["tags"])
+            resource = out_resource
         else:
             print(f"  Warning: unknown type '{entity_type}', skipping", file=sys.stderr)
             continue
@@ -472,8 +475,8 @@ def main():
 
     # RU-оружию/доспехам — name_en + канонический слаг (сверка стат-блоков EN↔RU).
     align_stat_table_name_en(all_data)
-    # RU-свойствам/мастерствам оружия — name_en по позиции (порядок определений = EN).
-    align_positional_name_en(all_data, ("weapon-properties", "masteries"))
+    # RU-свойствам/мастерствам оружия и действиям — name_en по позиции (порядок определений = EN).
+    align_positional_name_en(all_data, ("weapon-properties", "masteries", "actions"))
 
     # Resolve cross-references
     resolve_cross_refs(all_data)

--- a/.github/scripts/parsers/__init__.py
+++ b/.github/scripts/parsers/__init__.py
@@ -6,4 +6,4 @@ from .armor import parse_armor
 from .equipment import parse_equipment
 from .condition import parse_conditions
 from .feat import parse_feats
-from .glossary_defs import parse_defs
+from .glossary_defs import parse_defs, parse_tagged_defs

--- a/.github/scripts/parsers/glossary_defs.py
+++ b/.github/scripts/parsers/glossary_defs.py
@@ -47,3 +47,29 @@ def parse_defs(text: str, section: str) -> list[dict]:
             "description_md": desc,
         })
     return defs
+
+
+def parse_tagged_defs(text: str, tags: list[str]) -> list[dict]:
+    """Собрать определения #### «Имя [Тег]» по всему файлу, где Тег ∈ tags.
+
+    Rules Glossary размечает термины тегами: «Dash [Action]» / «Рывок [Действие]».
+    Имя = без тега. name_en=None — RU-выравнивание по позиции (порядок в глоссарии
+    одинаков: EN-алфавит) делается в generate_api.
+    """
+    parts = re.split(r"^#### (.+)$", text, flags=re.M)
+    tagset = set(tags)
+    defs = []
+    for j in range(1, len(parts), 2):
+        heading = parts[j].strip()
+        m = re.search(r"\[([^\]]+)\]\s*$", heading)
+        if not m or m.group(1) not in tagset:
+            continue
+        name = heading[:m.start()].strip()
+        desc = parts[j + 1].strip() if j + 1 < len(parts) else ""
+        defs.append({
+            "slug": slugify(name),
+            "name": name,
+            "name_en": None,
+            "description_md": desc,
+        })
+    return defs

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -6,6 +6,7 @@ import rehypePromoteHeadings from './src/lib/rehype-promote-headings.mjs';
 import rehypeWrapTables from './src/lib/rehype-wrap-tables.mjs';
 import rehypeEntityAutolink from './src/lib/rehype-entity-autolink.mjs';
 import rehypeKeywordHighlight from './src/lib/keyword-highlight.mjs';
+import rehypeRulesGloss from './src/lib/rules-gloss.mjs';
 
 // rules.omnisgm.com — статический (SSG) ридер SRD экосистемы OmnisGM.
 // Контент — Markdown из ../src/{game}/{version}/{en,ru}/**.md (вход контентного пайплайна),
@@ -123,6 +124,6 @@ export default defineConfig({
     // Порядок важен (issue #20): rehypeEntityAutolink оборачивает имена сущностей в <a>, затем
     // rehypeKeywordHighlight красит ключевые слова — последним, чтобы не лезть внутрь ссылок
     // (<a> в его SKIP_TAGS) и работать по уже готовому дереву.
-    rehypePlugins: [rehypePromoteHeadings, rehypeWrapTables, rehypeEntityAutolink, rehypeKeywordHighlight],
+    rehypePlugins: [rehypePromoteHeadings, rehypeWrapTables, rehypeEntityAutolink, rehypeKeywordHighlight, rehypeRulesGloss],
   },
 });

--- a/web/e2e/rules-gloss.spec.ts
+++ b/web/e2e/rules-gloss.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+// Глоссинг терминов Rules Glossary (issue #20): действия (Dash/Dodge/…) в тексте получают
+// hovercard-определение (span.gloss[data-hc], НЕ ссылка). Матчатся ТОЛЬКО в контексте
+// «X action» (EN) / «действие X» (RU) — голые омонимы («Attack» ×499) не трогаются.
+
+test('спелл: действие в тексте глоссится + наведение показывает определение', async ({ page }) => {
+  // Bestow Curse: «…действие Уклонение…» → span.gloss на «Уклонение».
+  await page.goto('/ru/dnd/srd-5.2/spells/bestow-curse/');
+  const g = page.locator('.rd-doc .gloss[data-hc*="/actions/dodge"]', { hasText: 'Уклонение' }).first();
+  await expect(g).toBeVisible();
+  await g.hover();
+  const card = page.locator('#ent-hovercard.is-open');
+  await expect(card).toBeVisible();
+  await expect(card.locator('.ent-hc-en')).toHaveText('Dodge');
+  await expect(card.locator('.ent-hc-body')).toContainText('Уклонение');
+});
+
+test('глава класса: действие глоссится (EN и RU симметрично)', async ({ page }) => {
+  // Воин: «take the Attack action» / «совершаете действие Атака» → gloss.
+  await page.goto('/en/dnd/srd-5.2/classes/fighter/');
+  await expect(page.locator('.rd-doc .gloss[data-hc*="/actions/attack"]').first()).toBeVisible();
+  await page.goto('/ru/dnd/srd-5.2/classes/fighter/');
+  await expect(page.locator('.rd-doc .gloss[data-hc*="/actions/attack"]').first()).toBeVisible();
+});
+
+test('точность: глосс действия стоит в контексте (за ним «action»)', async ({ page }) => {
+  await page.goto('/en/dnd/srd-5.2/classes/fighter/');
+  // Каждый глосс действия на этой странице — часть «X action» (текст сразу после = " action…").
+  const glosses = page.locator('.rd-doc .gloss[data-hc*="/actions/"]');
+  const n = await glosses.count();
+  expect(n).toBeGreaterThan(0);
+  for (let i = 0; i < n; i++) {
+    const tail = await glosses.nth(i).evaluate((el) => (el.nextSibling?.textContent || '').slice(0, 8));
+    expect(tail.toLowerCase()).toMatch(/^\s+action/);
+  }
+});
+
+test('hovercard-эндпоинт: есть карточки действий', async ({ request }) => {
+  const ru = await (await request.get('/hc/dnd/srd52/ru.json')).json();
+  expect(ru['actions/dash']?.name_en).toBe('Dash');
+  expect(ru['actions/dash']?.effect).toContain('Рывок');
+  expect(ru['actions/dodge']?.name_en).toBe('Dodge');
+});

--- a/web/src/lib/rules-gloss.mjs
+++ b/web/src/lib/rules-gloss.mjs
@@ -1,0 +1,131 @@
+// Глоссинг терминов Rules Glossary в тексте (issue #20): имя термина оборачивается в
+// <span class="gloss" data-hc> с hovercard-определением (НЕ ссылка — страниц у них нет).
+//
+// Сейчас — только ДЕЙСТВИЯ (Dash/Dodge/…). Их имена омонимичны обычным словам («Attack»
+// голым = 499 вхождений: броски атаки, не действие), поэтому матчим ТОЛЬКО в явном
+// контексте ссылки на действие:
+//   • EN: «<Term> action» (Term + слово-маркер «action»);
+//   • RU: «действие <Term>» (слово-маркер «действие/действия…» перед Term).
+// Голые вхождения не трогаем → 0 ложных срабатываний. AoE отложены: в RU-прозе нет
+// надёжного сигнала (спелл «Конус холода», списки форм) — EN-only сломал бы паритет.
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DATA_ROOT = path.resolve(process.cwd(), 'src/data/api');
+const verKeyOf = (version) => version.replace(/[.\-]/g, '');
+const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Не трогаем текст внутри ссылок/кода/заголовков и уже-глоссированного.
+const SKIP_TAGS = new Set(['a', 'code', 'pre', 'kbd', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+const hasSkipClass = (el) => {
+  const c = el.properties && el.properties.className;
+  if (!c) return false;
+  const arr = Array.isArray(c) ? c : [c];
+  return arr.includes('gloss') || arr.includes('ent-link') || arr.includes('kw');
+};
+
+// Маркер контекста: EN — сразу после Term идёт « action»; RU — перед Term стоит «действие ».
+// NB: JS \w — ASCII-only, кириллицу не ловит; RU-суффикс задаём явным классом [а-яё].
+const AFTER_CTX = { en: /^\s+action\b/i, ru: null };
+const BEFORE_CTX = { en: null, ru: /действ[а-яё]*\s+[«"„]?$/i };
+
+const cache = new Map(); // `${game}/${version}/${lang}` → { re, byName, verKey } | null
+
+function loadActions(game, version, lang) {
+  const cacheKey = `${game}/${version}/${lang}`;
+  if (cache.has(cacheKey)) return cache.get(cacheKey);
+  const verKey = verKeyOf(version);
+  let data;
+  try {
+    data = JSON.parse(fs.readFileSync(path.join(DATA_ROOT, game, verKey, lang, 'actions', 'all.json'), 'utf8'));
+  } catch {
+    cache.set(cacheKey, null);
+    return null;
+  }
+  const byName = new Map();
+  for (const e of data) if (e && e.name && e.slug) byName.set(e.name, e.slug);
+  if (!byName.size) { cache.set(cacheKey, null); return null; }
+  // Длинные имена раньше коротких; границы — юникод-aware (ASCII \b ломает кириллицу).
+  const alt = [...byName.keys()].sort((a, b) => b.length - a.length).map(escapeRegExp).join('|');
+  const re = new RegExp(`(?<![\\p{L}\\p{N}_])(${alt})(?![\\p{L}\\p{N}_])`, 'gu');
+  const res = { re, byName, verKey };
+  cache.set(cacheKey, res);
+  return res;
+}
+
+function glossNode(term, slug, ctx) {
+  return {
+    type: 'element',
+    tagName: 'span',
+    properties: {
+      className: ['gloss'],
+      tabindex: '0',
+      'data-hc': `${ctx.game}/${ctx.verKey}/${ctx.lang}/actions/${slug}`,
+    },
+    children: [{ type: 'text', value: term }],
+  };
+}
+
+function glossText(value, map, lang, ctx) {
+  map.re.lastIndex = 0;
+  const after = AFTER_CTX[lang];
+  const before = BEFORE_CTX[lang];
+  const nodes = [];
+  let last = 0;
+  let changed = false;
+  let m;
+  while ((m = map.re.exec(value))) {
+    const term = m[1];
+    const idx = m.index;
+    const end = idx + term.length;
+    const okAfter = after ? after.test(value.slice(end)) : false;
+    const okBefore = before ? before.test(value.slice(0, idx)) : false;
+    if (!okAfter && !okBefore) continue;
+    const slug = map.byName.get(term);
+    if (!slug) continue;
+    changed = true;
+    if (idx > last) nodes.push({ type: 'text', value: value.slice(last, idx) });
+    nodes.push(glossNode(term, slug, ctx));
+    last = end;
+  }
+  if (!changed) return null;
+  if (last < value.length) nodes.push({ type: 'text', value: value.slice(last) });
+  return nodes;
+}
+
+// Ядро: глоссит термины прямо в hast-дереве. Общая логика для глав (rehype) и страниц
+// сущностей (spells/monsters render()).
+export function glossRules(tree, { game, version, lang }) {
+  const map = loadActions(game, version, lang);
+  if (!map) return tree;
+  const ctx = { game, lang, verKey: map.verKey };
+  const walk = (node, skip) => {
+    if (!node.children) return;
+    for (let i = 0; i < node.children.length; i++) {
+      const child = node.children[i];
+      if (child.type === 'element') {
+        walk(child, skip || SKIP_TAGS.has(child.tagName) || hasSkipClass(child));
+      } else if (child.type === 'text' && !skip) {
+        const replaced = glossText(child.value, map, lang, ctx);
+        if (replaced) {
+          node.children.splice(i, 1, ...replaced);
+          i += replaced.length - 1;
+        }
+      }
+    }
+  };
+  walk(tree, false);
+  return tree;
+}
+
+// rehype-обёртка для глав (весь контент). Порядок в pipeline — ПОСЛЕ автолинка/подсветки,
+// чтобы не лезть внутрь уже-ссылок/подсветки (они в SKIP через hasSkipClass).
+export default function rehypeRulesGloss() {
+  return (tree, file) => {
+    const p = (file && (file.path || (file.history && file.history[0]))) || '';
+    const m = p.replace(/\\/g, '/').match(/\/(dnd|daggerheart|brp)\/([^/]+)\/(en|ru)\//);
+    if (!m) return;
+    const [, game, version, lang] = m;
+    glossRules(tree, { game, version, lang });
+  };
+}

--- a/web/src/pages/[lang]/dnd/[version]/animals/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/animals/[slug].astro
@@ -5,6 +5,7 @@ import { toHtml } from 'hast-util-to-html';
 import ReaderShell from '../../../../../components/ReaderShell.astro';
 import { autolinkTree } from '../../../../../lib/rehype-entity-autolink.mjs';
 import { highlightKeywords } from '../../../../../lib/keyword-highlight.mjs';
+import { glossRules } from '../../../../../lib/rules-gloss.mjs';
 import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
 
 // Programmatic-страницы животных (issue #20, Дорожка A) в общем шелле ридера.
@@ -58,6 +59,7 @@ const render = (md: string | undefined | null) => {
   const tree = fromHtml(marked.parse(md, { async: false }), { fragment: true });
   autolinkTree(tree, { game: 'dnd', version: verSlug, lang, selfSlug: entity.slug });
   highlightKeywords(tree, { lang });
+  glossRules(tree, { game: 'dnd', version: verSlug, lang });
   return toHtml(tree);
 };
 const renderEntry = (e: { name?: string; text_md: string }) =>

--- a/web/src/pages/[lang]/dnd/[version]/feats/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/feats/[slug].astro
@@ -5,6 +5,7 @@ import { toHtml } from 'hast-util-to-html';
 import ReaderShell from '../../../../../components/ReaderShell.astro';
 import { autolinkTree } from '../../../../../lib/rehype-entity-autolink.mjs';
 import { highlightKeywords } from '../../../../../lib/keyword-highlight.mjs';
+import { glossRules } from '../../../../../lib/rules-gloss.mjs';
 import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
 
 // Programmatic-страницы черт (issue #20, Дорожка A) в общем шелле ридера.
@@ -55,6 +56,7 @@ const render = (md: string | undefined | null) => {
   const tree = fromHtml(marked.parse(md, { async: false }), { fragment: true });
   autolinkTree(tree, { game: 'dnd', version: verSlug, lang, selfSlug: entity.slug });
   highlightKeywords(tree, { lang });
+  glossRules(tree, { game: 'dnd', version: verSlug, lang });
   return toHtml(tree);
 };
 const bodyHtml = render(entity.description_md as string);

--- a/web/src/pages/[lang]/dnd/[version]/magic-items/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/magic-items/[slug].astro
@@ -4,6 +4,7 @@ import { fromHtml } from 'hast-util-from-html';
 import { toHtml } from 'hast-util-to-html';
 import ReaderShell from '../../../../../components/ReaderShell.astro';
 import { autolinkTree } from '../../../../../lib/rehype-entity-autolink.mjs';
+import { glossRules } from '../../../../../lib/rules-gloss.mjs';
 import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
 
 // Programmatic-страницы магических предметов (issue #20, волна 3) в общем шелле ридера.
@@ -51,6 +52,7 @@ const render = (md: string | undefined | null) => {
   if (!md || md === 'None') return '';
   const tree = fromHtml(marked.parse(md, { async: false }), { fragment: true });
   autolinkTree(tree, { game: 'dnd', version: verSlug, lang, selfSlug: entity.slug });
+  glossRules(tree, { game: 'dnd', version: verSlug, lang });
   return toHtml(tree);
 };
 const bodyHtml = render(entity.description_md as string);

--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/[slug].astro
@@ -5,6 +5,7 @@ import { toHtml } from 'hast-util-to-html';
 import ReaderShell from '../../../../../components/ReaderShell.astro';
 import { autolinkTree } from '../../../../../lib/rehype-entity-autolink.mjs';
 import { highlightKeywords } from '../../../../../lib/keyword-highlight.mjs';
+import { glossRules } from '../../../../../lib/rules-gloss.mjs';
 import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
 
 // Programmatic-страницы монстров (issue #20, волна 3) в общем шелле ридера.
@@ -54,6 +55,7 @@ const render = (md: string | undefined | null) => {
   const tree = fromHtml(marked.parse(md, { async: false }), { fragment: true });
   autolinkTree(tree, { game: 'dnd', version: verSlug, lang, selfSlug: entity.slug });
   highlightKeywords(tree, { lang });
+  glossRules(tree, { game: 'dnd', version: verSlug, lang });
   return toHtml(tree);
 };
 const renderEntry = (e: { name?: string; text_md: string }) =>

--- a/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
@@ -5,6 +5,7 @@ import { toHtml } from 'hast-util-to-html';
 import ReaderShell from '../../../../../components/ReaderShell.astro';
 import { autolinkTree } from '../../../../../lib/rehype-entity-autolink.mjs';
 import { highlightKeywords } from '../../../../../lib/keyword-highlight.mjs';
+import { glossRules } from '../../../../../lib/rules-gloss.mjs';
 import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
 
 // Programmatic-страницы заклинаний (issue #20, волна 2) в общем шелле ридера.
@@ -54,6 +55,7 @@ const render = (md: string | undefined | null) => {
   const tree = fromHtml(marked.parse(md, { async: false }), { fragment: true });
   autolinkTree(tree, { game: 'dnd', version: verSlug, lang, selfSlug: entity.slug });
   highlightKeywords(tree, { lang });
+  glossRules(tree, { game: 'dnd', version: verSlug, lang });
   return toHtml(tree);
 };
 const bodyHtml = render(entity.description_md as string);

--- a/web/src/pages/hc/[game]/[ver]/[lang].json.ts
+++ b/web/src/pages/hc/[game]/[ver]/[lang].json.ts
@@ -199,6 +199,8 @@ const RESOURCES: { key: string; urlParent: string; body: (e: Record<string, unkn
   // клиентом для gloss-подсказок).
   { key: 'weapon-properties', urlParent: 'weapon-properties', body: (e) => defHtml(e.description_md as string) },
   { key: 'masteries', urlParent: 'masteries', body: (e) => defHtml(e.description_md as string) },
+  // Действия Rules Glossary — карточка-определение (страниц нет; глоссинг в тексте → span.gloss).
+  { key: 'actions', urlParent: 'actions', body: (e) => defHtml(e.description_md as string) },
 ];
 
 // Согласовано со сборкой страниц сущностей: пока только srd52 (en/ru).


### PR DESCRIPTION
Действия (Dash/Dodge/Attack/Magic/… — 12) в тексте глав и страниц сущностей получают **hovercard-определение** (`span.gloss[data-hc]`, без страницы).

## Риск и решение
Имена действий омонимичны обычным словам: голое «Attack» = **499** вхождений (броски атаки, не действие), «Magic» = 186. Автогло́сс всех = ковёр.

**Контекст-гейт** — матчим ТОЛЬКО явную ссылку на действие:
- **EN:** «\<Term\> action»;
- **RU:** «действие \<Term\>».

Голые вхождения не трогаем. На dist: **1104 глосса, 0 out-of-context (RU и EN), 0 вложенных в ссылки**, симметрично EN/RU.

## Инфраструктура
- `parse_tagged_defs` — определения `#### Имя [Тег]` по тегу (Action/Действие) → ресурс `actions`; `align_positional_name_en` выравнивает RU `name_en` по позиции.
- `rules-gloss.mjs` — rehype-плагин (главы) + `glossRules()` в render() страниц сущностей (спеллы/монстры/животные/черты/предметы). Юникод-границы (кириллица!), SKIP внутри ссылок/подсветки/заголовков.
- hc-эндпоинт: карточка-определение для actions.

## ⏸ AoE отложены (осознанно)
Области эффекта (Cone/Cube/…) не вошли: в **RU-прозе нет надёжного сигнала** — доминируют имена спеллов («Конус холода»), списки форм; измеренный «N-фут Конус» почти отсутствует. EN-only сломал бы паритет. Чистый путь — извлечь структурный `shape` у заклинаний (parser), отдельным PR.

## Проверки
- e2e: `rules-gloss.spec.ts` (4 — глосс в спелле + наведение «Dodge», симметрия EN/RU в главе класса, точность контекста, hc-карточки). **Полный прогон: 91 passed.**
- Грабли: `.astro` content-cache отдавал старые RU-главы — лечится чистым билдом (знакомые грабли).

🤖 Generated with [Claude Code](https://claude.com/claude-code)