### PR TITLE
Хабы #20 (SEO §2.3, PR C): обратная перелинковка сущность → хаб

### DIFF
--- a/web/e2e/monster-hubs.spec.ts
+++ b/web/e2e/monster-hubs.spec.ts
@@ -40,6 +40,17 @@ test('CR-хаб: диапазон 11–16 покрывает несколько 
   await expect(page.locator('h1')).toContainText('CR 1/2');
 });
 
+test('обратная перелинковка (PR C): страница монстра ведёт в хабы типа и CR (вкл. диапазон)', async ({ page }) => {
+  // Аболет — CR 10 (одиночный хаб) + тип аберрация.
+  await page.goto('/ru/dnd/srd-5.2/monsters-a-z/aboleth/');
+  await expect(page.locator('.ent-hubs a[href$="/monsters-a-z/type/aberration/"]')).toBeVisible();
+  await expect(page.locator('.ent-hubs a[href$="/monsters-a-z/cr/10/"]')).toBeVisible();
+  // Взрослый латунный дракон — CR 13 → диапазонный хаб 11-16.
+  await page.goto('/en/dnd/srd-5.2/monsters-a-z/adult-brass-dragon/');
+  await expect(page.locator('.ent-hubs a[href$="/monsters-a-z/cr/11-16/"]')).toBeVisible();
+  await expect(page.locator('.ent-hubs a[href$="/monsters-a-z/type/dragon/"]')).toBeVisible();
+});
+
 test('SEO: тип-хаб самоканоничен + hreflang-тройка', async ({ page }) => {
   await page.goto('/ru/dnd/srd-5.2/monsters-a-z/type/dragon/');
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(

--- a/web/e2e/spell-hubs.spec.ts
+++ b/web/e2e/spell-hubs.spec.ts
@@ -46,6 +46,14 @@ test('уровень-хаб: заговоры (level 0) — заголовок �
   await expect(page.locator('h1')).toHaveText('Cantrips');
 });
 
+test('обратная перелинковка (PR C): страница заклинания ведёт в хабы классов и уровня', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/fireball/');
+  const hubs = page.locator('.ent-hubs');
+  await expect(hubs.locator('a[href$="/spells/class/wizard/"]')).toBeVisible();
+  await expect(hubs.locator('a[href$="/spells/class/sorcerer/"]')).toBeVisible();
+  await expect(hubs.locator('a[href$="/spells/level/3/"]')).toBeVisible();
+});
+
 test('SEO: класс-хаб самоканоничен + hreflang-тройка', async ({ page }) => {
   await page.goto('/ru/dnd/srd-5.2/spells/class/wizard/');
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(

--- a/web/src/lib/monster-hubs.ts
+++ b/web/src/lib/monster-hubs.ts
@@ -51,7 +51,17 @@ export const CR_HUBS: CrHub[] = [
   { slug: '17-30', label: '17–30', values: RANGE(17, 30) },
 ];
 export const crHubBySlug = (slug: string) => CR_HUBS.find((h) => h.slug === slug);
+// Хаб, покрывающий конкретное значение CR (одиночный или диапазон) — для ссылки со страницы монстра.
+export const crHubForValue = (v: string) => CR_HUBS.find((h) => h.values.includes(v));
 export const crHubTitle = (h: CrHub, lang: Lang) => (lang === 'ru' ? `ПО ${h.label}` : `CR ${h.label}`);
+
+// Карта slug → канонический слаг типа (из EN-данных) — чтобы страница монстра любого языка
+// сослалась на верный type-хаб, не завися от непоследовательного RU-поля type.
+export function enTypeMap(ver: string): Map<string, string> {
+  return new Map(
+    (loadEntities(ver, 'en', 'monsters') as any[]).map((m) => [m.slug, String(m.type || '').toLowerCase()]),
+  );
+}
 
 // Порядок CR для сортировки: «1/8»→0.125, «10»→10.
 export const crOrder = (v: string): number => {

--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/[slug].astro
@@ -7,6 +7,7 @@ import { autolinkTree } from '../../../../../lib/rehype-entity-autolink.mjs';
 import { highlightKeywords } from '../../../../../lib/keyword-highlight.mjs';
 import { glossRules } from '../../../../../lib/rules-gloss.mjs';
 import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
+import { enTypeMap, typeLabel, crHubForValue, crHubTitle } from '../../../../../lib/monster-hubs';
 
 // Programmatic-страницы монстров (issue #20, волна 3) в общем шелле ридера.
 // URL вложен под главу-бестиарий: /{lang}/dnd/{version}/monsters-a-z/{slug}/.
@@ -23,6 +24,7 @@ export function getStaticPaths() {
   const paths = [];
   for (const { ver, lang } of BUILDS) {
     const monsters = loadEntities(ver, lang, 'monsters');
+    const typeMap = enTypeMap(ver); // slug → канонический typeSlug (из EN), для ссылки в type-хаб
     const siblings: Sib[] = monsters.map((m) => ({
       slug: m.slug, name: m.name,
       type: (m.type as string) ?? '', cr: (m.cr as { value?: string })?.value ?? '',
@@ -35,14 +37,14 @@ export function getStaticPaths() {
     for (const entity of monsters) {
       paths.push({
         params: { lang, version: VERSION_SLUG[ver], slug: entity.slug },
-        props: { entity, ver, lang, siblings, condMap },
+        props: { entity, ver, lang, siblings, condMap, typeSlug: typeMap.get(entity.slug) ?? 'monstrosity' },
       });
     }
   }
   return paths;
 }
 
-const { entity, ver, lang, siblings, condMap } = Astro.props;
+const { entity, ver, lang, siblings, condMap, typeSlug } = Astro.props;
 const verSlug = VERSION_SLUG[ver];
 const verLabel = VERSION_LABEL[ver];
 const verKey = ver; // srd52
@@ -250,6 +252,16 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
       </span>
     </nav>
   )}
+
+  <nav class="ent-hubs" aria-label={t('Списки монстров', 'Monster lists')}>
+    <span class="ent-related-h">{t('Ещё монстры', 'More monsters')}</span>
+    <span class="ent-related-list">
+      <a href={`${base}/type/${typeSlug}/`}>{typeLabel(typeSlug, lang)}</a>
+      {crHubForValue(cr.value ?? '0') && (
+        <a href={`${base}/cr/${crHubForValue(cr.value ?? '0')!.slug}/`}>{crHubTitle(crHubForValue(cr.value ?? '0')!, lang)}</a>
+      )}
+    </span>
+  </nav>
 </ReaderShell>
 
 <style>
@@ -296,6 +308,7 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
   .mon-entry { margin: 0 0 4px; }
 
   .ent-related { display: block; margin-top: 40px; padding-top: 20px; border-top: 1px solid var(--og-border); }
+  .ent-hubs { display: block; margin-top: 24px; padding-top: 16px; border-top: 1px solid var(--og-border-soft); }
   .ent-related-h {
     display: block; font-size: 13px; text-transform: uppercase; letter-spacing: 1px;
     color: var(--og-text-muted); margin-bottom: 10px;

--- a/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
@@ -7,6 +7,7 @@ import { autolinkTree } from '../../../../../lib/rehype-entity-autolink.mjs';
 import { highlightKeywords } from '../../../../../lib/keyword-highlight.mjs';
 import { glossRules } from '../../../../../lib/rules-gloss.mjs';
 import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
+import { spellClassSlugs, classLabel, levelLabel } from '../../../../../lib/spell-hubs';
 
 // Programmatic-страницы заклинаний (issue #20, волна 2) в общем шелле ридера.
 // URL: /{lang}/dnd/{version}/spells/{slug}/. EN и RU делят канонический (англ.) слаг → hreflang.
@@ -144,6 +145,9 @@ const sameSchool = (siblings as { slug: string; name: string; school: string }[]
   .slice(0, 8);
 
 const upLink = { href: `${base}/`, ru: 'Заклинания', en: 'Spells' };
+// Обратная перелинковка в хабы (issue #20, PR C): классы заклинания + его уровень.
+const hubClassSlugs = spellClassSlugs(entity as any, lang);
+const spellLevel = entity.level as number;
 const kind = t('Заклинание', 'Spell');
 const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel} ${kind}`)} · OmnisGM Rules`;
 ---
@@ -241,6 +245,16 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
       </span>
     </nav>
   )}
+
+  <nav class="ent-hubs" aria-label={t('Списки заклинаний', 'Spell lists')}>
+    <span class="ent-related-h">{t('Ещё заклинания', 'More spells')}</span>
+    <span class="ent-related-list">
+      {hubClassSlugs.map((cs) => (
+        <a href={`${base}/class/${cs}/`}>{classLabel(cs, lang)}</a>
+      ))}
+      <a href={`${base}/level/${spellLevel}/`}>{levelLabel(spellLevel, lang)}</a>
+    </span>
+  </nav>
 </ReaderShell>
 
 <style>
@@ -286,6 +300,7 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
     .spell-meta dd { display: inline; }
   }
   .ent-related { display: block; margin-top: 40px; padding-top: 20px; border-top: 1px solid var(--og-border); }
+  .ent-hubs { display: block; margin-top: 24px; padding-top: 16px; border-top: 1px solid var(--og-border-soft); }
   .ent-related-h {
     display: block; font-size: 13px; text-transform: uppercase; letter-spacing: 1px;
     color: var(--og-text-muted); margin-bottom: 10px;


### PR DESCRIPTION
Финальный слой хабов (issue #20, SEO §2.3, **PR C**) — замыкает связь **сущность ↔ хаб** (была односторонней: хаб→сущность). Теперь каждая из **~339 страниц заклинаний** и **~235 монстров** ведёт в свои хабы — передаёт им ссылочный вес и даёт навигацию «ещё такого же».

## Что добавлено
- **Страница заклинания** → хабы всех её классов + хаб её уровня (блок «Ещё заклинания»). Пример: Fireball → `class/wizard` + `class/sorcerer` + `level/3`.
- **Страница монстра** → хаб типа + хаб CR (одиночный **или диапазонный**: CR 13 → `cr/11-16`). Пример: Aboleth → `type/aberration` + `cr/10`.
  - `typeSlug` берётся из EN-данных (RU-поле `type` непоследовательно) через `enTypeMap`; CR→хаб через `crHubForValue`.

Блок оформлен **отдельным классом `.ent-hubs`** (лёгкий бордюр), а не общим `.ent-related` — чтобы не ломать строгие селекторы существующих related-тестов.

## Проверка
- Пересборка 2550 стр.; fireball → wizard+sorcerer+level/3; aboleth → aberration+cr/10; adult-brass-dragon (CR 13) → dragon+**cr/11-16**; SEO-скрипт зелёный.
- **e2e 114/114** (+2 обратной перелинковки); `astro check` 0 ошибок.

## Область / решения
- Овервью-посадочные (`/spells/`, `/monsters/`) **не делаем** — их URL заняты главами; перелинковка сущность↔хаб↔хаб уже полная.
- ItemList JSON-LD на хабах — опциональный полиш, можно отдельным мелким PR.

**Хабы завершены (A+B+C):** заклинания (36) + монстры (58) + двусторонняя перелинковка.

🤖 Generated with [Claude Code](https://claude.com/claude-code)