### PR TITLE
D&D: /all/-хабы заклинаний/монстров/предметов/животных (замена глоссарий-списков)

### DIFF
--- a/web/e2e/dnd-all-hubs.spec.ts
+++ b/web/e2e/dnd-all-hubs.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+// /all/-хабы D&D (issue #20): алфавитные индексы заклинаний/монстров/предметов/животных
+// со ссылками на entity-страницы + фасеты. Заменили плоские глоссарий-списки в сайдбаре.
+
+test('/all/-хабы рендерятся (5.2 + 5.1)', async ({ page }) => {
+  for (const url of [
+    '/ru/dnd/srd-5.2/spells/all/',
+    '/en/dnd/srd-5.2/monsters-a-z/all/',
+    '/ru/dnd/srd-5.2/magic-items/all/',
+    '/en/dnd/srd-5.2/animals/all/',
+    '/ru/dnd/srd-5.1/spells/all/',
+    '/en/dnd/srd-5.1/monsters-a-z/all/',
+    '/ru/dnd/srd-5.1/magic-items/all/',
+  ]) {
+    const res = await page.goto(url);
+    expect(res?.status(), url).toBe(200);
+    await expect(page.locator('.rd-doc h1')).toBeVisible();
+  }
+});
+
+test('spells/all: ссылки на заклинание и класс-хаб', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/all/');
+  await expect(page.locator('.hub-table a[href$="/spells/fireball/"]')).toBeVisible();
+  await expect(page.locator('.hub-table a[href$="/spells/class/wizard/"]').first()).toBeVisible();
+});
+
+test('monsters-a-z/all: ссылки на монстра и type-хаб', async ({ page }) => {
+  await page.goto('/en/dnd/srd-5.2/monsters-a-z/all/');
+  await expect(page.locator('.hub-table a[href$="/monsters-a-z/aboleth/"]')).toBeVisible();
+  await expect(page.locator('.hub-table a[href*="/monsters-a-z/type/"]').first()).toBeVisible();
+});
+
+test('хаб в сайдбаре (глоссарий) виден и подсвечен; плоский список скрыт', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/all/');
+  await expect(page.locator('.rd-nav a.rd-nav-active[href$="/spells/all/"]')).toBeVisible();
+  await expect(page.locator('.rd-nav a[href$="/14_glossary/02_spells/"]')).toHaveCount(0);
+});
+
+test('заменённая глоссарий-страница жива и держит nav-контекст (не сирота)', async ({ page }) => {
+  const res = await page.goto('/ru/dnd/srd-5.2/glossary/spells/');
+  expect(res?.status()).toBe(200);
+  await expect(page.locator('.rd-doc')).toBeVisible();
+  // Крошки/таб резолвятся через скрытый узел → активная система D&D 5.2, не «home»
+  // (у сироты title был бы без «D&D SRD 5.2.1»).
+  await expect(page).toHaveTitle(/D&D SRD 5\.2\.1/);
+});
+
+test('SEO: hreflang-тройка + /all/-хабы в sitemap', async ({ page, request }) => {
+  const res = await page.goto('/en/dnd/srd-5.2/spells/all/');
+  expect(res?.status()).toBe(200);
+  await expect(page.locator('link[rel="alternate"][hreflang="x-default"]')).toHaveCount(1);
+  const sm = await (await request.get('/sitemap-0.xml')).text();
+  expect(sm).toContain('/dnd/srd-5.2/spells/all/');
+  expect(sm).toContain('/dnd/srd-5.2/monsters-a-z/all/');
+});

--- a/web/src/lib/nav.ts
+++ b/web/src/lib/nav.ts
@@ -76,10 +76,16 @@ export const NAV: NavNode[] = [
       group('d52-glossary', 'Глоссарий', 'Glossary', [
         page('d52-g-terms', 'Термины', 'Terms', '/dnd/srd-5.2/14_Glossary/00_Glossary/'),
         page('d52-origins-hub', 'Виды и предыстории', 'Species & Backgrounds', '/dnd/srd-5.2/character-origins/all/'),
-        page('d52-g-spells', 'Заклинания (справочник)', 'Spells (Reference)', '/dnd/srd-5.2/14_Glossary/02_Spells/'),
-        page('d52-g-magicitems', 'Магические предметы (справочник)', 'Magic Items (Reference)', '/dnd/srd-5.2/14_Glossary/03_MagicItems/'),
-        page('d52-g-monsters', 'Монстры (справочник)', 'Monsters (Reference)', '/dnd/srd-5.2/14_Glossary/04_Monsters/'),
-        page('d52-g-animals', 'Животные (справочник)', 'Animals (Reference)', '/dnd/srd-5.2/14_Glossary/05_Animals/'),
+        // Плоские глоссарий-списки заменены нашими /all/-хабами (ссылки на entity-страницы +
+        // фасеты); сами списки скрыты (hidden), но их страницы остаются доступны по URL.
+        page('d52-spells-hub', 'Заклинания (справочник)', 'Spells (Reference)', '/dnd/srd-5.2/spells/all/'),
+        page('d52-magicitems-hub', 'Магические предметы (справочник)', 'Magic Items (Reference)', '/dnd/srd-5.2/magic-items/all/'),
+        page('d52-monsters-hub', 'Монстры (справочник)', 'Monsters (Reference)', '/dnd/srd-5.2/monsters-a-z/all/'),
+        page('d52-animals-hub', 'Животные (справочник)', 'Animals (Reference)', '/dnd/srd-5.2/animals/all/'),
+        hidden('d52-g-spells', 'Заклинания (справочник)', 'Spells (Reference)', '/dnd/srd-5.2/14_Glossary/02_Spells/'),
+        hidden('d52-g-magicitems', 'Магические предметы (справочник)', 'Magic Items (Reference)', '/dnd/srd-5.2/14_Glossary/03_MagicItems/'),
+        hidden('d52-g-monsters', 'Монстры (справочник)', 'Monsters (Reference)', '/dnd/srd-5.2/14_Glossary/04_Monsters/'),
+        hidden('d52-g-animals', 'Животные (справочник)', 'Animals (Reference)', '/dnd/srd-5.2/14_Glossary/05_Animals/'),
       ]),
     ]),
     group('d51', 'SRD 5.1', 'SRD 5.1', [
@@ -102,9 +108,13 @@ export const NAV: NavNode[] = [
       group('d51-glossary', 'Глоссарий', 'Glossary', [
         page('d51-g-terms', 'Термины', 'Terms', '/dnd/srd-5.1/16_Glossary/00_Glossary/'),
         page('d51-races-hub', 'Расы (справочник)', 'Races (Reference)', '/dnd/srd-5.1/races/all/'),
-        page('d51-g-spells', 'Заклинания (справочник)', 'Spells (Reference)', '/dnd/srd-5.1/16_Glossary/02_Spells/'),
-        page('d51-g-magicitems', 'Магические предметы (справочник)', 'Magic Items (Reference)', '/dnd/srd-5.1/16_Glossary/03_MagicItems/'),
-        page('d51-g-monsters', 'Монстры (справочник)', 'Monsters (Reference)', '/dnd/srd-5.1/16_Glossary/04_Monsters/'),
+        // Плоские глоссарий-списки заменены /all/-хабами; списки скрыты (страницы живы).
+        page('d51-spells-hub', 'Заклинания (справочник)', 'Spells (Reference)', '/dnd/srd-5.1/spells/all/'),
+        page('d51-magicitems-hub', 'Магические предметы (справочник)', 'Magic Items (Reference)', '/dnd/srd-5.1/magic-items/all/'),
+        page('d51-monsters-hub', 'Монстры (справочник)', 'Monsters (Reference)', '/dnd/srd-5.1/monsters-a-z/all/'),
+        hidden('d51-g-spells', 'Заклинания (справочник)', 'Spells (Reference)', '/dnd/srd-5.1/16_Glossary/02_Spells/'),
+        hidden('d51-g-magicitems', 'Магические предметы (справочник)', 'Magic Items (Reference)', '/dnd/srd-5.1/16_Glossary/03_MagicItems/'),
+        hidden('d51-g-monsters', 'Монстры (справочник)', 'Monsters (Reference)', '/dnd/srd-5.1/16_Glossary/04_Monsters/'),
       ]),
     ]),
     page('d52-converting', 'Конвертация в SRD 5.2.1', 'Converting to SRD 5.2.1', '/dnd/converting-srd-5.2/converting-to-srd-5.2.1/'),

--- a/web/src/pages/[lang]/dnd/[version]/animals/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/animals/all.astro
@@ -1,0 +1,72 @@
+---
+import ReaderShell from '../../../../../components/ReaderShell.astro';
+import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
+
+// Хаб-справочник всех животных (issue #20, только 5.2): /{lang}/dnd/{version}/animals/all/.
+// Алфавитный индекс со ссылками на страницы животных. Заменяет плоский глоссарий-список.
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-animals-hub' };
+
+interface Animal { slug: string; name: string; size?: string; type?: string; cr?: { value?: string }; hp?: { average?: number } }
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as const },
+    { ver: 'srd52', lang: 'ru' as const },
+  ];
+  return BUILDS.map(({ ver, lang }) => ({
+    params: { lang, version: VERSION_SLUG[ver] },
+    props: { ver, lang, animals: (loadEntities(ver, lang, 'animals') as unknown as Animal[]).slice().sort((a, b) => a.name.localeCompare(b.name)) },
+  }));
+}
+
+const { ver, lang, animals } = Astro.props as { ver: string; lang: 'en' | 'ru'; animals: Animal[] };
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+const base = `/${lang}/dnd/${verSlug}/animals`;
+
+const heading = t('Все животные', 'All Animals');
+const title = `${heading} — D&D ${verLabel} · OmnisGM Rules`;
+const description = t(
+  `Все ${animals.length} животных D&D ${verLabel} по алфавиту: размер, тип, ПО и хиты со ссылками на страницы животных.`,
+  `All ${animals.length} D&D ${verLabel} animals alphabetically: size, type, CR and HP with links to each animal page.`,
+);
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={heading}
+  description={description}
+  headings={[]}
+  upLink={{ href: `/${lang}/dnd/${verSlug}/animals/`, ru: 'Животные', en: 'Animals' }}
+>
+  <h1>{heading}</h1>
+  <p>
+    {t(
+      `${animals.length} животных D&D ${verLabel} по алфавиту. В таблице — размер, тип, ПО и хиты. Нажмите на имя, чтобы открыть страницу животного.`,
+      `${animals.length} D&D ${verLabel} animals alphabetically. The table lists size, type, CR and HP. Select a name to open the animal page.`,
+    )}
+  </p>
+
+  <div class="rd-table-wrap">
+    <table class="hub-table">
+      <thead>
+        <tr>
+          <th>{t('Животное', 'Animal')}</th><th>{t('Размер', 'Size')}</th>
+          <th>{t('Тип', 'Type')}</th><th>{t('ПО', 'CR')}</th><th>{t('Хиты', 'HP')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {animals.map((a) => (
+          <tr>
+            <td><a href={`${base}/${a.slug}/`}>{a.name}</a></td>
+            <td>{a.size ?? '—'}</td><td>{a.type ?? '—'}</td>
+            <td>{a.cr?.value ?? '—'}</td><td>{a.hp?.average ?? '—'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+</ReaderShell>

--- a/web/src/pages/[lang]/dnd/[version]/magic-items/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/magic-items/all.astro
@@ -1,0 +1,82 @@
+---
+import ReaderShell from '../../../../../components/ReaderShell.astro';
+import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
+
+// Хаб-справочник всех магических предметов (issue #20): /{lang}/dnd/{version}/magic-items/all/.
+// Алфавитный индекс со ссылками на страницы предметов. Заменяет плоский глоссарий-список.
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-magicitems-hub', srd51: 'd51-magicitems-hub' };
+
+interface Item { slug: string; name: string; name_en?: string | null; type?: string; rarity?: string; attunement?: { required?: boolean } }
+
+// Редкость в данных — английский ключ; отображаем по языку.
+const RARITY: Record<string, [string, string]> = {
+  common: ['обычный', 'common'], uncommon: ['необычный', 'uncommon'], rare: ['редкий', 'rare'],
+  'very rare': ['очень редкий', 'very rare'], legendary: ['легендарный', 'legendary'], artifact: ['артефакт', 'artifact'],
+};
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as const },
+    { ver: 'srd52', lang: 'ru' as const },
+    { ver: 'srd51', lang: 'en' as const },
+    { ver: 'srd51', lang: 'ru' as const },
+  ];
+  return BUILDS.map(({ ver, lang }) => ({
+    params: { lang, version: VERSION_SLUG[ver] },
+    props: { ver, lang, items: (loadEntities(ver, lang, 'magic-items') as unknown as Item[]).slice().sort((a, b) => a.name.localeCompare(b.name)) },
+  }));
+}
+
+const { ver, lang, items } = Astro.props as { ver: string; lang: 'en' | 'ru'; items: Item[] };
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+const base = `/${lang}/dnd/${verSlug}/magic-items`;
+const rarityLabel = (r?: string) => (r && RARITY[r] ? (lang === 'ru' ? RARITY[r][0] : RARITY[r][1]) : (r ?? ''));
+
+const heading = t('Все магические предметы', 'All Magic Items');
+const title = `${heading} — D&D ${verLabel} · OmnisGM Rules`;
+const description = t(
+  `Все ${items.length} магических предметов D&D ${verLabel} по алфавиту: тип, редкость и настройка со ссылками на страницы предметов.`,
+  `All ${items.length} D&D ${verLabel} magic items alphabetically: type, rarity and attunement with links to each item page.`,
+);
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={heading}
+  description={description}
+  headings={[]}
+  upLink={{ href: `/${lang}/dnd/${verSlug}/magic-items/`, ru: 'Магические предметы', en: 'Magic Items' }}
+>
+  <h1>{heading}</h1>
+  <p>
+    {t(
+      `${items.length} магических предметов D&D ${verLabel} по алфавиту. В таблице — тип, редкость и требуется ли настройка. Нажмите на название, чтобы открыть страницу предмета.`,
+      `${items.length} D&D ${verLabel} magic items alphabetically. The table lists type, rarity and whether attunement is required. Select a name to open the item page.`,
+    )}
+  </p>
+
+  <div class="rd-table-wrap">
+    <table class="hub-table">
+      <thead>
+        <tr>
+          <th>{t('Предмет', 'Item')}</th><th>{t('Тип', 'Type')}</th>
+          <th>{t('Редкость', 'Rarity')}</th><th>{t('Настройка', 'Attunement')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((it) => (
+          <tr>
+            <td><a href={`${base}/${it.slug}/`}>{it.name}</a></td>
+            <td>{it.type ?? '—'}</td>
+            <td>{rarityLabel(it.rarity)}</td>
+            <td>{it.attunement?.required ? t('да', 'yes') : '—'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+</ReaderShell>

--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/all.astro
@@ -1,0 +1,74 @@
+---
+import ReaderShell from '../../../../../components/ReaderShell.astro';
+import { VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
+import { monstersWithFacets, typeLabel, type Lang, type MonsterLite } from '../../../../../lib/monster-hubs';
+
+// Хаб-справочник всех монстров (issue #20): /{lang}/dnd/{version}/monsters-a-z/all/.
+// Алфавитный индекс со ссылками на страницы монстров + колонка типа (ссылка на type-хаб).
+// Заменяет плоский глоссарий-список «Монстры (справочник)» (тот был без ссылок).
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-monsters-hub', srd51: 'd51-monsters-hub' };
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as Lang },
+    { ver: 'srd52', lang: 'ru' as Lang },
+    { ver: 'srd51', lang: 'en' as Lang },
+    { ver: 'srd51', lang: 'ru' as Lang },
+  ];
+  return BUILDS.map(({ ver, lang }) => ({
+    params: { lang, version: VERSION_SLUG[ver] },
+    props: { ver, lang, monsters: monstersWithFacets(ver, lang).sort((a, b) => a.name.localeCompare(b.name)) },
+  }));
+}
+
+const { ver, lang, monsters } = Astro.props as { ver: string; lang: Lang; monsters: MonsterLite[] };
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+const base = `/${lang}/dnd/${verSlug}/monsters-a-z`;
+
+const heading = t('Все монстры', 'All Monsters');
+const title = `${heading} — D&D ${verLabel} · OmnisGM Rules`;
+const description = t(
+  `Все ${monsters.length} монстров D&D ${verLabel} по алфавиту: тип, размер, ПО и хиты со ссылками на страницы монстров.`,
+  `All ${monsters.length} D&D ${verLabel} monsters alphabetically: type, size, CR and HP with links to each monster page.`,
+);
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={heading}
+  description={description}
+  headings={[]}
+  upLink={{ href: `${base}/`, ru: 'Монстры от А до Я', en: 'Monsters A–Z' }}
+>
+  <h1>{heading}</h1>
+  <p>
+    {t(
+      `${monsters.length} монстров D&D ${verLabel} по алфавиту. В таблице — тип (ссылка на список типа), размер, ПО и хиты. Нажмите на имя, чтобы открыть страницу монстра.`,
+      `${monsters.length} D&D ${verLabel} monsters alphabetically. The table lists type (linked to its list), size, CR and HP. Select a name to open the monster page.`,
+    )}
+  </p>
+
+  <div class="rd-table-wrap">
+    <table class="hub-table">
+      <thead>
+        <tr>
+          <th>{t('Монстр', 'Monster')}</th><th>{t('Тип', 'Type')}</th>
+          <th>{t('Размер', 'Size')}</th><th>{t('ПО', 'CR')}</th><th>{t('Хиты', 'HP')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {monsters.map((m) => (
+          <tr>
+            <td><a href={`${base}/${m.slug}/`}>{m.name}</a></td>
+            <td><a href={`${base}/type/${m.typeSlug}/`}>{typeLabel(m.typeSlug, lang)}</a></td>
+            <td>{m.size}</td><td>{m.cr}</td><td>{m.hp ?? '—'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+</ReaderShell>

--- a/web/src/pages/[lang]/dnd/[version]/spells/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/all.astro
@@ -1,0 +1,82 @@
+---
+import ReaderShell from '../../../../../components/ReaderShell.astro';
+import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
+import {
+  classLabel, levelShort, schoolLabel, spellClassSlugs, byName,
+  type Lang, type SpellLite,
+} from '../../../../../lib/spell-hubs';
+
+// Хаб-справочник всех заклинаний (issue #20): /{lang}/dnd/{version}/spells/all/.
+// Алфавитный индекс со ссылками на страницы заклинаний + колонка классов (ссылки на класс-хабы).
+// Заменяет плоский глоссарий-список «Заклинания (справочник)» (тот был без ссылок).
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-spells-hub', srd51: 'd51-spells-hub' };
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as Lang },
+    { ver: 'srd52', lang: 'ru' as Lang },
+    { ver: 'srd51', lang: 'en' as Lang },
+    { ver: 'srd51', lang: 'ru' as Lang },
+  ];
+  return BUILDS.map(({ ver, lang }) => ({
+    params: { lang, version: VERSION_SLUG[ver] },
+    props: { ver, lang, spells: (loadEntities(ver, lang, 'spells') as unknown as SpellLite[]).slice().sort(byName) },
+  }));
+}
+
+const { ver, lang, spells } = Astro.props as { ver: string; lang: Lang; spells: SpellLite[] };
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+const base = `/${lang}/dnd/${verSlug}/spells`;
+
+const heading = t('Все заклинания', 'All Spells');
+const title = `${heading} — D&D ${verLabel} · OmnisGM Rules`;
+const description = t(
+  `Все ${spells.length} заклинаний D&D ${verLabel} по алфавиту: уровень, школа и классы со ссылками на страницы заклинаний.`,
+  `All ${spells.length} D&D ${verLabel} spells alphabetically: level, school and classes with links to each spell page.`,
+);
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={heading}
+  description={description}
+  headings={[]}
+  upLink={{ href: `${base}/`, ru: 'Заклинания', en: 'Spells' }}
+>
+  <h1>{heading}</h1>
+  <p>
+    {t(
+      `${spells.length} заклинаний D&D ${verLabel} по алфавиту. В таблице — уровень, школа и классы (ссылки на класс-хабы). Нажмите на название, чтобы открыть страницу заклинания.`,
+      `${spells.length} D&D ${verLabel} spells alphabetically. The table lists level, school and classes (linked to class hubs). Select a name to open the spell page.`,
+    )}
+  </p>
+
+  <div class="rd-table-wrap">
+    <table class="hub-table">
+      <thead>
+        <tr>
+          <th>{t('Заклинание', 'Spell')}</th><th>{t('Уровень', 'Level')}</th>
+          <th>{t('Школа', 'School')}</th><th>{t('Классы', 'Classes')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {spells.map((s) => (
+          <tr>
+            <td><a href={`${base}/${s.slug}/`}>{s.name}</a></td>
+            <td>{levelShort(s.level, lang)}</td>
+            <td>{schoolLabel(s.school, lang)}</td>
+            <td>
+              {spellClassSlugs(s, lang).map((cs, i) => (
+                <>{i > 0 ? ', ' : ''}<a href={`${base}/class/${cs}/`}>{classLabel(cs, lang)}</a></>
+              ))}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+</ReaderShell>


### PR DESCRIPTION
Закрывает отложенное из #150. У D&D были только фасетные хабы (класс/уровень/CR/тип) без единого `/all/`-индекса, поэтому плоские глоссарий-списки (таблицы БЕЗ ссылок на entity-страницы) в сайдбаре не заменялись. Теперь заменены — единообразно с Daggerheart/BRP.

## Новые `/all/`-хабы (алфавитный индекс со ссылками на страницы + фасеты)
- **spells/all** (5.2+5.1): Заклинание | Уровень | Школа | Классы (классы → класс-хабы). ~320 заклинаний.
- **monsters-a-z/all** (5.2+5.1): Монстр | Тип | Размер | ПО | Хиты (тип → type-хаб). ~317 монстров.
- **magic-items/all** (5.2+5.1): Предмет | Тип | Редкость | Настройка. ~258.
- **animals/all** (5.2): Животное | Размер | Тип | ПО | Хиты. 95.

Переиспользуют `spell-hubs`/`monster-hubs` (schoolLabel/classLabel/typeLabel/levelShort/…).

## nav
В группе «Глоссарий» 5.2/5.1 плоские списки (`d5x-g-spells/magicitems/monsters/animals`) → `hidden`, на их места — видимые `d5x-*-hub`. Термины (`*-g-terms`) и главы не тронуты. Скрытые списки держим узлами → их страницы резолвят nav-контекст (не сироты).

## Проверки
- **154/154 e2e** (+6 в `dnd-all-hubs.spec.ts`: рендер, ссылки на заклинание/класс/монстра/тип, замена в сайдбаре, живучесть глоссарий-страницы с контекстом D&D 5.2, SEO/sitemap).
- `astro check` 0/0. Визуальные снапшоты 5.2 инертны (группа «Глоссарий» свёрнута на condition/legal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)