### PR TITLE
feat(rules): hovercard-глоссинг терминов ядра Rules Glossary #20

### DIFF
--- a/.github/scripts/config.py
+++ b/.github/scripts/config.py
@@ -14,6 +14,7 @@ SOURCES = [
     {"ver": "srd52", "lang": "ru", "type": "glossary_defs","file": "srd-5.2/ru/06_Equipment.md",   "section": "Свойства",         "out": "weapon-properties"},
     {"ver": "srd52", "lang": "ru", "type": "glossary_defs","file": "srd-5.2/ru/06_Equipment.md",   "section": "Свойства мастерства", "out": "masteries"},
     {"ver": "srd52", "lang": "ru", "type": "tagged_defs",  "file": "srd-5.2/ru/08_RulesGlossary.md","tags": ["Действие"],           "out": "actions"},
+    {"ver": "srd52", "lang": "ru", "type": "untagged_defs","file": "srd-5.2/ru/08_RulesGlossary.md","out": "rules-terms"},
     # SRD 5.2 EN
     {"ver": "srd52", "lang": "en", "type": "spell",      "file": "srd-5.2/en/07_Spells.md",       "h": 3},
     {"ver": "srd52", "lang": "en", "type": "monster",     "file": "srd-5.2/en/12_MonstersA-Z.md",  "h": 3},
@@ -27,6 +28,7 @@ SOURCES = [
     {"ver": "srd52", "lang": "en", "type": "glossary_defs","file": "srd-5.2/en/06_Equipment.md",   "section": "Properties",          "out": "weapon-properties"},
     {"ver": "srd52", "lang": "en", "type": "glossary_defs","file": "srd-5.2/en/06_Equipment.md",   "section": "Mastery Properties",  "out": "masteries"},
     {"ver": "srd52", "lang": "en", "type": "tagged_defs",  "file": "srd-5.2/en/08_RulesGlossary.md","tags": ["Action"],             "out": "actions"},
+    {"ver": "srd52", "lang": "en", "type": "untagged_defs","file": "srd-5.2/en/08_RulesGlossary.md","out": "rules-terms"},
     # SRD 5.1 RU
     {"ver": "srd51", "lang": "ru", "type": "spell",      "file": "srd-5.1/ru/10_Spells.md",       "h": 3},
     {"ver": "srd51", "lang": "ru", "type": "monster",     "file": "srd-5.1/ru/15_MonstersA-Z.md",  "h": 3},

--- a/.github/scripts/generate_api.py
+++ b/.github/scripts/generate_api.py
@@ -26,7 +26,7 @@ from config import (SOURCES, SKIP_HEADINGS_SPELL, SKIP_HEADINGS_MONSTER,
                     SKIP_HEADINGS_EQUIPMENT, SKIP_HEADINGS_FEAT)
 from parsers import (parse_spells, parse_monsters, parse_magic_items,
                      parse_weapons, parse_armor, parse_equipment,
-                     parse_conditions, parse_feats, parse_defs, parse_tagged_defs)
+                     parse_conditions, parse_feats, parse_defs, parse_tagged_defs, parse_untagged_defs)
 from parsers.base import slugify
 from schemas import RESOURCE_SCHEMAS
 
@@ -459,6 +459,9 @@ def main():
         elif entity_type == "tagged_defs":
             entities = parse_tagged_defs(text, source["tags"])
             resource = out_resource
+        elif entity_type == "untagged_defs":
+            entities = parse_untagged_defs(text)
+            resource = out_resource
         else:
             print(f"  Warning: unknown type '{entity_type}', skipping", file=sys.stderr)
             continue
@@ -476,7 +479,7 @@ def main():
     # RU-оружию/доспехам — name_en + канонический слаг (сверка стат-блоков EN↔RU).
     align_stat_table_name_en(all_data)
     # RU-свойствам/мастерствам оружия и действиям — name_en по позиции (порядок определений = EN).
-    align_positional_name_en(all_data, ("weapon-properties", "masteries", "actions"))
+    align_positional_name_en(all_data, ("weapon-properties", "masteries", "actions", "rules-terms"))
 
     # Resolve cross-references
     resolve_cross_refs(all_data)

--- a/.github/scripts/parsers/__init__.py
+++ b/.github/scripts/parsers/__init__.py
@@ -6,4 +6,4 @@ from .armor import parse_armor
 from .equipment import parse_equipment
 from .condition import parse_conditions
 from .feat import parse_feats
-from .glossary_defs import parse_defs, parse_tagged_defs
+from .glossary_defs import parse_defs, parse_tagged_defs, parse_untagged_defs

--- a/.github/scripts/parsers/glossary_defs.py
+++ b/.github/scripts/parsers/glossary_defs.py
@@ -49,6 +49,29 @@ def parse_defs(text: str, section: str) -> list[dict]:
     return defs
 
 
+def parse_untagged_defs(text: str) -> list[dict]:
+    """Собрать определения #### БЕЗ тега [..] (термины ядра Rules Glossary).
+
+    Состояния/действия/AoE/… помечены тегом и парсятся отдельно; здесь — прочие термины
+    (Преимущество, Укрытие, Концентрация…). name_en=None — RU-выравнивание по позиции
+    (глоссарий в EN-алфавите) в generate_api.
+    """
+    parts = re.split(r"^#### (.+)$", text, flags=re.M)
+    defs = []
+    for j in range(1, len(parts), 2):
+        heading = parts[j].strip()
+        if re.search(r"\[[^\]]+\]\s*$", heading):
+            continue  # тегированный термин — не сюда
+        desc = parts[j + 1].strip() if j + 1 < len(parts) else ""
+        defs.append({
+            "slug": slugify(heading),
+            "name": heading,
+            "name_en": None,
+            "description_md": desc,
+        })
+    return defs
+
+
 def parse_tagged_defs(text: str, tags: list[str]) -> list[dict]:
     """Собрать определения #### «Имя [Тег]» по всему файлу, где Тег ∈ tags.
 

--- a/web/e2e/rules-gloss.spec.ts
+++ b/web/e2e/rules-gloss.spec.ts
@@ -42,3 +42,33 @@ test('hovercard-эндпоинт: есть карточки действий', a
   expect(ru['actions/dash']?.effect).toContain('Рывок');
   expect(ru['actions/dodge']?.name_en).toBe('Dodge');
 });
+
+test('термин ядра: Концентрация глоссится + наведение показывает определение', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/bestow-curse/');
+  const g = page.locator('.rd-doc .gloss[data-hc*="/rules-terms/concentration"]').first();
+  await expect(g).toBeVisible();
+  await g.hover();
+  const card = page.locator('#ent-hovercard.is-open');
+  await expect(card).toBeVisible();
+  await expect(card.locator('.ent-hc-en')).toHaveText('Concentration');
+});
+
+test('термин ядра: многословный дистинктивный (Труднопроходимая местность) — EN и RU', async ({ page }) => {
+  // Стем-матч ловит склонения RU; EN — точная фраза.
+  await page.goto('/ru/dnd/srd-5.2/spells/arcane-hand/');
+  await expect(page.locator('.rd-doc .gloss[data-hc*="/rules-terms/difficult-terrain"]').first()).toBeVisible();
+  await page.goto('/en/dnd/srd-5.2/spells/arcane-hand/');
+  await expect(page.locator('.rd-doc .gloss[data-hc*="/rules-terms/difficult-terrain"]').first()).toBeVisible();
+});
+
+test('безопасность: обычное слово (Cover/Укрытие) НЕ в наборе — не глоссится', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/rules-glossary/');
+  await expect(page.locator('.gloss[data-hc*="/rules-terms/cover"]')).toHaveCount(0);
+});
+
+test('hovercard-эндпоинт: есть карточки терминов ядра', async ({ request }) => {
+  const ru = await (await request.get('/hc/dnd/srd52/ru.json')).json();
+  expect(ru['rules-terms/concentration']?.name_en).toBe('Concentration');
+  expect(ru['rules-terms/difficult-terrain']?.name_en).toBe('Difficult Terrain');
+  expect(ru['rules-terms/passive-perception']?.effect).toContain('Пассивная Внимательность');
+});

--- a/web/src/lib/rules-gloss.mjs
+++ b/web/src/lib/rules-gloss.mjs
@@ -1,13 +1,17 @@
 // Глоссинг терминов Rules Glossary в тексте (issue #20): имя термина оборачивается в
 // <span class="gloss" data-hc> с hovercard-определением (НЕ ссылка — страниц у них нет).
 //
-// Сейчас — только ДЕЙСТВИЯ (Dash/Dodge/…). Их имена омонимичны обычным словам («Attack»
-// голым = 499 вхождений: броски атаки, не действие), поэтому матчим ТОЛЬКО в явном
-// контексте ссылки на действие:
-//   • EN: «<Term> action» (Term + слово-маркер «action»);
-//   • RU: «действие <Term>» (слово-маркер «действие/действия…» перед Term).
-// Голые вхождения не трогаем → 0 ложных срабатываний. AoE отложены: в RU-прозе нет
-// надёжного сигнала (спелл «Конус холода», списки форм) — EN-only сломал бы паритет.
+// Две группы:
+//  • ДЕЙСТВИЯ (actions, Dash/Dodge/…): имена омонимичны словам («Attack» голым = 499
+//    вхождений), поэтому матчим ТОЛЬКО в явном контексте — EN «<Term> action», RU «действие
+//    <Term>». Голые вхождения не трогаем.
+//  • ТЕРМИНЫ ЯДРА (rules-terms): курируемый список ДИСТИНКТИВНЫХ терминов (многословных —
+//    «Труднопроходимая местность», «Провоцированные атаки» — и пары надёжных: Концентрация).
+//    RU склоняется без сигнала капитализации → матчим по СТЕМ-паттерну (инвариантная основа,
+//    ловит все падежи); EN — точная фраза с заглавной. Общие односложные слова (Укрытие/Урон/
+//    Спасбросок) НЕ включены — риск пере-линковки.
+//
+// AoE отложены: в RU-прозе нет надёжного сигнала (спелл «Конус холода», списки форм).
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -15,7 +19,6 @@ const DATA_ROOT = path.resolve(process.cwd(), 'src/data/api');
 const verKeyOf = (version) => version.replace(/[.\-]/g, '');
 const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-// Не трогаем текст внутри ссылок/кода/заголовков и уже-глоссированного.
 const SKIP_TAGS = new Set(['a', 'code', 'pre', 'kbd', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
 const hasSkipClass = (el) => {
   const c = el.properties && el.properties.className;
@@ -24,79 +27,120 @@ const hasSkipClass = (el) => {
   return arr.includes('gloss') || arr.includes('ent-link') || arr.includes('kw');
 };
 
-// Маркер контекста: EN — сразу после Term идёт « action»; RU — перед Term стоит «действие ».
-// NB: JS \w — ASCII-only, кириллицу не ловит; RU-суффикс задаём явным классом [а-яё].
-const AFTER_CTX = { en: /^\s+action\b/i, ru: null };
-const BEFORE_CTX = { en: null, ru: /действ[а-яё]*\s+[«"„]?$/i };
+// Контекст действий: EN — сразу после Term «action»; RU — перед Term «действие ».
+// NB: JS \w — ASCII-only; RU-суффиксы задаём явным классом [а-яё].
+const AFTER_CTX = { en: /^\s+action\b/iu, ru: null };
+const BEFORE_CTX = { en: null, ru: /действ[а-яё]*\s+[«"„]?$/iu };
 
-const cache = new Map(); // `${game}/${version}/${lang}` → { re, byName, verKey } | null
+// Курируемые термины ядра. en — точная фраза (регэксп-фрагмент, матч с учётом регистра);
+// ru — стем-паттерн (регэксп-фрагмент, матч БЕЗ учёта регистра, ловит склонения). Все —
+// дистинктивные (многословные либо однозначные), чтобы не задеть обычные слова.
+const CORE_TERMS = [
+  { slug: 'difficult-terrain', en: 'Difficult Terrain', ru: 'Труднопроходим[а-яё]+\\s+местност[а-яё]+' },
+  { slug: 'passive-perception', en: 'Passive Perception', ru: 'Пассивн[а-яё]+\\s+[Вв]нимательност[а-яё]+' },
+  { slug: 'opportunity-attacks', en: 'Opportunity Attacks?', ru: 'Провоцированн[а-яё]+\\s+атак[а-яё]+' },
+  { slug: 'temporary-hit-points', en: 'Temporary Hit Points', ru: 'Временн[а-яё]+\\s+хит[а-яё]+' },
+  { slug: 'heroic-inspiration', en: 'Heroic Inspiration', ru: 'Героическ[а-яё]+\\s+вдохновени[а-яё]+' },
+  { slug: 'critical-hit', en: 'Critical Hits?', ru: 'Критическ[а-яё]+\\s+попадани[а-яё]+' },
+  { slug: 'death-saving-throw', en: 'Death Saving Throws?', ru: 'Спасброс[а-яё]+\\s+от\\s+смерти' },
+  { slug: 'concentration', en: 'Concentration', ru: 'Концентрац[а-яё]+' },
+  // Сенсорные термины (Тёмное/Слепое зрение, Truesight, Tremorsense) намеренно НЕ включены:
+  // ковром идут по строкам «Чувства» в бестиарии, а RU-проза для truesight использует другой
+  // термин («истинное зрение» ≠ глоссарное «Видение истины»). Отдельно, с гейтом «не в статблоке».
+];
+const grp = (slug) => slug.replace(/-/g, '_');
+const slugFromGroups = (groups) => {
+  for (const t of CORE_TERMS) if (groups[grp(t.slug)] != null) return t.slug;
+  return null;
+};
 
-function loadActions(game, version, lang) {
+const cache = new Map();
+
+function loadGloss(game, version, lang) {
   const cacheKey = `${game}/${version}/${lang}`;
   if (cache.has(cacheKey)) return cache.get(cacheKey);
   const verKey = verKeyOf(version);
-  let data;
-  try {
-    data = JSON.parse(fs.readFileSync(path.join(DATA_ROOT, game, verKey, lang, 'actions', 'all.json'), 'utf8'));
-  } catch {
-    cache.set(cacheKey, null);
-    return null;
+  const read = (res) => {
+    try { return JSON.parse(fs.readFileSync(path.join(DATA_ROOT, game, verKey, lang, res, 'all.json'), 'utf8')); }
+    catch { return null; }
+  };
+  // Действия: имя → slug + альтернация (юникод-границы; ASCII \b ломает кириллицу).
+  const actionsData = read('actions');
+  let actionRe = null;
+  const actionByName = new Map();
+  if (actionsData) {
+    for (const e of actionsData) if (e && e.name && e.slug) actionByName.set(e.name, e.slug);
+    if (actionByName.size) {
+      const alt = [...actionByName.keys()].sort((a, b) => b.length - a.length).map(escapeRegExp).join('|');
+      actionRe = new RegExp(`(?<![\\p{L}\\p{N}_])(${alt})(?![\\p{L}\\p{N}_])`, 'gu');
+    }
   }
-  const byName = new Map();
-  for (const e of data) if (e && e.name && e.slug) byName.set(e.name, e.slug);
-  if (!byName.size) { cache.set(cacheKey, null); return null; }
-  // Длинные имена раньше коротких; границы — юникод-aware (ASCII \b ломает кириллицу).
-  const alt = [...byName.keys()].sort((a, b) => b.length - a.length).map(escapeRegExp).join('|');
-  const re = new RegExp(`(?<![\\p{L}\\p{N}_])(${alt})(?![\\p{L}\\p{N}_])`, 'gu');
-  const res = { re, byName, verKey };
+  // Термины ядра: именованные группы; EN — регистро-зависимо, RU — регистро-независимо (стемы).
+  const field = lang === 'en' ? 'en' : 'ru';
+  const parts = CORE_TERMS.map((t) => `(?<${grp(t.slug)}>${t[field]})`).join('|');
+  const flags = lang === 'en' ? 'gu' : 'giu';
+  const coreRe = new RegExp(`(?<![\\p{L}\\p{N}_])(?:${parts})(?![\\p{L}\\p{N}_])`, flags);
+
+  const res = actionRe || coreRe ? { actionRe, actionByName, coreRe, verKey } : null;
   cache.set(cacheKey, res);
   return res;
 }
 
-function glossNode(term, slug, ctx) {
+function glossNode(term, slug, resource, ctx) {
   return {
     type: 'element',
     tagName: 'span',
     properties: {
       className: ['gloss'],
       tabindex: '0',
-      'data-hc': `${ctx.game}/${ctx.verKey}/${ctx.lang}/actions/${slug}`,
+      'data-hc': `${ctx.game}/${ctx.verKey}/${ctx.lang}/${resource}/${slug}`,
     },
     children: [{ type: 'text', value: term }],
   };
 }
 
 function glossText(value, map, lang, ctx) {
-  map.re.lastIndex = 0;
-  const after = AFTER_CTX[lang];
-  const before = BEFORE_CTX[lang];
+  const spans = []; // { idx, end, term, slug, resource }
+  // Действия — с контекст-гейтом.
+  if (map.actionRe) {
+    map.actionRe.lastIndex = 0;
+    const after = AFTER_CTX[lang], before = BEFORE_CTX[lang];
+    let m;
+    while ((m = map.actionRe.exec(value))) {
+      const term = m[1], idx = m.index, end = idx + term.length;
+      const ok = (after && after.test(value.slice(end))) || (before && before.test(value.slice(0, idx)));
+      if (!ok) continue;
+      const slug = map.actionByName.get(term);
+      if (slug) spans.push({ idx, end, term, slug, resource: 'actions' });
+    }
+  }
+  // Термины ядра — прямой матч (дистинктивные).
+  if (map.coreRe) {
+    map.coreRe.lastIndex = 0;
+    let m;
+    while ((m = map.coreRe.exec(value))) {
+      const slug = slugFromGroups(m.groups || {});
+      if (slug) spans.push({ idx: m.index, end: m.index + m[0].length, term: m[0], slug, resource: 'rules-terms' });
+    }
+  }
+  if (!spans.length) return null;
+  // Сортировка + отбрасывание пересечений (первый по позиции побеждает).
+  spans.sort((a, b) => a.idx - b.idx || b.end - a.end);
   const nodes = [];
   let last = 0;
-  let changed = false;
-  let m;
-  while ((m = map.re.exec(value))) {
-    const term = m[1];
-    const idx = m.index;
-    const end = idx + term.length;
-    const okAfter = after ? after.test(value.slice(end)) : false;
-    const okBefore = before ? before.test(value.slice(0, idx)) : false;
-    if (!okAfter && !okBefore) continue;
-    const slug = map.byName.get(term);
-    if (!slug) continue;
-    changed = true;
-    if (idx > last) nodes.push({ type: 'text', value: value.slice(last, idx) });
-    nodes.push(glossNode(term, slug, ctx));
-    last = end;
+  for (const s of spans) {
+    if (s.idx < last) continue; // пересечение с уже вставленным
+    if (s.idx > last) nodes.push({ type: 'text', value: value.slice(last, s.idx) });
+    nodes.push(glossNode(s.term, s.slug, s.resource, ctx));
+    last = s.end;
   }
-  if (!changed) return null;
   if (last < value.length) nodes.push({ type: 'text', value: value.slice(last) });
   return nodes;
 }
 
-// Ядро: глоссит термины прямо в hast-дереве. Общая логика для глав (rehype) и страниц
-// сущностей (spells/monsters render()).
+// Ядро: глоссит термины прямо в hast-дереве. Для глав (rehype) и страниц сущностей (render()).
 export function glossRules(tree, { game, version, lang }) {
-  const map = loadActions(game, version, lang);
+  const map = loadGloss(game, version, lang);
   if (!map) return tree;
   const ctx = { game, lang, verKey: map.verKey };
   const walk = (node, skip) => {
@@ -118,8 +162,7 @@ export function glossRules(tree, { game, version, lang }) {
   return tree;
 }
 
-// rehype-обёртка для глав (весь контент). Порядок в pipeline — ПОСЛЕ автолинка/подсветки,
-// чтобы не лезть внутрь уже-ссылок/подсветки (они в SKIP через hasSkipClass).
+// rehype-обёртка для глав. Порядок в pipeline — ПОСЛЕ автолинка/подсветки (они в SKIP).
 export default function rehypeRulesGloss() {
   return (tree, file) => {
     const p = (file && (file.path || (file.history && file.history[0]))) || '';

--- a/web/src/pages/hc/[game]/[ver]/[lang].json.ts
+++ b/web/src/pages/hc/[game]/[ver]/[lang].json.ts
@@ -201,6 +201,8 @@ const RESOURCES: { key: string; urlParent: string; body: (e: Record<string, unkn
   { key: 'masteries', urlParent: 'masteries', body: (e) => defHtml(e.description_md as string) },
   // Действия Rules Glossary — карточка-определение (страниц нет; глоссинг в тексте → span.gloss).
   { key: 'actions', urlParent: 'actions', body: (e) => defHtml(e.description_md as string) },
+  // Термины ядра Rules Glossary — карточка-определение (глоссится курируемое подмножество).
+  { key: 'rules-terms', urlParent: 'rules-terms', body: (e) => defHtml(e.description_md as string) },
 ];
 
 // Согласовано со сборкой страниц сущностей: пока только srd52 (en/ru).


### PR DESCRIPTION
**8 дистинктивных терминов ядра** в тексте получают hovercard-определение (`span.gloss[data-hc]`): Концентрация, Труднопроходимая местность, Пассивная Внимательность, Провоцированные атаки, Временные хиты, Героическое вдохновение, Критическое попадание, Спасбросок от смерти.

## Проблема и решение (аудит)
RU-проза **склоняет** термины без сигнала капитализации: EN «Difficult Terrain» = 44, а RU номинатив «…местность» = **0** (всегда «…местности»). Матч по номинативу = дикая асимметрия.

**Стем-матч RU** (инвариантная основа ловит все падежи): `Труднопроходим[а-яё]+ местност[а-яё]+`. EN — точная фраза с заглавной. Именованные группы регэкспа.

Только **дистинктивные** (многословные + Концентрация). Общие односложные (Укрытие/Урон/Спасбросок) **исключены** — риск пере-линковки.

## Итог (dist)
- **EN 881 / RU 842** глоссов — сбалансировано; **0 пере-линковки, 0 вложенных в ссылки**.
- passive-perception плотнее на chapter-страницах бестиария/животных (строка «Чувства» каждого существа) — симметрично, на reference-страницах приемлемо.

## Что НЕ вошло (осознанно)
Сенсорные термины (Тёмное/Слепое зрение, Truesight, Tremorsense) — ковром идут по статблокам, а RU-truesight в прозе использует другой термин («истинное зрение» ≠ глоссарное «Видение истины»). Нужен гейт «не в статблоке» — отдельно. Опасности/отношения — нежизнеспособны (в прошлом аудите: нет прозы/сигнала, расхождение перевода).

## Инфраструктура
`parse_untagged_defs` → ресурс `rules-terms` (115 терминов, HC для любого); `rules-gloss.mjs` теперь матчит и действия (контекст), и термины ядра (стем/точная фраза).

## Проверки
+4 e2e (Концентрация + наведение, многословный EN/RU, «Cover» не глоссится, hc-карточки). **Полный прогон: 95 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)