### PR TITLE
Хабы монстров #20 (SEO §2.3, PR B): по типу и по CR

### DIFF
--- a/web/e2e/monster-hubs.spec.ts
+++ b/web/e2e/monster-hubs.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+// Хабы монстров (issue #20, SEO §2.3, PR B): по типу (13) и по CR (одиночные 0–10 + диапазоны
+// 11–16 / 17–30). Группировка по слагу через чистый EN-тип (RU-поле type непоследовательно).
+
+test('тип-хаб: драконы — список + ссылки, EN/RU симметрично по числу монстров', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/monsters-a-z/type/dragon/');
+  await expect(page.locator('h1')).toHaveText('Монстры типа «Дракон»');
+  const ru = await page.locator('.hub-table tbody tr').count();
+  expect(ru).toBeGreaterThan(30);
+  await page.goto('/en/dnd/srd-5.2/monsters-a-z/type/dragon/');
+  await expect(page.locator('h1')).toHaveText('Dragon Monsters');
+  expect(await page.locator('.hub-table tbody tr').count()).toBe(ru);
+});
+
+test('тип-хаб: ссылка на монстра ведёт на его страницу', async ({ page }) => {
+  await page.goto('/en/dnd/srd-5.2/monsters-a-z/type/aberration/');
+  await page.locator('.hub-table a[href$="/monsters-a-z/aboleth/"]').first().click();
+  await expect(page).toHaveURL(/\/monsters-a-z\/aboleth\/$/);
+  await expect(page.locator('h1')).toContainText('Aboleth');
+});
+
+test('CR-хаб: одиночный ПО 5 — все строки ровно CR 5', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/monsters-a-z/cr/5/');
+  await expect(page.locator('h1')).toHaveText('Монстры с ПО 5');
+  const crCells = await page.locator('.hub-table tbody tr td:nth-child(2)').allTextContents();
+  expect(crCells.length).toBeGreaterThan(0);
+  for (const c of crCells) expect(c.trim()).toBe('5');
+  // Колонка типа ссылается на type-хаб.
+  await expect(page.locator('.hub-table a[href*="/monsters-a-z/type/"]').first()).toBeVisible();
+});
+
+test('CR-хаб: диапазон 11–16 покрывает несколько CR + слаг дроби 1/2 → 1-2', async ({ page }) => {
+  await page.goto('/en/dnd/srd-5.2/monsters-a-z/cr/11-16/');
+  await expect(page.locator('h1')).toHaveText('CR 11–16 Monsters');
+  const crs = new Set(await page.locator('.hub-table tbody tr td:nth-child(2)').allTextContents());
+  expect(crs.size).toBeGreaterThan(1); // диапазон, а не одно значение
+  // Дробный CR — валидный слаг.
+  await page.goto('/en/dnd/srd-5.2/monsters-a-z/cr/1-2/');
+  await expect(page.locator('h1')).toContainText('CR 1/2');
+});
+
+test('SEO: тип-хаб самоканоничен + hreflang-тройка', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/monsters-a-z/type/dragon/');
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    'href', 'https://rules.omnisgm.com/ru/dnd/srd-5.2/monsters-a-z/type/dragon/');
+  for (const hl of ['en', 'ru', 'x-default']) {
+    await expect(page.locator(`link[rel="alternate"][hreflang="${hl}"]`)).toHaveCount(1);
+  }
+});

--- a/web/scripts/verify_dist_seo.mjs
+++ b/web/scripts/verify_dist_seo.mjs
@@ -32,6 +32,8 @@ const SAMPLE = [
   { type: 'glossary', tail: 'dnd/srd-5.2/rules-glossary/' },
   { type: 'spell-hub-class', tail: 'dnd/srd-5.2/spells/class/wizard/' },
   { type: 'spell-hub-level', tail: 'dnd/srd-5.2/spells/level/3/' },
+  { type: 'monster-hub-type', tail: 'dnd/srd-5.2/monsters-a-z/type/dragon/' },
+  { type: 'monster-hub-cr', tail: 'dnd/srd-5.2/monsters-a-z/cr/5/' },
 ];
 const LANGS = ['en', 'ru'];
 // Страницы, где noindex ЛЕГИТИМЕН (сейчас пусто — глоссарии переоткрыты в #106).

--- a/web/src/lib/monster-hubs.ts
+++ b/web/src/lib/monster-hubs.ts
@@ -1,0 +1,78 @@
+// Хабы монстров (issue #20, SEO §2.3, PR B): фасетные списки по типу и по CR.
+// Роуты: monsters-a-z/type/[type] и monsters-a-z/cr/[cr] (детали монстров — под monsters-a-z/).
+//
+// ВАЖНО: RU-поле `type` переведено НЕПОСЛЕДОВАТЕЛЬНО (construct → «конструкт»/«конструкция»,
+// fey → «фей»/«фея», monstrosity → «чудовище»/«чудовищность») — фильтровать по нему нельзя.
+// Группируем по СЛАГУ через чистый EN-тип (слаг языконезависим); `cr.value` чист в обоих языках.
+import { loadEntities } from './entities';
+
+export type Lang = 'en' | 'ru';
+
+export interface MonsterLite {
+  slug: string;
+  name: string;
+  size: string;
+  cr: string;         // «0», «1/2», «5», «30»
+  hp: number | null;  // среднее
+  ac: number | null;
+  typeSlug: string;   // канонический слаг типа (из EN-данных)
+}
+
+// Канонические типы (13). slug = EN-тип в lowercase. ru — единая подпись (без разнобоя данных).
+export const MONSTER_TYPES: { slug: string; en: string; ru: string }[] = [
+  { slug: 'aberration', en: 'Aberration', ru: 'Аберрация' },
+  { slug: 'celestial', en: 'Celestial', ru: 'Небожитель' },
+  { slug: 'construct', en: 'Construct', ru: 'Конструкт' },
+  { slug: 'dragon', en: 'Dragon', ru: 'Дракон' },
+  { slug: 'elemental', en: 'Elemental', ru: 'Элементаль' },
+  { slug: 'fey', en: 'Fey', ru: 'Фей' },
+  { slug: 'fiend', en: 'Fiend', ru: 'Исчадие' },
+  { slug: 'giant', en: 'Giant', ru: 'Великан' },
+  { slug: 'humanoid', en: 'Humanoid', ru: 'Гуманоид' },
+  { slug: 'monstrosity', en: 'Monstrosity', ru: 'Чудовище' },
+  { slug: 'ooze', en: 'Ooze', ru: 'Слизь' },
+  { slug: 'plant', en: 'Plant', ru: 'Растение' },
+  { slug: 'undead', en: 'Undead', ru: 'Нежить' },
+];
+export const typeBySlug = (slug: string) => MONSTER_TYPES.find((t) => t.slug === slug);
+export const typeLabel = (slug: string, lang: Lang) => {
+  const t = typeBySlug(slug);
+  return t ? t[lang] : slug;
+};
+
+// CR-хабы: одиночные для частых 0–10 (все ≥5 монстров), редкий тяжёлый хвост — в диапазоны.
+const CR_SINGLES = ['0', '1/8', '1/4', '1/2', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10'];
+const RANGE = (a: number, b: number) => Array.from({ length: b - a + 1 }, (_, i) => String(a + i));
+export const crSlug = (v: string) => v.replace('/', '-'); // «1/2» → «1-2»
+export interface CrHub { slug: string; label: string; values: string[] }
+export const CR_HUBS: CrHub[] = [
+  ...CR_SINGLES.map((v) => ({ slug: crSlug(v), label: v, values: [v] })),
+  { slug: '11-16', label: '11–16', values: RANGE(11, 16) },
+  { slug: '17-30', label: '17–30', values: RANGE(17, 30) },
+];
+export const crHubBySlug = (slug: string) => CR_HUBS.find((h) => h.slug === slug);
+export const crHubTitle = (h: CrHub, lang: Lang) => (lang === 'ru' ? `ПО ${h.label}` : `CR ${h.label}`);
+
+// Порядок CR для сортировки: «1/8»→0.125, «10»→10.
+export const crOrder = (v: string): number => {
+  if (v.includes('/')) { const [a, b] = v.split('/').map(Number); return a / b; }
+  return Number(v);
+};
+export const byCrThenName = (a: MonsterLite, b: MonsterLite) =>
+  crOrder(a.cr) - crOrder(b.cr) || a.name.localeCompare(b.name);
+
+// Монстры текущего языка с приклеенными фасетами. typeSlug — из EN-данных (чистый источник).
+export function monstersWithFacets(ver: string, lang: Lang): MonsterLite[] {
+  const enType = new Map(
+    (loadEntities(ver, 'en', 'monsters') as any[]).map((m) => [m.slug, String(m.type || '').toLowerCase()]),
+  );
+  return (loadEntities(ver, lang, 'monsters') as any[]).map((m) => ({
+    slug: m.slug,
+    name: m.name,
+    size: m.size ?? '',
+    cr: m.cr?.value ?? '0',
+    hp: typeof m.hp?.average === 'number' ? m.hp.average : null,
+    ac: typeof m.ac?.value === 'number' ? m.ac.value : null,
+    typeSlug: enType.get(m.slug) ?? 'monstrosity',
+  }));
+}

--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/cr/[cr].astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/cr/[cr].astro
@@ -1,0 +1,105 @@
+---
+import ReaderShell from '../../../../../../components/ReaderShell.astro';
+import { VERSION_SLUG, VERSION_LABEL } from '../../../../../../lib/entities';
+import {
+  MONSTER_TYPES, CR_HUBS, typeLabel, crHubTitle, crHubBySlug, byCrThenName, monstersWithFacets,
+  type Lang, type MonsterLite,
+} from '../../../../../../lib/monster-hubs';
+
+// Хаб монстров по CR (issue #20, SEO §2.3): /{lang}/dnd/{version}/monsters-a-z/cr/{cr}/.
+// Одиночные CR 0–10 (частые) + диапазоны 11–16 и 17–30 (редкий тяжёлый хвост, чтобы не плодить
+// тонкие страницы). Колонка типа → ссылки на type-хабы. Слаг «1/2»→«1-2».
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-monstersaz' };
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as Lang },
+    { ver: 'srd52', lang: 'ru' as Lang },
+  ];
+  const paths = [];
+  for (const { ver, lang } of BUILDS) {
+    const all = monstersWithFacets(ver, lang);
+    for (const hub of CR_HUBS) {
+      const set = new Set(hub.values);
+      const mine = all.filter((m) => set.has(m.cr)).sort(byCrThenName);
+      if (!mine.length) continue;
+      paths.push({
+        params: { lang, version: VERSION_SLUG[ver], cr: hub.slug },
+        props: { ver, lang, crHubSlug: hub.slug, monsters: mine },
+      });
+    }
+  }
+  return paths;
+}
+
+const { ver, lang, crHubSlug, monsters } = Astro.props as {
+  ver: string; lang: Lang; crHubSlug: string; monsters: MonsterLite[];
+};
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+const base = `/${lang}/dnd/${verSlug}/monsters-a-z`;
+const monHref = (slug: string) => `${base}/${slug}/`;
+const hub = crHubBySlug(crHubSlug)!;
+const crName = crHubTitle(hub, lang);
+
+const heading = t(`Монстры с ${crName}`, `${crName} Monsters`);
+const title = `${heading} — D&D ${verLabel} · OmnisGM Rules`;
+const description = t(
+  `Все ${monsters.length} монстров с ${crName} в D&D ${verLabel}: тип, размер и хиты, со ссылками на страницы монстров.`,
+  `All ${monsters.length} monsters of ${crName} in D&D ${verLabel}: type, size and HP, with links to each monster.`,
+);
+const otherCr = CR_HUBS.filter((h) => h.slug !== crHubSlug);
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={heading}
+  description={description}
+  headings={[]}
+  upLink={{ href: `${base}/`, ru: 'Монстры от А до Я', en: 'Monsters A–Z' }}
+>
+  <h1>{heading}</h1>
+  <p>
+    {t(
+      `${monsters.length} монстров с ${crName} в D&D ${verLabel}. В таблице — тип (ссылка на список типа), размер и хиты. Нажмите на имя, чтобы открыть страницу монстра.`,
+      `${monsters.length} monsters of ${crName} in D&D ${verLabel}. The table lists type (linked to its list), size and HP. Select a name to open the monster page.`,
+    )}
+  </p>
+
+  <div class="rd-table-wrap">
+    <table class="hub-table">
+      <thead>
+        <tr>
+          <th>{t('Монстр', 'Monster')}</th><th>{t('ПО', 'CR')}</th>
+          <th>{t('Тип', 'Type')}</th><th>{t('Размер', 'Size')}</th><th>{t('Хиты', 'HP')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {monsters.map((m) => (
+          <tr>
+            <td><a href={monHref(m.slug)}>{m.name}</a></td>
+            <td>{m.cr}</td>
+            <td><a href={`${base}/type/${m.typeSlug}/`}>{typeLabel(m.typeSlug, lang)}</a></td>
+            <td>{m.size}</td><td>{m.hp ?? '—'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+
+  <nav class="hub-links" aria-label={t('Другие хабы монстров', 'Other monster hubs')}>
+    <p><strong>{t('Другие CR:', 'Other CR:')}</strong>{' '}
+      {otherCr.map((h, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/cr/${h.slug}/`}>{crHubTitle(h, lang)}</a></>
+      ))}
+    </p>
+    <p><strong>{t('По типу:', 'By type:')}</strong>{' '}
+      {MONSTER_TYPES.map((x, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/type/${x.slug}/`}>{typeLabel(x.slug, lang)}</a></>
+      ))}
+    </p>
+  </nav>
+</ReaderShell>

--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/type/[type].astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/type/[type].astro
@@ -1,0 +1,101 @@
+---
+import ReaderShell from '../../../../../../components/ReaderShell.astro';
+import { VERSION_SLUG, VERSION_LABEL } from '../../../../../../lib/entities';
+import {
+  MONSTER_TYPES, CR_HUBS, typeLabel, crHubTitle, byCrThenName, monstersWithFacets,
+  type Lang, type MonsterLite,
+} from '../../../../../../lib/monster-hubs';
+
+// Хаб монстров по типу (issue #20, SEO §2.3): /{lang}/dnd/{version}/monsters-a-z/type/{type}/.
+// Все монстры типа, отсортированы по CR. EN/RU делят англ. слаг типа → каноникал + hreflang.
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-monstersaz' };
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as Lang },
+    { ver: 'srd52', lang: 'ru' as Lang },
+  ];
+  const paths = [];
+  for (const { ver, lang } of BUILDS) {
+    const all = monstersWithFacets(ver, lang);
+    for (const tp of MONSTER_TYPES) {
+      const mine = all.filter((m) => m.typeSlug === tp.slug).sort(byCrThenName);
+      if (!mine.length) continue;
+      paths.push({
+        params: { lang, version: VERSION_SLUG[ver], type: tp.slug },
+        props: { ver, lang, typeSlug: tp.slug, monsters: mine },
+      });
+    }
+  }
+  return paths;
+}
+
+const { ver, lang, typeSlug, monsters } = Astro.props as {
+  ver: string; lang: Lang; typeSlug: string; monsters: MonsterLite[];
+};
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+const base = `/${lang}/dnd/${verSlug}/monsters-a-z`;
+const monHref = (slug: string) => `${base}/${slug}/`;
+const tp = typeLabel(typeSlug, lang);
+
+const heading = t(`Монстры типа «${tp}»`, `${tp} Monsters`);
+const title = `${heading} — D&D ${verLabel} · OmnisGM Rules`;
+const description = t(
+  `Все ${monsters.length} монстров типа «${tp}» в D&D ${verLabel}: показатель опасности, размер, хиты и КД, со ссылками на страницы монстров.`,
+  `All ${monsters.length} ${tp} monsters in D&D ${verLabel}: challenge rating, size, HP and AC, with links to each monster.`,
+);
+const otherTypes = MONSTER_TYPES.filter((x) => x.slug !== typeSlug);
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={heading}
+  description={description}
+  headings={[]}
+  upLink={{ href: `${base}/`, ru: 'Монстры от А до Я', en: 'Monsters A–Z' }}
+>
+  <h1>{heading}</h1>
+  <p>
+    {t(
+      `${monsters.length} монстров типа «${tp}» в D&D ${verLabel}, по возрастанию показателя опасности. Нажмите на имя, чтобы открыть страницу монстра.`,
+      `${monsters.length} ${tp} monsters in D&D ${verLabel}, ordered by challenge rating. Select a name to open the monster page.`,
+    )}
+  </p>
+
+  <div class="rd-table-wrap">
+    <table class="hub-table">
+      <thead>
+        <tr>
+          <th>{t('Монстр', 'Monster')}</th><th>{t('ПО', 'CR')}</th>
+          <th>{t('Размер', 'Size')}</th><th>{t('Хиты', 'HP')}</th><th>{t('КД', 'AC')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {monsters.map((m) => (
+          <tr>
+            <td><a href={monHref(m.slug)}>{m.name}</a></td>
+            <td>{m.cr}</td><td>{m.size}</td>
+            <td>{m.hp ?? '—'}</td><td>{m.ac ?? '—'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+
+  <nav class="hub-links" aria-label={t('Другие хабы монстров', 'Other monster hubs')}>
+    <p><strong>{t('Другие типы:', 'Other types:')}</strong>{' '}
+      {otherTypes.map((x, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/type/${x.slug}/`}>{typeLabel(x.slug, lang)}</a></>
+      ))}
+    </p>
+    <p><strong>{t('По CR:', 'By CR:')}</strong>{' '}
+      {CR_HUBS.map((h, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/cr/${h.slug}/`}>{crHubTitle(h, lang)}</a></>
+      ))}
+    </p>
+  </nav>
+</ReaderShell>


### PR DESCRIPTION
Второй слой хабов (issue #20, SEO §2.3, **PR B**) — монстры. **+58 индексируемых URL** («cr 5 monsters 5e», «драконы днд»). Под `monsters-a-z/` (там же детали, `PARENT_NAV=d52-monstersaz`).

## Роуты
Англ. слаг фасета → общий каноникал + hreflang:
- `monsters-a-z/type/{type}` — **13** типов ×2. Все монстры типа, сортировка по CR.
- `monsters-a-z/cr/{cr}` — **14 одиночных CR** (0–10, частые, все ≥5 монстров) + **2 диапазона** (11–16, 17–30 — редкий тяжёлый хвост, чтобы не плодить тонкие страницы; согласованное решение). Слаг дроби «1/2»→«1-2». Колонка типа ссылается на type-хаб.

## Ключевое (`lib/monster-hubs.ts`)
RU-поле `type` переведено **непоследовательно** (construct→«конструкт»/«конструкция», fey→«фей»/«фея», monstrosity→«чудовище»/«чудовищность») — фильтровать по нему нельзя. Группируем по **слагу через чистый EN-тип** (слаг языконезависим), RU-подписи типов — единый курируемый список. `cr.value` чист в обоих языках. Все монстры покрыты схемой (проверено), коллизий слагов с `type`/`cr` нет.

SEO-скрипт этапа 3 расширен: +2 типа монстр-хабов (22 стр. проверяются).

## Проверка
- Пересборка **2550 стр. (+58)**; dragon-хаб **45** монстров (EN=RU), CR 5 = **22**, диапазон 11–16 = **27** (все CR 11..16), каноникал/hreflang/JSON-LD в норме, **58 хаб-URL в sitemap**.
- **e2e 112/112** (+5); `astro check` 0 ошибок.

## Дальше
**PR C** — перелинковка со страниц сущностей («ещё драконы» / «ещё CR 5» на странице монстра; «ещё заклинания жреца» на странице спелла) + хаб-овервью посадочные + опц. ItemList JSON-LD/сортировка.

🤖 Generated with [Claude Code](https://claude.com/claude-code)