### PR TITLE
prev/next пропускает скрытые глоссарий-списки (шов из ревью #150)

### DIFF
--- a/web/e2e/daggerheart.spec.ts
+++ b/web/e2e/daggerheart.spec.ts
@@ -92,6 +92,13 @@ test('SEO: hreflang-тройка + сущности в sitemap', async ({ page, 
   expect(sm).toContain('/daggerheart/srd-1.0/adversaries/acid-burrower/');
 });
 
+test('prev/next пропускает скрытые глоссарий-списки (замена хабами)', async ({ page }) => {
+  // С последнего видимого хаба глоссария «дальше» не должно уводить в скрытый плоский список.
+  await page.goto('/ru/daggerheart/srd-1.0/environments/all/');
+  const nextHref = await page.locator('.rd-pn-r').first().getAttribute('href');
+  expect(nextHref, 'next не ведёт в скрытый /glossary/ список').not.toContain('/glossary/');
+});
+
 test('hovercard-бакет daggerheart отдаёт карточки терминов', async ({ request }) => {
   const res = await request.get('/hc/daggerheart/srd10/ru.json');
   expect(res.status()).toBe(200);

--- a/web/src/components/ReaderShell.astro
+++ b/web/src/components/ReaderShell.astro
@@ -88,9 +88,18 @@ const alternates = bilingual
     ? { en: routeOf(pathSlug, 'en'), ru: routeOf(pathSlug, 'ru'), xDefault: routeOf(pathSlug, 'en') }
     : { en: '/en/', ru: '/ru/', xDefault: '/' };
 
+// prev/next пропускают hidden-узлы (скрытые из сайдбара глоссарий-списки, заменённые
+// хабами): иначе поток «дальше» уводил бы читателя в 2-3 страницы подряд, которых нет в
+// дереве. Соседей самой скрытой страницы считаем до ближайшего видимого в обе стороны.
 const idx = FLAT_PAGES.findIndex((p) => p.id === currentId);
-const prev = idx > 0 ? FLAT_PAGES[idx - 1] : null;
-const next = idx >= 0 && idx < FLAT_PAGES.length - 1 ? FLAT_PAGES[idx + 1] : null;
+const visibleFrom = (start: number, step: number) => {
+  for (let i = start; i >= 0 && i < FLAT_PAGES.length; i += step) {
+    if (!FLAT_PAGES[i].hidden) return FLAT_PAGES[i];
+  }
+  return null;
+};
+const prev = idx > 0 ? visibleFrom(idx - 1, -1) : null;
+const next = idx >= 0 ? visibleFrom(idx + 1, 1) : null;
 
 // ── JSON-LD (schema.org) — для rich-результатов и хлебных крошек в выдаче ───────
 const SITE = 'https://rules.omnisgm.com';


### PR DESCRIPTION
Закрывает не-блокер из ревью #150: `ReaderShell` брал prev/next по `FLAT_PAGES` без фильтра `hidden`, поэтому «дальше» с последнего видимого хаба глоссария уводило читателя в 2-3 подряд **скрытых** плоских списка (которых нет в сайдбаре), прежде чем попасть в следующую систему.

## Фикс
`visibleFrom(start, step)` — ищет ближайший НЕ-`hidden` узел в нужную сторону. Работает симметрично:
- видимая страница: сосед-`hidden` пропускается (DH `environments-hub` → «дальше» → `brp/legal`, минуя 3 скрытых списка);
- сама скрытая страница: её соседи — ближайшие видимые в обе стороны (`environments-hub` ← `glossary/adversaries` → `brp/legal`).

## Проверки
- e2e-страж: с `environments/all` «next` не ведёт в `/glossary/`. 148/148 e2e, `astro check` 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)