### PR TITLE
Термины ядра #20: убрать attack-roll из глоссинга (структурная асимметрия)

### DIFF
--- a/web/src/lib/rules-gloss.mjs
+++ b/web/src/lib/rules-gloss.mjs
@@ -49,7 +49,10 @@ const CORE_TERMS = [
   // ни на одной стороне. Все многословны либо однозначны в этом корпусе (ложных срабатываний нет).
   { slug: 'armor-class', en: 'Armor Class', ru: 'Класс[а-яё]*\\s+доспех[а-яё]+' },
   { slug: 'bonus-action', en: 'Bonus Actions?', ru: 'Бонусн[а-яё]+\\s+действи[а-яё]+' },
-  { slug: 'attack-roll', en: 'Attack Rolls?', ru: 'Брос[а-яё]+\\s+атак[а-яё]+' },
+  // attack-roll намеренно НЕ глоссим (батч 2 включал, откатили): EN 5.2 формализовал
+  // «Melee/Ranged Attack Roll» как капитал-компаунд (429×), матч ловил «Attack Roll» внутри,
+  // а RU пишет «рукопашная/дальнобойная атака» БЕЗ «бросок атаки» → структурная асимметрия
+  // (dist 864/427), стемом не лечится. Карточка HC у attack-roll остаётся (это сущность).
   { slug: 'initiative', en: 'Initiative', ru: 'Инициатив[а-яё]+' },
   { slug: 'challenge-rating', en: 'Challenge Rating', ru: 'Показател[а-яё]+\\s+опасност[а-яё]+' },
   { slug: 'unarmed-strike', en: 'Unarmed Strikes?', ru: 'Безоружн[а-яё]+\\s+удар[а-яё]*' },


### PR DESCRIPTION
Фикс по итогам аудита RU==EN (по фактическим глоссам в `dist`). `attack-roll` — единственный из 22 терминов ядра, который **структурно** нарушает симметрию, и стемом это не лечится.

## Причина
EN 5.2 формализовал **«Melee/Ranged Attack Roll»** как капитал-компаунд (Melee 360 + Ranged 69 = 429×), а наш матч `Attack Rolls?` ловит «Attack Roll» внутри него. RU так не пишет — **«рукопашная атака» (404×) / «дальнобойная атака» (103×)**, БЕЗ «бросок атаки».

Итог в `dist`: **EN 864 / RU 427 (2.0×)**. Это разница фразировки, а не недоглошенные склонения → стем не поможет.

## Что меняется
- Убрана одна строка из `CORE_TERMS` (`web/src/lib/rules-gloss.mjs`).
- **Карточка HC у `attack-roll` остаётся** — это сущность `rules-terms`; перестаём лишь автоглоссить его в прозе.
- Остальные 21 термин ядра не тронуты.

## Результат
`rules-terms` в целом стал симметричным: **EN 2542 / RU 2526 (ratio 1.006**, было 1.15).

## Верификация (чистая пересборка, 2456 стр.)
- `attack-roll` глоссов в dist: **0**;
- e2e **101/101**, `astro check` 0 ошибок;
- карточка HC `attack-roll` на месте (сущность жива).

🤖 Generated with [Claude Code](https://claude.com/claude-code)