### PR TITLE
chore(brand): бамп @omnisgm-app/brand 0.7.0 (--og-text-strong)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/sitemap": "^3.3.0",
-        "@omnisgm-app/brand": "^0.7.0",
+        "@omnisgm-app/brand": "^0.7.1",
         "astro": "^5.7.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-html": "^9.0.5",
@@ -2868,9 +2868,9 @@
       }
     },
     "node_modules/@omnisgm-app/brand": {
-      "version": "0.7.0",
-      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.7.0/8d2f27441a25b5bc367ae6f5e83f05f25f70076b",
-      "integrity": "sha512-rNPtn94ks8AEBYzJ8JsACSSIHjCIsGRwZCbg0mpUp7trJjx5wHPqYyJL04hQLt5t9wvEpMQKfNHzw2VHTuogsw=="
+      "version": "0.7.1",
+      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.7.1/727adf16ccd58944a694d4c1ee657e39327a7d0a",
+      "integrity": "sha512-w/X9JPWx0sCtlskFaImh8BQxM5mPI6iJFM3d4ulYatRCDd7LFX+WbZOa+QhBaZcbV7cN6f1+6p9rZI62IRDWxA=="
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/sitemap": "^3.3.0",
-        "@omnisgm-app/brand": "^0.6.0",
+        "@omnisgm-app/brand": "^0.7.0",
         "astro": "^5.7.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-html": "^9.0.5",
@@ -2868,9 +2868,9 @@
       }
     },
     "node_modules/@omnisgm-app/brand": {
-      "version": "0.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.6.0/30b01fcb9e6cffda31576c2f042de2dca83daad3",
-      "integrity": "sha512-FwKI+oENJNryOW5Ifc5eF4GCa/BJzUB18hjv1UEaOB9nDOBF4bDAyidleW4PBmobezDHHqC6hGN1g2j1a4DR9A=="
+      "version": "0.7.0",
+      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.7.0/8d2f27441a25b5bc367ae6f5e83f05f25f70076b",
+      "integrity": "sha512-rNPtn94ks8AEBYzJ8JsACSSIHjCIsGRwZCbg0mpUp7trJjx5wHPqYyJL04hQLt5t9wvEpMQKfNHzw2VHTuogsw=="
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.3.0",
-    "@omnisgm-app/brand": "^0.6.0",
+    "@omnisgm-app/brand": "^0.7.0",
     "astro": "^5.7.0",
     "hast-util-from-html": "^2.0.3",
     "hast-util-to-html": "^9.0.5",

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.3.0",
-    "@omnisgm-app/brand": "^0.7.0",
+    "@omnisgm-app/brand": "^0.7.1",
     "astro": "^5.7.0",
     "hast-util-from-html": "^2.0.3",
     "hast-util-to-html": "^9.0.5",


### PR DESCRIPTION
## Что и зачем

Раскатка бренд-токена **`--og-text-strong` (#F5F5F7)** по продуктам (Brand#12 / v0.7.0). Порядок владельца: News → **Rules** → Table.

## Правки
- `web/package.json` / lock: `@omnisgm-app/brand` `^0.6.0` → **`^0.7.0`**.

**Визуально Rules НЕ меняется:** новый токен — display-роль для крупных serif-заголовков листа персонажа (Table). У Rules заголовки ридера на основном `--og-text` (#E6E6E9), off-token `#fff` нет — токен просто становится доступен.

## Тесты (локально)
- `astro check` ✓ (0 errors, 0 warnings, 3 hints — прежние)
- `npm run build` ✓ (2550 стр., `--og-text-strong` в CSS, 18 self-host woff2, CDN не вернулся)
- `npx playwright test` — **114 passed / 0** (visual-снапшоты не поехали → рендер идентичен)

🤖 Generated with [Claude Code](https://claude.com/claude-code)