### PR TITLE
fix(ci): area в JSON-схеме заклинаний — деплой #121 падал на валидации #20

### DIFF
--- a/.github/scripts/schemas.py
+++ b/.github/scripts/schemas.py
@@ -127,6 +127,20 @@ SPELL_SCHEMA = {
             "required": ["value", "type", "concentration"],
             "additionalProperties": False,
         },
+        # Область эффекта (форма из EN-описания; null — у заклинания нет измеренной AoE).
+        "area": {
+            "type": ["object", "null"],
+            "properties": {
+                "shape": {
+                    "type": "string",
+                    "enum": ["cone", "cube", "cylinder", "emanation", "line", "sphere"],
+                },
+                "size_ft": {"type": "integer"},
+                "radius": {"type": "boolean"},
+            },
+            "required": ["shape", "size_ft", "radius"],
+            "additionalProperties": False,
+        },
         "description_md": {"type": ["string", "null"]},
         "higher_levels_md": {"type": ["string", "null"]},
         "cantrip_upgrade_md": {"type": ["string", "null"]},
@@ -134,7 +148,7 @@ SPELL_SCHEMA = {
     },
     "required": [
         "slug", "name", "name_en", "level", "school", "classes",
-        "casting_time", "range", "components", "duration",
+        "casting_time", "range", "components", "duration", "area",
         "description_md", "higher_levels_md", "cantrip_upgrade_md", "has_stat_block",
     ],
     "additionalProperties": False,


### PR DESCRIPTION
## Проблема
[Деплой после мёржа #121](https://github.com/OmnisGM-App/OmnisGM-Rules/actions/runs/29247596247) упал:
```
Schema validation error in srd52/ru — spells, entity 'true-strike':
Error: hosting predeploy error: Command terminated with non-zero exit code 1
```

Новое поле `spells.area` (форма области эффекта, #121) не описано в `SPELL_SCHEMA`, где `additionalProperties: False` → jsonschema-валидация в firebase predeploy его отклонила.

**Почему локально не поймали:** `gen-entity-data.mjs` гоняет `generate_api.py` с `--no-validate` (dependency-free), а CI-предеплой — с валидацией (jsonschema установлен).

## Фикс
`area` добавлено в `SPELL_SCHEMA`: `object|null` с `shape` (enum 6 форм), `size_ft` (int), `radius` (bool); и в `required`.

**Воспроведено:** `generate_api.py` С валидацией локально → **0 ошибок, 140 файлов**.

## Влияние
Прод **не затронут** — оставался на прошлом успешном деплое (#120). Пайплайн был красным (все будущие деплои падали бы) — этот фикс возвращает зелёный и доставляет AoE (#121) в прод.

🤖 Generated with [Claude Code](https://claude.com/claude-code)