### PR TITLE
feat(rules): области эффекта заклинаний через структурный shape #20

### DIFF
--- a/.github/scripts/config.py
+++ b/.github/scripts/config.py
@@ -15,6 +15,7 @@ SOURCES = [
     {"ver": "srd52", "lang": "ru", "type": "glossary_defs","file": "srd-5.2/ru/06_Equipment.md",   "section": "Свойства мастерства", "out": "masteries"},
     {"ver": "srd52", "lang": "ru", "type": "tagged_defs",  "file": "srd-5.2/ru/08_RulesGlossary.md","tags": ["Действие"],           "out": "actions"},
     {"ver": "srd52", "lang": "ru", "type": "untagged_defs","file": "srd-5.2/ru/08_RulesGlossary.md","out": "rules-terms"},
+    {"ver": "srd52", "lang": "ru", "type": "tagged_defs",  "file": "srd-5.2/ru/08_RulesGlossary.md","tags": ["Область воздействия"], "out": "areas-of-effect"},
     # SRD 5.2 EN
     {"ver": "srd52", "lang": "en", "type": "spell",      "file": "srd-5.2/en/07_Spells.md",       "h": 3},
     {"ver": "srd52", "lang": "en", "type": "monster",     "file": "srd-5.2/en/12_MonstersA-Z.md",  "h": 3},
@@ -29,6 +30,7 @@ SOURCES = [
     {"ver": "srd52", "lang": "en", "type": "glossary_defs","file": "srd-5.2/en/06_Equipment.md",   "section": "Mastery Properties",  "out": "masteries"},
     {"ver": "srd52", "lang": "en", "type": "tagged_defs",  "file": "srd-5.2/en/08_RulesGlossary.md","tags": ["Action"],             "out": "actions"},
     {"ver": "srd52", "lang": "en", "type": "untagged_defs","file": "srd-5.2/en/08_RulesGlossary.md","out": "rules-terms"},
+    {"ver": "srd52", "lang": "en", "type": "tagged_defs",  "file": "srd-5.2/en/08_RulesGlossary.md","tags": ["Area of Effect"], "out": "areas-of-effect"},
     # SRD 5.1 RU
     {"ver": "srd51", "lang": "ru", "type": "spell",      "file": "srd-5.1/ru/10_Spells.md",       "h": 3},
     {"ver": "srd51", "lang": "ru", "type": "monster",     "file": "srd-5.1/ru/15_MonstersA-Z.md",  "h": 3},

--- a/.github/scripts/generate_api.py
+++ b/.github/scripts/generate_api.py
@@ -175,6 +175,20 @@ def align_positional_name_en(all_data: dict, resources: tuple[str, ...]) -> None
             r["slug"] = e["slug"]
 
 
+def backfill_spell_area(all_data: dict) -> None:
+    """RU-заклинаниям — area по слагу из EN (форма извлекается только из EN-описания)."""
+    for (ver, lang, resource), spells in all_data.items():
+        if lang != "en" or resource != "spells":
+            continue
+        en_area = {s["slug"]: s.get("area") for s in spells}
+        ru = all_data.get((ver, "ru", "spells"))
+        if not ru:
+            continue
+        for s in ru:
+            if s.get("area") is None and en_area.get(s["slug"]):
+                s["area"] = en_area[s["slug"]]
+
+
 def resolve_cross_refs(all_data: dict) -> None:
     """Resolve spell name → slug cross-references for monsters and magic items."""
     spell_lookup: dict[tuple[str, str], dict[str, str]] = {}
@@ -479,7 +493,9 @@ def main():
     # RU-оружию/доспехам — name_en + канонический слаг (сверка стат-блоков EN↔RU).
     align_stat_table_name_en(all_data)
     # RU-свойствам/мастерствам оружия и действиям — name_en по позиции (порядок определений = EN).
-    align_positional_name_en(all_data, ("weapon-properties", "masteries", "actions", "rules-terms"))
+    align_positional_name_en(all_data, ("weapon-properties", "masteries", "actions", "rules-terms", "areas-of-effect"))
+    # RU-заклинаниям — area (форма) по слагу из EN.
+    backfill_spell_area(all_data)
 
     # Resolve cross-references
     resolve_cross_refs(all_data)

--- a/.github/scripts/parsers/spell.py
+++ b/.github/scripts/parsers/spell.py
@@ -203,6 +203,27 @@ def _ru_shape(shape_type: str) -> str:
             "sphere": "сфер", "hemisphere": "полусфер"}.get(shape_type, "")
 
 
+# Область эффекта из ОПИСАНИЯ (5.2 пишет форму там: «in a 60-foot Cone»), а не в строке
+# Дистанции. Извлекаем из EN (надёжно); RU получает area по слагу (бэкфилл в generate_api),
+# т.к. RU-проза выражает форму разнородно.
+_AREA_RE = re.compile(
+    r"(\d+)-foot(-radius)?\s+(Cone|Cube|Cylinder|Emanation|Line|Sphere)\b")
+
+
+def parse_area_from_desc(desc_md: str) -> dict | None:
+    """→ {shape, size_ft, radius} по первому измеренному упоминанию формы (EN-описание)."""
+    if not desc_md:
+        return None
+    m = _AREA_RE.search(desc_md)
+    if not m:
+        return None
+    return {
+        "shape": m.group(3).lower(),
+        "size_ft": int(m.group(1)),
+        "radius": m.group(2) is not None,
+    }
+
+
 def _parse_components(value: str, lang: str) -> dict:
     """Parse spell components."""
     v_upper = value.upper()
@@ -377,6 +398,8 @@ def parse_spells(text: str, heading_level: int, lang: str,
             "range": spell_range,
             "components": components,
             "duration": duration,
+            # area из EN-описания; для RU останется None и заполнится по слагу (backfill).
+            "area": parse_area_from_desc(desc_md) if lang == "en" else None,
             "description_md": desc_md,
             "higher_levels_md": higher_md,
             "cantrip_upgrade_md": cantrip_md,

--- a/web/e2e/rules-gloss.spec.ts
+++ b/web/e2e/rules-gloss.spec.ts
@@ -72,3 +72,30 @@ test('hovercard-эндпоинт: есть карточки терминов я�
   expect(ru['rules-terms/difficult-terrain']?.name_en).toBe('Difficult Terrain');
   expect(ru['rules-terms/passive-perception']?.effect).toContain('Пассивная Внимательность');
 });
+
+test('область эффекта: стат-блок заклинания — строка «Область» с глоссом формы', async ({ page }) => {
+  // Конус холода: форма извлечена структурно из описания → строка «Область: Конус, 60 футов».
+  await page.goto('/ru/dnd/srd-5.2/spells/cone-of-cold/');
+  const row = page.locator('.spell-meta-row', { hasText: 'Область' });
+  await expect(row).toContainText('Конус');
+  await expect(row).toContainText('60 футов');
+  const g = row.locator('.gloss[data-hc*="/areas-of-effect/cone"]');
+  await expect(g).toBeVisible();
+  await g.hover();
+  const card = page.locator('#ent-hovercard.is-open');
+  await expect(card).toBeVisible();
+  await expect(card.locator('.ent-hc-en')).toHaveText('Cone');
+});
+
+test('область эффекта: EN — «N-foot Shape», форма глоссится (симметрия)', async ({ page }) => {
+  await page.goto('/en/dnd/srd-5.2/spells/fireball/');
+  const row = page.locator('.spell-meta-row', { hasText: 'Area' });
+  await expect(row).toContainText('20-foot-radius');
+  await expect(row.locator('.gloss[data-hc*="/areas-of-effect/sphere"]')).toBeVisible();
+});
+
+test('hovercard-эндпоинт: есть карточки областей эффекта', async ({ request }) => {
+  const ru = await (await request.get('/hc/dnd/srd52/ru.json')).json();
+  expect(ru['areas-of-effect/cone']?.name_en).toBe('Cone');
+  expect(ru['areas-of-effect/sphere']?.name_en).toBe('Sphere');
+});

--- a/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
@@ -34,17 +34,20 @@ export function getStaticPaths() {
   for (const { ver, lang } of BUILDS) {
     const spells = loadEntities(ver, lang, 'spells');
     const siblings = spells.map((s) => ({ slug: s.slug, name: s.name, school: s.school as string, level: s.level as string }));
+    // Локализованные имена форм области (shape=slug): «cone»→«Конус»/«Cone» + для hovercard.
+    const aoeNames: Record<string, string> = {};
+    for (const a of loadEntities(ver, lang, 'areas-of-effect')) aoeNames[a.slug] = a.name;
     for (const entity of spells) {
       paths.push({
         params: { lang, version: VERSION_SLUG[ver], slug: entity.slug },
-        props: { entity, ver, lang, siblings },
+        props: { entity, ver, lang, siblings, aoeNames },
       });
     }
   }
   return paths;
 }
 
-const { entity, ver, lang, siblings } = Astro.props;
+const { entity, ver, lang, siblings, aoeNames } = Astro.props;
 const verSlug = VERSION_SLUG[ver];
 const verLabel = VERSION_LABEL[ver];
 const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
@@ -126,6 +129,14 @@ const castVal = (entity.casting_time as Record<string, unknown>)?.value as strin
 const rangeVal = (entity.range as Record<string, unknown>)?.value as string;
 const durVal = (entity.duration as Record<string, unknown>)?.value as string;
 
+// Область эффекта (форма извлечена структурно из EN-описания): строка «Область» с глоссом формы.
+const area = entity.area as { shape: string; size_ft: number; radius: boolean } | null;
+const areaShapeName = area ? (aoeNames[area.shape] ?? area.shape) : '';
+const areaHc = area ? `dnd/${ver}/${lang}/areas-of-effect/${area.shape}` : '';
+const areaSize = area
+  ? t(`${area.radius ? 'радиус ' : ''}${area.size_ft} футов`, `${area.size_ft}-foot${area.radius ? '-radius' : ''}`)
+  : '';
+
 const base = `/${lang}/dnd/${verSlug}/spells`;
 // «Та же школа» — до 8 других заклинаний той же школы (внутренняя перелинковка/SEO).
 const sameSchool = (siblings as { slug: string; name: string; school: string }[])
@@ -160,6 +171,12 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
     )}
     {rangeVal && (
       <div class="spell-meta-row"><dt>{t('Дистанция', 'Range')}</dt><dd>{rangeVal}</dd></div>
+    )}
+    {area && (
+      <div class="spell-meta-row"><dt>{t('Область', 'Area')}</dt>
+        <dd>{lang === 'en'
+          ? <Fragment>{areaSize ? `${areaSize} ` : ''}<span class="gloss" tabindex="0" data-hc={areaHc}>{areaShapeName}</span></Fragment>
+          : <Fragment><span class="gloss" tabindex="0" data-hc={areaHc}>{areaShapeName}</span>{areaSize ? `, ${areaSize}` : ''}</Fragment>}</dd></div>
     )}
     {compItems.length > 0 && (
       <div class="spell-meta-row">

--- a/web/src/pages/hc/[game]/[ver]/[lang].json.ts
+++ b/web/src/pages/hc/[game]/[ver]/[lang].json.ts
@@ -203,6 +203,8 @@ const RESOURCES: { key: string; urlParent: string; body: (e: Record<string, unkn
   { key: 'actions', urlParent: 'actions', body: (e) => defHtml(e.description_md as string) },
   // Термины ядра Rules Glossary — карточка-определение (глоссится курируемое подмножество).
   { key: 'rules-terms', urlParent: 'rules-terms', body: (e) => defHtml(e.description_md as string) },
+  // Области эффекта — карточка-определение (глосс формы в стат-блоке заклинания).
+  { key: 'areas-of-effect', urlParent: 'areas-of-effect', body: (e) => defHtml(e.description_md as string) },
 ];
 
 // Согласовано со сборкой страниц сущностей: пока только srd52 (en/ru).


### PR DESCRIPTION
Форма области эффекта (Cone/Cube/Cylinder/Emanation/Line/Sphere) появляется в стат-блоке заклинания как **строка «Область»** с hovercard-определением.

## Подход — структурный shape (обходит проблему RU-прозы)
В прошлом аудите AoE отложили: RU-проза выражает форму разнородно и с коллизиями (спелл «Конус холода», списки форм) — глоссинг по прозе ненадёжен.

**Решение:** форма извлекается **структурно из EN-описания** (парсер: `N-foot[-radius] Shape` → `area {shape, size_ft, radius}`), а RU получает `area` **по слагу** из EN (бэкфилл). Форма — структурный атрибут, глосс в **контролируемой строке стат-блока**, а не в прозе.

## Результат (симметрично EN/RU)
| | RU | EN |
|---|---|---|
| Конус холода | Область: **Конус**, 60 футов | Area: 60-foot **Cone** |
| Огненный шар | Область: **Сфера**, радиус 20 футов | Area: 20-foot-radius **Sphere** |

Форма (жирным) — `span.gloss` → hovercard-определение (ресурс `areas-of-effect`, `tagged_defs [Area of Effect]`).

**Покрытие: 63 заклинания** с областью (EN и RU симметрично).

## Проверки
+3 e2e (строка «Область» RU + наведение «Cone», EN «N-foot Shape» симметрия, hc-карточки). **Полный прогон: 98 passed.**

С этим PR глоссарий закрыт по всем жизнеспособным категориям (см. обновлённую Дорожку B в #20). Осталось только ⛔-нежизнеспособное (опасности/отношения/общие односложные) и ⏸-сенсорные (нужен статблок-гейт).

🤖 Generated with [Claude Code](https://claude.com/claude-code)