### PR TITLE
Заклинания: стилизованная подсказка компонентов В/С/М

### DIFF
--- a/web/e2e/spells.spec.ts
+++ b/web/e2e/spells.spec.ts
@@ -15,13 +15,19 @@ test('страница заклинания: заголовок, EN-имя, ст
   await expect(meta).toContainText('Длительность');
 });
 
-test('компоненты В/С/М — abbr с подсказкой (полное слово в title)', async ({ page }) => {
+test('компоненты В/С/М — стилизованная подсказка (полное слово), не нативный title', async ({ page }) => {
   await page.goto('/ru/dnd/srd-5.2/spells/fireball/');
   const abbrs = page.locator('.spell-meta abbr');
   await expect(abbrs).toHaveCount(3);
-  await expect(abbrs.nth(0)).toHaveAttribute('title', 'Вербальный');
-  await expect(abbrs.nth(1)).toHaveAttribute('title', 'Соматический');
-  await expect(abbrs.nth(2)).toHaveAttribute('title', 'Материальный');
+  // Полное слово в data-tip (для CSS-подсказки) + aria-label (для скринридеров); нативный title убран.
+  await expect(abbrs.nth(0)).toHaveAttribute('data-tip', 'Вербальный');
+  await expect(abbrs.nth(0)).toHaveAttribute('aria-label', 'Вербальный');
+  await expect(abbrs.nth(1)).toHaveAttribute('data-tip', 'Соматический');
+  await expect(abbrs.nth(2)).toHaveAttribute('data-tip', 'Материальный');
+  // Подсказка реально всплывает по наведению (::after берёт текст из data-tip).
+  await abbrs.nth(0).hover();
+  const tip = await abbrs.nth(0).evaluate((el) => getComputedStyle(el, '::after').content);
+  expect(tip).toContain('Вербальный');
 });
 
 test('классы и подклассы — ссылки; подкласс скрыт, если класс уже в списке', async ({ page }) => {

--- a/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
@@ -187,7 +187,7 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
         <dt>{t('Компоненты', 'Components')}</dt>
         <dd>
           {compItems.map((c, i) => (
-            <Fragment>{i > 0 ? ', ' : ''}<abbr title={c.full}>{c.a}</abbr></Fragment>
+            <Fragment>{i > 0 ? ', ' : ''}<abbr tabindex="0" aria-label={c.full} data-tip={c.full}>{c.a}</abbr></Fragment>
           ))}
           {materialDesc && <span class="spell-mat"> ({materialDesc})</span>}
         </dd>
@@ -284,10 +284,18 @@ const title = `${entity.name} — ${t(`${kind} D&D ${verLabel}`, `D&D ${verLabel
     color: var(--og-text-muted); font-weight: 600;
   }
   .spell-meta dd { margin: 0; color: var(--og-text-2); }
-  /* Компоненты В/С/М: подсказка (полное слово) по наведению — нативный title. */
+  /* Компоненты В/С/М: полное слово — СТИЛИЗОВАННАЯ подсказка (нативный title капризен/не
+     всплывал), одинаково в RU/EN. Текст в data-tip + aria-label (для скринридеров). */
   .spell-meta abbr {
-    text-decoration: none; border-bottom: 1px dotted var(--og-text-muted); cursor: help;
-    font-weight: 600; color: var(--og-text);
+    position: relative; text-decoration: none; border-bottom: 1px dotted var(--og-text-muted);
+    cursor: help; font-weight: 600; color: var(--og-text);
+  }
+  .spell-meta abbr:hover::after, .spell-meta abbr:focus-visible::after {
+    content: attr(data-tip);
+    position: absolute; left: 50%; bottom: calc(100% + 8px); transform: translateX(-50%);
+    background: var(--og-bg-3); color: var(--og-text); border: 1px solid var(--og-border);
+    border-radius: 8px; padding: 5px 10px; font-size: 12.5px; font-weight: 400; line-height: 1.2;
+    white-space: nowrap; z-index: 20; pointer-events: none; box-shadow: 0 4px 14px rgba(0,0,0,.35);
   }
   .spell-mat { color: var(--og-text-muted); }
   /* Классы/подклассы — ссылки в едином стиле с «Ещё из школы» (<a><strong>): белый текст


### PR DESCRIPTION
Компоненты В/С/М показывали полное слово через нативный `title` у `<abbr>`, но он капризен/не всплывал (владелец: подсказки нет в RU, хотя атрибут `title` на проде присутствует в обоих языках).

## Фикс
Заменил нативный `title` на **стилизованную CSS-подсказку** — одинаково надёжно в RU/EN, в стиле сайта:
- `abbr`: `title` → `data-tip` (текст) + `aria-label` (скринридеры) + `tabindex=0` (подсказка и по фокусу с клавиатуры);
- CSS `::after` по `:hover` / `:focus-visible` — тёмная плашка с полным словом (`attr(data-tip)`) над компонентом.

## Проверка
Скриншот: над «В» всплывает «Вербальный». Тест обновлён (data-tip/aria-label + реальное появление `::after`). **e2e spells 5/5**, `astro check` 0 ошибок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)