### PR TITLE
CI: валидация JSON API по схеме на PR + деплой на весь .github/scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,21 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Валидация JSON API по схеме — тем же generate_api.py, что гоняет firebase predeploy
+      # при деплое (schemas.py, additionalProperties:False). Локальный prebuild зовёт генератор
+      # с --no-validate (без jsonschema, чтобы dev-сборка была бездефолтной), поэтому дрейф схемы
+      # (новое поле парсера не заведено в schemas.py) на PR не всплывал и ронял уже ДЕПЛОЙ (#20,
+      # spell.area). Ставим python+jsonschema и валидируем здесь — раньше мёржа, а не после.
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Validate JSON API schema
+        run: |
+          pip install jsonschema
+          python3 .github/scripts/generate_api.py \
+            --src-root src/dnd --output-dir "$RUNNER_TEMP/api-validate"
+
       - uses: actions/setup-node@v6
         with:
           node-version: '20'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,10 @@ on:
       - 'web/**'
       - 'src/**'
       - 'config/**'
-      - '.github/scripts/generate_api.py'
+      # Весь каталог: generate_api.py тянет schemas.py / config.py / parsers/** — правка любого
+      # из них меняет JSON API, но раньше деплой триггерил только сам generate_api.py, поэтому
+      # чинить схему/парсер приходилось ручным workflow_dispatch (грабли #20). Теперь авто-деплой.
+      - '.github/scripts/**'
       - 'firebase.json'
   workflow_dispatch:
 


### PR DESCRIPTION
Закрывает технический долг, всплывший в #20: новое поле парсера `spell.area` не было заведено в `schemas.py`, из-за чего валидация упала **на деплое**, а не на PR (PR-CI билдит с `--no-validate`, а `firebase predeploy` — с валидацией).

## Что меняется

**1. `ci.yml` — новый шаг «Validate JSON API schema»**
Ставит `python`+`jsonschema` и гоняет `generate_api.py` **без** `--no-validate` — ровно тем же путём, что `firebase predeploy` при деплое (`schemas.py`, `additionalProperties:False`). Стоит до `npm ci` → быстрый python-only фейл. Локальный `prebuild` (`gen-entity-data.mjs`) намеренно **остаётся** с `--no-validate` (dev-сборка без питон-зависимостей); дрейф схемы теперь ловится на PR.

**2. `deploy.yml` — `paths` расширены**
Было: только `.github/scripts/generate_api.py`. Стало: `.github/scripts/**`. Генератор тянет `schemas.py` / `config.py` / `parsers/**` — правка любого меняет JSON API, но раньше не триггерила авто-деплой → приходилось руками `workflow_dispatch`. Теперь фикс схемы/парсера деплоится сам.

## Проверка
- Локально `generate_api.py` с валидацией → `EXIT=0`, 140 файлов / 4522 сущности, 0 ошибок схемы.
- YAML обоих воркфлоу валиден.

🤖 Generated with [Claude Code](https://claude.com/claude-code)