### PR TITLE
Сквозной аудит формата ссылок: везде под эталон глоссария

### DIFF
--- a/web/src/pages/[lang]/dnd/[version]/animals/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/animals/[slug].astro
@@ -249,7 +249,7 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
       <span class="ent-related-h">{t(`Ещё животные: ПО ${cr?.value}`, `More CR ${cr?.value} animals`)}</span>
       <span class="ent-related-list">
         {sameCr.map((r) => (
-          <a href={`${base}/${r.slug}/`}><strong>{r.name}</strong></a>
+          <a href={`${base}/${r.slug}/`}>{r.name}</a>
         ))}
       </span>
     </nav>

--- a/web/src/pages/[lang]/dnd/[version]/armor/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/armor/[slug].astro
@@ -124,7 +124,7 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
       <span class="ent-related-h">{isShield ? t('Ещё доспехи', 'More armor') : t(`Ещё: ${catLabel} доспех`, `More ${catLabel} armor`)}</span>
       <span class="ent-related-list">
         {similar.map((r) => (
-          <a href={`${base}/${r.slug}/`}><strong>{r.name}</strong></a>
+          <a href={`${base}/${r.slug}/`}>{r.name}</a>
         ))}
       </span>
     </nav>

--- a/web/src/pages/[lang]/dnd/[version]/equipment/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/equipment/[slug].astro
@@ -146,7 +146,7 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
       <span class="ent-related-h">{t(`Ещё: ${sectionLabel}`, `More ${sectionLabel}`)}</span>
       <span class="ent-related-list">
         {sameSection.map((r) => (
-          <a href={`${base}/${r.slug}/`}><strong>{r.name}</strong></a>
+          <a href={`${base}/${r.slug}/`}>{r.name}</a>
         ))}
       </span>
     </nav>

--- a/web/src/pages/[lang]/dnd/[version]/feats/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/feats/[slug].astro
@@ -124,7 +124,7 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
       <span class="ent-related-h">{t(`Ещё: ${catLabel}`, `More: ${catLabel}`)}</span>
       <span class="ent-related-list">
         {sameCat.map((r) => (
-          <a href={`${base}/${r.slug}/`}><strong>{r.name}</strong></a>
+          <a href={`${base}/${r.slug}/`}>{r.name}</a>
         ))}
       </span>
     </nav>

--- a/web/src/pages/[lang]/dnd/[version]/magic-items/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/magic-items/[slug].astro
@@ -117,7 +117,7 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
       <span class="ent-related-h">{t(`Ещё: ${itemType}`, `More ${itemType}`)}</span>
       <span class="ent-related-list">
         {sameType.map((r) => (
-          <a href={`${base}/${r.slug}/`}><strong>{r.name}</strong></a>
+          <a href={`${base}/${r.slug}/`}>{r.name}</a>
         ))}
       </span>
     </nav>

--- a/web/src/pages/[lang]/dnd/[version]/rules-glossary/conditions/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/rules-glossary/conditions/[slug].astro
@@ -80,7 +80,7 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
       <span class="ent-related-h">{t('Другие состояния', 'Other conditions')}</span>
       <span class="ent-related-list">
         {related.map((r) => (
-          <a href={`${base}/${r.slug}/`}><strong>{r.name}</strong></a>
+          <a href={`${base}/${r.slug}/`}>{r.name}</a>
         ))}
       </span>
     </nav>

--- a/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
@@ -201,7 +201,7 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
         <dt>{t('Классы', 'Classes')}</dt>
         <dd>
           {classList.map((c, i) => (
-            <Fragment>{i > 0 ? ', ' : ''}{CLASS_SLUG[c] ? <a href={classUrl(CLASS_SLUG[c])}><strong>{c}</strong></a> : c}</Fragment>
+            <Fragment>{i > 0 ? ', ' : ''}{CLASS_SLUG[c] ? <a href={classUrl(CLASS_SLUG[c])}>{c}</a> : c}</Fragment>
           ))}
         </dd>
       </div>
@@ -212,7 +212,7 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
         <dd>
           {subList.map((s, i) => (
             <Fragment>{i > 0 ? ', ' : ''}{subClass(s)
-              ? <a href={subUrl(s)}><strong>{subClsName(s)}: {s}</strong></a>
+              ? <a href={subUrl(s)}>{subClsName(s)}: {s}</a>
               : s}</Fragment>
           ))}
         </dd>

--- a/web/src/pages/[lang]/dnd/[version]/weapons/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/weapons/[slug].astro
@@ -169,7 +169,7 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
       <span class="ent-related-h">{t(`Ещё: ${catLabel} оружие ${typeLabel}`, `More ${catLabel} ${typeLabel} weapons`)}</span>
       <span class="ent-related-list">
         {similar.map((r) => (
-          <a href={`${base}/${r.slug}/`}><strong>{r.name}</strong></a>
+          <a href={`${base}/${r.slug}/`}>{r.name}</a>
         ))}
       </span>
     </nav>

--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -256,15 +256,18 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
    цвет НАСЛЕДУЕТСЯ от ячейки (имя-столбец белый, классы — приглушённые), подчёркивание
    ПУНКТИРНОЕ акцентом; по наведению — сплошное + акцентный цвет. Базовый .rd-doc a красил
    текст акцентом сплошной линией («всё фиолетовое») — переопределяем на эталон. */
-.rd-doc .hub-table a, .rd-doc .hub-links a, .rd-doc .ent-related-list a {
+.rd-doc .hub-table a, .rd-doc .hub-links a, .rd-doc .ent-related-list a, .rd-doc .spell-meta a {
   color: inherit;
   border-bottom: 1px dashed color-mix(in oklab, var(--og-accent) 55%, transparent);
 }
-.rd-doc .hub-table a:hover, .rd-doc .hub-links a:hover, .rd-doc .ent-related-list a:hover {
+.rd-doc .hub-table a:hover, .rd-doc .hub-links a:hover, .rd-doc .ent-related-list a:hover,
+.rd-doc .spell-meta a:hover {
   color: var(--og-accent);
   border-bottom-style: solid;
   border-bottom-color: var(--og-accent);
 }
+/* Related-блоки — это ИМЕНА сущностей → белые, как имя-столбец в глоссарии (не приглушённые). */
+.rd-doc .ent-related-list a { color: var(--og-text); }
 
 .rd-source {
   margin: 36px 0 0; padding-top: 16px; border-top: 1px solid var(--og-border);


### PR DESCRIPTION
Перепроверил **все сгенерённые страницы** на остатки старого формата ссылок (белый жирный + сплошная линия) — по просьбе владельца после того, как остался старый вид на строке «Классы» одиночного заклинания.

## Найдено и починено
1. **Мета-строки «Классы»/«Подклассы»** на странице заклинания (`.spell-meta`) — были `<a><strong>` (жирный + сплошная). Добавил `.spell-meta a` в правило `.ent-link`, убрал `<strong>` → приглушённый + пунктир (как классы в глоссарии).
2. **Related-блоки ещё 7 типов сущностей** (feats / weapons / magic-items / armor / animals / equipment / conditions) — оставались `<a><strong>` (правил только spells/monsters ранее). Убрал `<strong>`.
3. **Related-имена сущностей** — вернул белый (`var(--og-text)`): это ИМЕНА (как имя-столбец глоссария), наследование давало приглушённый.

## Единая семантика (эталон `.ent-link`)
- **имена** сущностей — белые + пунктир;
- **метаданные-ссылки** (классы / тип / CR / уровень / подклассы) — приглушённые + пунктир;
- по наведению — сплошное + акцент.

## Проверка
Вычисленный стиль подтверждён на всех точках; **e2e 48/48** (spells/monsters/feats/weapons/animals/equipment/armor/conditions/hubs); `astro check` 0 ошибок. Остатков `<a><strong>` в dnd-страницах не осталось (лендинг `index` не трогаем — там список систем, другой контекст).

🤖 Generated with [Claude Code](https://claude.com/claude-code)