### PR TITLE
Хабы заклинаний #20 (SEO §2.3, PR A): по классу и по уровню

### DIFF
--- a/web/e2e/spell-hubs.spec.ts
+++ b/web/e2e/spell-hubs.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+// Хабы заклинаний (issue #20, SEO §2.3): фасетные списки по классу и уровню.
+// Класс-хаб — секции H2 по уровням; уровень-хаб — таблица с колонкой классов (ссылки на класс-хабы).
+
+test('класс-хаб: волшебник — секции по уровням + ссылки на заклинания (EN/RU симметрично)', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/class/wizard/');
+  await expect(page.locator('h1')).toHaveText('Заклинания волшебника');
+  // Секции уровней (заговоры + 1..9 = 10) и ссылка на конкретное заклинание.
+  await expect(page.locator('.rd-doc h2[id^="lvl-"]')).toHaveCount(10);
+  const fireball = page.locator('.hub-table a[href$="/spells/fireball/"]');
+  await expect(fireball.first()).toBeVisible();
+  // Симметрия: EN-хаб на том же (англ.) слаге, столько же ссылок на заклинания.
+  const ruCount = await page.locator('.hub-table a[href*="/spells/"]').count();
+  await page.goto('/en/dnd/srd-5.2/spells/class/wizard/');
+  await expect(page.locator('h1')).toHaveText('Wizard Spells');
+  expect(await page.locator('.hub-table a[href*="/spells/"]').count()).toBe(ruCount);
+});
+
+test('класс-хаб: ссылка на заклинание ведёт на его страницу', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/class/wizard/');
+  await page.locator('.hub-table a[href$="/spells/fireball/"]').first().click();
+  await expect(page).toHaveURL(/\/spells\/fireball\/$/);
+  await expect(page.locator('h1')).toContainText('Огненный шар');
+});
+
+test('класс-хаб: перелинковка на другие классы и на уровни', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/class/wizard/');
+  const links = page.locator('.hub-links');
+  await expect(links.locator('a[href$="/spells/class/cleric/"]')).toBeVisible();
+  await expect(links.locator('a[href$="/spells/level/3/"]')).toBeVisible();
+});
+
+test('уровень-хаб: 3 уровень — таблица заклинаний, классы ссылаются на класс-хабы', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/level/3/');
+  await expect(page.locator('h1')).toHaveText('Заклинания 3 уровня');
+  await expect(page.locator('.hub-table a[href$="/spells/fireball/"]').first()).toBeVisible();
+  // В колонке «Классы» — ссылки на класс-хабы.
+  await expect(page.locator('.hub-table a[href$="/spells/class/wizard/"]').first()).toBeVisible();
+});
+
+test('уровень-хаб: заговоры (level 0) — заголовок «Заговоры»', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/level/0/');
+  await expect(page.locator('h1')).toHaveText('Заговоры');
+  await page.goto('/en/dnd/srd-5.2/spells/level/0/');
+  await expect(page.locator('h1')).toHaveText('Cantrips');
+});
+
+test('SEO: класс-хаб самоканоничен + hreflang-тройка', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/class/wizard/');
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    'href', 'https://rules.omnisgm.com/ru/dnd/srd-5.2/spells/class/wizard/');
+  for (const hl of ['en', 'ru', 'x-default']) {
+    await expect(page.locator(`link[rel="alternate"][hreflang="${hl}"]`)).toHaveCount(1);
+  }
+});

--- a/web/scripts/verify_dist_seo.mjs
+++ b/web/scripts/verify_dist_seo.mjs
@@ -30,6 +30,8 @@ const SAMPLE = [
   { type: 'animal', tail: 'dnd/srd-5.2/animals/hippopotamus/' },
   { type: 'feat', tail: 'dnd/srd-5.2/feats/boon-of-fate/' },
   { type: 'glossary', tail: 'dnd/srd-5.2/rules-glossary/' },
+  { type: 'spell-hub-class', tail: 'dnd/srd-5.2/spells/class/wizard/' },
+  { type: 'spell-hub-level', tail: 'dnd/srd-5.2/spells/level/3/' },
 ];
 const LANGS = ['en', 'ru'];
 // Страницы, где noindex ЛЕГИТИМЕН (сейчас пусто — глоссарии переоткрыты в #106).

--- a/web/src/lib/spell-hubs.ts
+++ b/web/src/lib/spell-hubs.ts
@@ -1,0 +1,69 @@
+// Хабы заклинаний (issue #20, SEO §2.3): фасетные списки по классу и по уровню.
+// Общие данные/подписи для двух роутов: spells/class/[class] и spells/level/[level].
+//
+// ВАЖНО: в JSON-данных поле `classes` ПЕРЕВЕДЕНО (RU: «Волшебник», EN: «Wizard»), а URL-слаг
+// фасета обязан быть языконезависимым (общий каноникал + hreflang, как у слагов сущностей).
+// Поэтому фильтруем по имени класса НА ЯЗЫКЕ ДАННЫХ, а слаг берём из этой таблицы.
+export type Lang = 'en' | 'ru';
+
+export interface SpellLite {
+  slug: string;
+  name: string;
+  level: number;
+  school: string;
+  classes: string[];
+}
+
+// ruGen — родительный падеж («заклинания <кого?>»); наивное «+а» ломается на Чародей/Жрец.
+export const SPELL_CLASSES: { slug: string; en: string; ru: string; ruGen: string }[] = [
+  { slug: 'bard', en: 'Bard', ru: 'Бард', ruGen: 'барда' },
+  { slug: 'cleric', en: 'Cleric', ru: 'Жрец', ruGen: 'жреца' },
+  { slug: 'druid', en: 'Druid', ru: 'Друид', ruGen: 'друида' },
+  { slug: 'paladin', en: 'Paladin', ru: 'Паладин', ruGen: 'паладина' },
+  { slug: 'ranger', en: 'Ranger', ru: 'Следопыт', ruGen: 'следопыта' },
+  { slug: 'sorcerer', en: 'Sorcerer', ru: 'Чародей', ruGen: 'чародея' },
+  { slug: 'warlock', en: 'Warlock', ru: 'Колдун', ruGen: 'колдуна' },
+  { slug: 'wizard', en: 'Wizard', ru: 'Волшебник', ruGen: 'волшебника' },
+];
+
+export const LEVELS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+export const classBySlug = (slug: string) => SPELL_CLASSES.find((c) => c.slug === slug);
+export const classLabel = (slug: string, lang: Lang) => {
+  const c = classBySlug(slug);
+  return c ? c[lang] : slug;
+};
+// «Заклинания <классаGen>» (RU род.п.) / «<Class>» (EN, атрибутив в «X Spells»).
+export const classHubName = (slug: string, lang: Lang) => {
+  const c = classBySlug(slug);
+  if (!c) return slug;
+  return lang === 'ru' ? c.ruGen : c.en;
+};
+// Имя класса в том виде, в каком оно лежит в данных этого языка (для фильтра spell.classes).
+export const classNameInData = (slug: string, lang: Lang) => classLabel(slug, lang);
+
+export const levelLabel = (n: number, lang: Lang) =>
+  n === 0 ? (lang === 'ru' ? 'Заговоры' : 'Cantrips') : lang === 'ru' ? `${n}-й уровень` : `Level ${n}`;
+// Короткая подпись уровня заклинания в таблице/строке.
+export const levelShort = (n: number, lang: Lang) =>
+  n === 0 ? (lang === 'ru' ? 'Заговор' : 'Cantrip') : lang === 'ru' ? `${n} ур.` : `Lv ${n}`;
+
+// Школа: в RU JSON поле переведено наполовину (Evocation vs Воплощения) — нормализуем
+// двусторонним мапом (тот же, что на странице заклинания).
+const SCHOOLS: [string, string][] = [
+  ['Abjuration', 'Ограждения'], ['Conjuration', 'Вызова'], ['Divination', 'Прорицания'],
+  ['Enchantment', 'Очарования'], ['Evocation', 'Воплощения'], ['Illusion', 'Иллюзии'],
+  ['Necromancy', 'Некромантии'], ['Transmutation', 'Преобразования'],
+];
+export const schoolLabel = (raw: string, lang: Lang) => {
+  const p = SCHOOLS.find(([en, ru]) => en === raw || ru === raw);
+  return p ? (lang === 'ru' ? p[1] : p[0]) : raw;
+};
+
+// Классы заклинания (слаги) — из переведённого поля classes через обратный поиск по языку данных.
+export const spellClassSlugs = (spell: SpellLite, lang: Lang): string[] =>
+  (spell.classes || [])
+    .map((name) => SPELL_CLASSES.find((c) => c[lang] === name)?.slug)
+    .filter((s): s is string => Boolean(s));
+
+export const byName = (a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name);

--- a/web/src/pages/[lang]/dnd/[version]/spells/class/[class].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/class/[class].astro
@@ -1,0 +1,111 @@
+---
+import ReaderShell from '../../../../../../components/ReaderShell.astro';
+import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../../lib/entities';
+import {
+  SPELL_CLASSES, LEVELS, classLabel, classHubName, classNameInData, levelLabel, schoolLabel, byName,
+  type Lang, type SpellLite,
+} from '../../../../../../lib/spell-hubs';
+
+// Хаб заклинаний по классу (issue #20, SEO §2.3): /{lang}/dnd/{version}/spells/class/{class}/.
+// Все заклинания класса, сгруппированы H2-секциями по уровню (ловит и «wizard spells 5e», и
+// длинный хвост «заклинания жреца 1 уровня» без 80 тонких страниц). EN/RU делят англ. слаг
+// класса → общий каноникал + hreflang. Родитель nav — глава «Заклинания».
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-spells' };
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as Lang },
+    { ver: 'srd52', lang: 'ru' as Lang },
+  ];
+  const paths = [];
+  for (const { ver, lang } of BUILDS) {
+    const spells = loadEntities(ver, lang, 'spells') as unknown as SpellLite[];
+    for (const cls of SPELL_CLASSES) {
+      const dataName = classNameInData(cls.slug, lang);
+      const mine = spells.filter((s) => (s.classes || []).includes(dataName));
+      if (!mine.length) continue; // страхует от пустого хаба
+      paths.push({
+        params: { lang, version: VERSION_SLUG[ver], class: cls.slug },
+        props: { ver, lang, classSlug: cls.slug, spells: mine },
+      });
+    }
+  }
+  return paths;
+}
+
+const { ver, lang, classSlug, spells } = Astro.props as {
+  ver: string; lang: Lang; classSlug: string; spells: SpellLite[];
+};
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+const base = `/${lang}/dnd/${verSlug}/spells`;
+const spellHref = (slug: string) => `${base}/${slug}/`;
+
+const clsName = classLabel(classSlug, lang);
+const clsGen = classHubName(classSlug, lang); // род.п. (RU) / имя (EN) для «Заклинания X»
+// Секции по уровню: только непустые, отсортированы; в каждой — заклинания по алфавиту.
+const sections = LEVELS
+  .map((n) => ({ n, items: spells.filter((s) => s.level === n).sort(byName) }))
+  .filter((sec) => sec.items.length > 0);
+const headings = sections.map((sec) => ({ depth: 2, slug: `lvl-${sec.n}`, text: levelLabel(sec.n, lang) }));
+
+const title = `${t(`Заклинания ${clsGen}`, `${clsGen} Spells`)} — D&D ${verLabel} · OmnisGM Rules`;
+const description = t(
+  `Все ${spells.length} заклинаний класса ${clsName} в D&D ${verLabel}, сгруппированы по уровню, со школой и ссылками на страницы заклинаний.`,
+  `All ${spells.length} ${clsName} spells in D&D ${verLabel}, grouped by level, with school and links to each spell.`,
+);
+const otherClasses = SPELL_CLASSES.filter((c) => c.slug !== classSlug);
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={t(`Заклинания ${clsGen}`, `${clsGen} Spells`)}
+  description={description}
+  headings={headings}
+  upLink={{ href: `${base}/`, ru: 'Заклинания', en: 'Spells' }}
+>
+  <h1>{t(`Заклинания ${clsGen}`, `${clsGen} Spells`)}</h1>
+  <p>
+    {t(
+      `${spells.length} заклинаний доступно классу «${clsName}» в D&D ${verLabel}. Сгруппированы по уровню — от заговоров до 9-го. Нажмите на название, чтобы открыть страницу заклинания.`,
+      `${spells.length} spells are available to the ${clsName} in D&D ${verLabel}, grouped by level from cantrips to 9th. Select a name to open the spell page.`,
+    )}
+  </p>
+
+  {sections.map((sec) => (
+    <section>
+      <h2 id={`lvl-${sec.n}`}>{levelLabel(sec.n, lang)} <span class="hub-count">({sec.items.length})</span></h2>
+      <div class="rd-table-wrap">
+        <table class="hub-table">
+          <thead>
+            <tr><th>{t('Заклинание', 'Spell')}</th><th>{t('Школа', 'School')}</th></tr>
+          </thead>
+          <tbody>
+            {sec.items.map((s) => (
+              <tr>
+                <td><a href={spellHref(s.slug)}>{s.name}</a></td>
+                <td>{schoolLabel(s.school, lang)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  ))}
+
+  <nav class="hub-links" aria-label={t('Другие хабы заклинаний', 'Other spell hubs')}>
+    <p><strong>{t('Другие классы:', 'Other classes:')}</strong>{' '}
+      {otherClasses.map((c, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/class/${c.slug}/`}>{classLabel(c.slug, lang)}</a></>
+      ))}
+    </p>
+    <p><strong>{t('По уровню:', 'By level:')}</strong>{' '}
+      {LEVELS.map((n, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/level/${n}/`}>{levelLabel(n, lang)}</a></>
+      ))}
+    </p>
+  </nav>
+</ReaderShell>

--- a/web/src/pages/[lang]/dnd/[version]/spells/level/[level].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/level/[level].astro
@@ -1,0 +1,104 @@
+---
+import ReaderShell from '../../../../../../components/ReaderShell.astro';
+import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../../lib/entities';
+import {
+  SPELL_CLASSES, LEVELS, classLabel, levelLabel, schoolLabel, spellClassSlugs, byName,
+  type Lang, type SpellLite,
+} from '../../../../../../lib/spell-hubs';
+
+// Хаб заклинаний по уровню (issue #20, SEO §2.3): /{lang}/dnd/{version}/spells/level/{n}/.
+// Все заклинания уровня n (0 = заговоры) с колонкой классов (ссылки на класс-хабы). Ловит
+// «level 3 spells 5e» / «заклинания 3 уровня». EN/RU делят числовой слаг → каноникал + hreflang.
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-spells' };
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as Lang },
+    { ver: 'srd52', lang: 'ru' as Lang },
+  ];
+  const paths = [];
+  for (const { ver, lang } of BUILDS) {
+    const spells = loadEntities(ver, lang, 'spells') as unknown as SpellLite[];
+    for (const n of LEVELS) {
+      const mine = spells.filter((s) => s.level === n).sort(byName);
+      if (!mine.length) continue;
+      paths.push({
+        params: { lang, version: VERSION_SLUG[ver], level: String(n) },
+        props: { ver, lang, level: n, spells: mine },
+      });
+    }
+  }
+  return paths;
+}
+
+const { ver, lang, level, spells } = Astro.props as {
+  ver: string; lang: Lang; level: number; spells: SpellLite[];
+};
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+const base = `/${lang}/dnd/${verSlug}/spells`;
+const spellHref = (slug: string) => `${base}/${slug}/`;
+
+const heading = level === 0
+  ? t('Заговоры', 'Cantrips')
+  : t(`Заклинания ${level} уровня`, `Level ${level} Spells`);
+const title = `${heading} — D&D ${verLabel} · OmnisGM Rules`;
+const description = t(
+  `Все ${spells.length} ${level === 0 ? 'заговоров' : `заклинаний ${level} уровня`} в D&D ${verLabel}: школа, классы и ссылки на страницы заклинаний.`,
+  `All ${spells.length} ${level === 0 ? 'cantrips' : `level ${level} spells`} in D&D ${verLabel}: school, classes and links to each spell.`,
+);
+const otherLevels = LEVELS.filter((n) => n !== level);
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={heading}
+  description={description}
+  headings={[]}
+  upLink={{ href: `${base}/`, ru: 'Заклинания', en: 'Spells' }}
+>
+  <h1>{heading}</h1>
+  <p>
+    {t(
+      `${spells.length} ${level === 0 ? 'заговоров' : `заклинаний ${level} уровня`} в D&D ${verLabel}. В таблице — школа и классы, которым доступно заклинание. Нажмите на название, чтобы открыть страницу заклинания.`,
+      `${spells.length} ${level === 0 ? 'cantrips' : `level ${level} spells`} in D&D ${verLabel}. The table lists school and the classes that can cast each spell. Select a name to open the spell page.`,
+    )}
+  </p>
+
+  <div class="rd-table-wrap">
+    <table class="hub-table">
+      <thead>
+        <tr><th>{t('Заклинание', 'Spell')}</th><th>{t('Школа', 'School')}</th><th>{t('Классы', 'Classes')}</th></tr>
+      </thead>
+      <tbody>
+        {spells.map((s) => (
+          <tr>
+            <td><a href={spellHref(s.slug)}>{s.name}</a></td>
+            <td>{schoolLabel(s.school, lang)}</td>
+            <td>
+              {spellClassSlugs(s, lang).map((cs, i) => (
+                <>{i > 0 ? ', ' : ''}<a href={`${base}/class/${cs}/`}>{classLabel(cs, lang)}</a></>
+              ))}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+
+  <nav class="hub-links" aria-label={t('Другие хабы заклинаний', 'Other spell hubs')}>
+    <p><strong>{t('Другие уровни:', 'Other levels:')}</strong>{' '}
+      {otherLevels.map((n, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/level/${n}/`}>{levelLabel(n, lang)}</a></>
+      ))}
+    </p>
+    <p><strong>{t('По классу:', 'By class:')}</strong>{' '}
+      {SPELL_CLASSES.map((c, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/class/${c.slug}/`}>{classLabel(c.slug, lang)}</a></>
+      ))}
+    </p>
+  </nav>
+</ReaderShell>

--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -247,6 +247,12 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 .rd-doc tbody td { color: var(--og-text-2); line-height: 1.5; }
 .rd-doc tbody td:first-child { color: var(--og-text); font-weight: 500; }
 
+/* Хабы заклинаний (issue #20): счётчик у заголовка уровня + блок перелинковки на соседние хабы. */
+.rd-doc .hub-count { color: var(--og-text-muted); font-weight: 400; font-size: 0.85em; }
+.rd-doc .hub-links { margin: 28px 0 0; padding: 16px 0 0; border-top: 1px solid var(--og-border-soft); font-size: 14px; }
+.rd-doc .hub-links p { margin: 0 0 8px; color: var(--og-text-2); }
+.rd-doc .hub-links p:last-child { margin-bottom: 0; }
+
 .rd-source {
   margin: 36px 0 0; padding-top: 16px; border-top: 1px solid var(--og-border);
   display: flex; gap: 10px; align-items: baseline; flex-wrap: wrap;


### PR DESCRIPTION
Первый слой хабов (issue #20, SEO §2.3, **PR A из плана**) — фасетные списки-страницы, ловящие головные запросы («wizard spells 5e», «заклинания жреца 1 уровня»). **+36 индексируемых URL.**

## Роуты
Англ. слаг фасета → общий каноникал + hreflang (как у слагов сущностей):
- `spells/class/{class}` — **8** классов ×2 языка. Все заклинания класса, **H2-секции по уровням** (заговоры…9) → ловит и класс-запрос, и длинный хвост класс×уровень **без 80 тонких страниц** (согласованное решение).
- `spells/level/{n}` — **10** уровней ×2. Таблица: школа + колонка классов (ссылки на класс-хабы → внутренняя перелинковка).

## Ключевые детали
- **`lib/spell-hubs.ts`** — канонический маппинг класс-слаг ↔ `{en, ru, ruGen}`. В данных поле `classes` **переведено** (RU «Волшебник»), а URL-слаг языконезависим → фильтруем по имени на языке данных. `ruGen` — корректный род. падеж («Заклинания волшебника», а не наивное «+а», ломавшееся на Чародей/Жрец).
- `school` нормализуется двусторонним мапом (в RU JSON поле наполовину переведено).
- Через **`ReaderShell`** → canonical / hreflang / JSON-LD / nav / CTA бесплатно; класс-хаб отдаёт секции уровней в правый TOC.
- Перелинковка на соседние хабы внизу; таблицы в `.rd-table-wrap` (скролл на мобиле).
- **SEO-скрипт этапа 3 #22 расширен**: +2 типа хабов в сэмпл (18 стр. проверяются).

## Проверка
- Чистая пересборка **2492 стр. (+36)**; wizard-хаб **218 ссылок / 10 секций**, level-3 **42 ссылки**, каноникал/hreflang/JSON-LD в норме; **36 хаб-URL в sitemap**.
- **e2e 107/107** (+6 хаб-тестов); `astro check` 0 ошибок.

## Дальше по плану
- **PR B** — хабы монстров (тип + CR-диапазоны).
- **PR C** — перелинковка со страниц сущностей («ещё заклинания жреца») + хаб-овервью посадочные + опц. ItemList JSON-LD/сортировка.

🤖 Generated with [Claude Code](https://claude.com/claude-code)