### PR TITLE
Хабы #20: ссылки в таблицах — белый текст + фиолетовое подчёркивание

### DIFF
--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -252,12 +252,14 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 .rd-doc .hub-links { margin: 28px 0 0; padding: 16px 0 0; border-top: 1px solid var(--og-border-soft); font-size: 14px; }
 .rd-doc .hub-links p { margin: 0 0 8px; color: var(--og-text-2); }
 .rd-doc .hub-links p:last-child { margin-bottom: 0; }
-/* В плотных списках-хабах ссылка в каждой строке → сплошное подчёркивание базового .rd-doc a
-   даёт «частокол». Убираем постоянную линию, показываем по наведению; цвет-акцент сохраняем. */
-.rd-doc .hub-table a, .rd-doc .hub-links a { border-bottom: none; }
-.rd-doc .hub-table a:hover, .rd-doc .hub-links a:hover {
-  border-bottom: 1px solid color-mix(in oklab, var(--og-accent) 55%, transparent);
+/* Ссылки в хаб-таблицах/футере — как контентные чипы: БЕЛЫЙ текст (а не заливка акцентом) +
+   акцентное подчёркивание, темнеет по наведению. Базовый .rd-doc a красит текст акцентом
+   («всё фиолетовое») — переопределяем цвет на текстовый, оставляя фиолетовую линию. */
+.rd-doc .hub-table a, .rd-doc .hub-links a {
+  color: var(--og-text);
+  border-bottom: 1px solid color-mix(in oklab, var(--og-accent) 45%, transparent);
 }
+.rd-doc .hub-table a:hover, .rd-doc .hub-links a:hover { border-bottom-color: var(--og-accent); }
 
 .rd-source {
   margin: 36px 0 0; padding-top: 16px; border-top: 1px solid var(--og-border);


### PR DESCRIPTION
Правит стиль ссылок в таблицах хабов по фидбеку владельца.

## Проблема
Прошлый фикс убрал подчёркивание совсем → ссылки остались залиты акцентом: **вся таблица — «стена фиолетового текста»**. По дизайну ссылка должна быть **белой с фиолетовым подчёркиванием** (как контентные чипы «Ещё из школы», `<a><strong>`).

## Фикс
В `.hub-table a` / `.hub-links a`: `color: var(--og-text)` (белый) + `border-bottom` акцентом (фиолетовая линия, темнеет по наведению). Базовый `.rd-doc a` красил текст акцентом — снимаем заливку, оставляем линию.

## Проверка
Вычисленный стиль ссылки = `color: rgb(230,230,233)` + `border-bottom: 1px` акцент; скриншот — белые ссылки с тонким фиолетовым подчёркиванием, «фиолетовой стены» нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)