### PR TITLE
Хабы #20: ссылки — под эталон глоссария (.ent-link, пунктир)

### DIFF
--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/[slug].astro
@@ -247,7 +247,7 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
       <span class="ent-related-h">{t(`Ещё существа: ${creatureType}`, `More ${creatureType} creatures`)}</span>
       <span class="ent-related-list">
         {sameType.map((r) => (
-          <a href={`${base}/${r.slug}/`}><strong>{r.name}</strong></a>
+          <a href={`${base}/${r.slug}/`}>{r.name}</a>
         ))}
       </span>
     </nav>
@@ -256,9 +256,9 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
   <nav class="ent-hubs" aria-label={t('Списки монстров', 'Monster lists')}>
     <span class="ent-related-h">{t('Ещё монстры', 'More monsters')}</span>
     <span class="ent-related-list">
-      <a href={`${base}/type/${typeSlug}/`}><strong>{typeLabel(typeSlug, lang)}</strong></a>
+      <a href={`${base}/type/${typeSlug}/`}>{typeLabel(typeSlug, lang)}</a>
       {crHubForValue(cr.value ?? '0') && (
-        <a href={`${base}/cr/${crHubForValue(cr.value ?? '0')!.slug}/`}><strong>{crHubTitle(crHubForValue(cr.value ?? '0')!, lang)}</strong></a>
+        <a href={`${base}/cr/${crHubForValue(cr.value ?? '0')!.slug}/`}>{crHubTitle(crHubForValue(cr.value ?? '0')!, lang)}</a>
       )}
     </span>
   </nav>

--- a/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
@@ -240,7 +240,7 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
       <span class="ent-related-h">{t(`Ещё из школы ${school}`, `More ${school} spells`)}</span>
       <span class="ent-related-list">
         {sameSchool.map((r) => (
-          <a href={`${base}/${r.slug}/`}><strong>{r.name}</strong></a>
+          <a href={`${base}/${r.slug}/`}>{r.name}</a>
         ))}
       </span>
     </nav>
@@ -250,9 +250,9 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
     <span class="ent-related-h">{t('Ещё заклинания', 'More spells')}</span>
     <span class="ent-related-list">
       {hubClassSlugs.map((cs) => (
-        <a href={`${base}/class/${cs}/`}><strong>{classLabel(cs, lang)}</strong></a>
+        <a href={`${base}/class/${cs}/`}>{classLabel(cs, lang)}</a>
       ))}
-      <a href={`${base}/level/${spellLevel}/`}><strong>{levelLabel(spellLevel, lang)}</strong></a>
+      <a href={`${base}/level/${spellLevel}/`}>{levelLabel(spellLevel, lang)}</a>
     </span>
   </nav>
 </ReaderShell>

--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -252,14 +252,19 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 .rd-doc .hub-links { margin: 28px 0 0; padding: 16px 0 0; border-top: 1px solid var(--og-border-soft); font-size: 14px; }
 .rd-doc .hub-links p { margin: 0 0 8px; color: var(--og-text-2); }
 .rd-doc .hub-links p:last-child { margin-bottom: 0; }
-/* Ссылки в хаб-таблицах/футере — как контентные чипы: БЕЛЫЙ текст (а не заливка акцентом) +
-   акцентное подчёркивание, темнеет по наведению. Базовый .rd-doc a красит текст акцентом
-   («всё фиолетовое») — переопределяем цвет на текстовый, оставляя фиолетовую линию. */
-.rd-doc .hub-table a, .rd-doc .hub-links a {
-  color: var(--og-text);
-  border-bottom: 1px solid color-mix(in oklab, var(--og-accent) 45%, transparent);
+/* Ссылки в хаб-таблицах/футере — как автоссылки .ent-link в глоссарии (эталон владельца):
+   цвет НАСЛЕДУЕТСЯ от ячейки (имя-столбец белый, классы — приглушённые), подчёркивание
+   ПУНКТИРНОЕ акцентом; по наведению — сплошное + акцентный цвет. Базовый .rd-doc a красил
+   текст акцентом сплошной линией («всё фиолетовое») — переопределяем на эталон. */
+.rd-doc .hub-table a, .rd-doc .hub-links a, .rd-doc .ent-related-list a {
+  color: inherit;
+  border-bottom: 1px dashed color-mix(in oklab, var(--og-accent) 55%, transparent);
 }
-.rd-doc .hub-table a:hover, .rd-doc .hub-links a:hover { border-bottom-color: var(--og-accent); }
+.rd-doc .hub-table a:hover, .rd-doc .hub-links a:hover, .rd-doc .ent-related-list a:hover {
+  color: var(--og-accent);
+  border-bottom-style: solid;
+  border-bottom-color: var(--og-accent);
+}
 
 .rd-source {
   margin: 36px 0 0; padding-top: 16px; border-top: 1px solid var(--og-border);


### PR DESCRIPTION
Приводит стиль ссылок к эталону, который указал владелец — таблица **глоссария** (`/glossary/spells/`).

## Эталон
Ссылки там — в стиле автоссылок `.ent-link`: цвет **наследуется** от ячейки (имя-столбец белый, метаданные приглушённые), подчёркивание **пунктирное** акцентом, по наведению — сплошное + акцент. Прошлые попытки (сплошной акцент; белый+сплошной) не совпадали.

## Фикс
Единым правилом `reader.css` привёл к `.ent-link`:
- `.hub-table a` + `.hub-links a` — таблицы и футер хабов;
- `.ent-related-list a` — накрывает и «Ещё из школы/типа», и «Ещё заклинания/монстры» на страницах сущностей (их тоже отметили как неправильный формат).

Убрал `<strong>` из этих блоков (глоссарий не жирный).

## Результат
- Вычисленный стиль: имя-ссылка `rgb(230,230,233)`+dashed, класс-ссылка `rgb(166,169,184)`+dashed — как в глоссарии.
- Скриншоты хаба и низа страницы заклинания совпадают с эталоном.
- **e2e 23/23** (хабы+спеллы+монстры), `astro check` 0 ошибок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)