### PR TITLE
Хабы #20: стиль ссылок — под конвенции ридера

### DIFF
--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/[slug].astro
@@ -256,9 +256,9 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
   <nav class="ent-hubs" aria-label={t('Списки монстров', 'Monster lists')}>
     <span class="ent-related-h">{t('Ещё монстры', 'More monsters')}</span>
     <span class="ent-related-list">
-      <a href={`${base}/type/${typeSlug}/`}>{typeLabel(typeSlug, lang)}</a>
+      <a href={`${base}/type/${typeSlug}/`}><strong>{typeLabel(typeSlug, lang)}</strong></a>
       {crHubForValue(cr.value ?? '0') && (
-        <a href={`${base}/cr/${crHubForValue(cr.value ?? '0')!.slug}/`}>{crHubTitle(crHubForValue(cr.value ?? '0')!, lang)}</a>
+        <a href={`${base}/cr/${crHubForValue(cr.value ?? '0')!.slug}/`}><strong>{crHubTitle(crHubForValue(cr.value ?? '0')!, lang)}</strong></a>
       )}
     </span>
   </nav>

--- a/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
@@ -250,9 +250,9 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
     <span class="ent-related-h">{t('Ещё заклинания', 'More spells')}</span>
     <span class="ent-related-list">
       {hubClassSlugs.map((cs) => (
-        <a href={`${base}/class/${cs}/`}>{classLabel(cs, lang)}</a>
+        <a href={`${base}/class/${cs}/`}><strong>{classLabel(cs, lang)}</strong></a>
       ))}
-      <a href={`${base}/level/${spellLevel}/`}>{levelLabel(spellLevel, lang)}</a>
+      <a href={`${base}/level/${spellLevel}/`}><strong>{levelLabel(spellLevel, lang)}</strong></a>
     </span>
   </nav>
 </ReaderShell>

--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -252,6 +252,12 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 .rd-doc .hub-links { margin: 28px 0 0; padding: 16px 0 0; border-top: 1px solid var(--og-border-soft); font-size: 14px; }
 .rd-doc .hub-links p { margin: 0 0 8px; color: var(--og-text-2); }
 .rd-doc .hub-links p:last-child { margin-bottom: 0; }
+/* В плотных списках-хабах ссылка в каждой строке → сплошное подчёркивание базового .rd-doc a
+   даёт «частокол». Убираем постоянную линию, показываем по наведению; цвет-акцент сохраняем. */
+.rd-doc .hub-table a, .rd-doc .hub-links a { border-bottom: none; }
+.rd-doc .hub-table a:hover, .rd-doc .hub-links a:hover {
+  border-bottom: 1px solid color-mix(in oklab, var(--og-accent) 55%, transparent);
+}
 
 .rd-source {
   margin: 36px 0 0; padding-top: 16px; border-top: 1px solid var(--og-border);


### PR DESCRIPTION
Правит два расхождения стиля ссылок, замеченные после хабов.

## 1. «Частокол» подчёркиваний в таблицах хабов
Ссылка в каждой строке (`.hub-table`) и в футере-перелинковке (`.hub-links`) получала сплошное подчёркивание базового `.rd-doc a` → в плотном списке это визуальный шум. Убрал постоянную линию, показываю **по наведению**; цвет-акцент сохранён.

## 2. Блок «Ещё заклинания/монстры» не совпадал с соседним
На страницах сущностей блок `.ent-hubs` шёл голыми `<a>` (акцентный цвет), а соседний «Ещё из школы/типа» (`.ent-related`) использует `<a><strong>` (белый от `.rd-doc strong` + акцентное подчёркивание). Обернул ссылки в `<strong>` → единый вид.

## Проверка
Визуально (скриншоты класс-хаба, CR-хаба, низа страницы заклинания — блоки совпали) + **e2e 13/13** хабов, `astro check` 0 ошибок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)