### PR TITLE
D&D-хабы: кликабельные колонки, школа-хаб, CR животных, сортируемые таблицы (#20)

### DIFF
--- a/web/e2e/dnd-all-hubs.spec.ts
+++ b/web/e2e/dnd-all-hubs.spec.ts
@@ -46,6 +46,39 @@ test('заменённая глоссарий-страница жива и де�
   await expect(page).toHaveTitle(/D&D SRD 5\.2\.1/);
 });
 
+test('spells/all: уровень и школа кликабельны; школа-хаб рендерится', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/all/');
+  // Уровень → level-хаб, школа → school-хаб (оба новые).
+  await expect(page.locator('.hub-table a[href*="/spells/level/"]').first()).toBeVisible();
+  const school = page.locator('.hub-table a[href*="/spells/school/"]').first();
+  await expect(school).toBeVisible();
+  const res = await page.goto('/en/dnd/srd-5.2/spells/school/evocation/');
+  expect(res?.status()).toBe(200);
+  await expect(page.locator('.rd-doc h1')).toContainText('Evocation');
+  await expect(page.locator('.hub-table a[href*="/spells/level/"]').first()).toBeVisible();
+});
+
+test('monsters/all + animals/all: ПО кликабельно → CR-хаб (у животных свой)', async ({ page }) => {
+  await page.goto('/en/dnd/srd-5.2/monsters-a-z/all/');
+  await expect(page.locator('.hub-table a[href*="/monsters-a-z/cr/"]').first()).toBeVisible();
+  await page.goto('/en/dnd/srd-5.2/animals/all/');
+  const acr = page.locator('.hub-table a[href*="/animals/cr/"]').first();
+  await expect(acr).toBeVisible();
+  const res = await page.goto('/en/dnd/srd-5.2/animals/cr/0/');
+  expect(res?.status()).toBe(200);
+  await expect(page.locator('.hub-table')).toBeVisible();
+});
+
+test('сортировка: клик по заголовку столбца переупорядочивает строки', async ({ page }) => {
+  await page.goto('/en/dnd/srd-5.2/monsters-a-z/all/');
+  const firstBefore = await page.locator('.hub-table tbody tr td:first-child').first().textContent();
+  const crHeader = page.locator('.hub-table[data-sortable] thead th').nth(3); // столбец «CR»
+  await crHeader.click();
+  await expect(crHeader).toHaveAttribute('aria-sort', 'ascending');
+  const firstAfter = await page.locator('.hub-table tbody tr td:first-child').first().textContent();
+  expect(firstAfter).not.toBe(firstBefore); // порядок изменился (алфавит → по CR)
+});
+
 test('SEO: hreflang-тройка + /all/-хабы в sitemap', async ({ page, request }) => {
   const res = await page.goto('/en/dnd/srd-5.2/spells/all/');
   expect(res?.status()).toBe(200);

--- a/web/e2e/origins.spec.ts
+++ b/web/e2e/origins.spec.ts
@@ -44,12 +44,12 @@ test('канонический слаг EN↔RU: RU-вид/предыстори�
   expect((await page.goto('/ru/dnd/srd-5.2/species/%D0%B3%D0%BE%D0%BB%D0%B8%D0%B0%D1%84/'))?.status()).toBe(404);
 });
 
-test('хаб происхождений: карточки видов и предысторий + entity→хаб', async ({ page }) => {
+test('хаб происхождений: таблица видов и предысторий (сортируемая) + entity→хаб', async ({ page }) => {
   const res = await page.goto('/ru/dnd/srd-5.2/character-origins/all/');
   expect(res?.status()).toBe(200);
-  await expect(page.locator('.og-card a[href$="/species/human/"]')).toBeVisible();
-  await expect(page.locator('.og-card a[href$="/backgrounds/sage/"]')).toBeVisible();
-  await expect(page.locator('.og-card .og-card-link')).toHaveCount(13); // 9 видов + 4 предыстории
+  await expect(page.locator('.hub-table[data-sortable] a[href$="/species/human/"]')).toBeVisible();
+  await expect(page.locator('.hub-table a[href$="/backgrounds/sage/"]')).toBeVisible();
+  await expect(page.locator('.hub-table tbody td:first-child a')).toHaveCount(13); // 9 видов + 4 предыстории
   // Со страницы вида «в раздел» → хаб.
   await page.goto('/ru/dnd/srd-5.2/species/elf/');
   await expect(page.locator(`a[href$="/character-origins/all/"]`).first()).toBeVisible();

--- a/web/e2e/srd51.spec.ts
+++ b/web/e2e/srd51.spec.ts
@@ -82,13 +82,13 @@ test('расы 5.1: страница расы — EN-имя, подрасы, а�
   await expect(page.locator('.ent-related a[href$="/races/elf/"]')).toBeVisible();
 });
 
-test('хаб рас 5.1: карточки всех рас со ссылками на страницы + доступен из страницы расы', async ({ page }) => {
+test('хаб рас 5.1: сортируемая таблица всех рас со ссылками + доступен из страницы расы', async ({ page }) => {
   const res = await page.goto('/ru/dnd/srd-5.1/races/all/');
   expect(res?.status()).toBe(200);
-  // 9 карточек-ссылок на entity-страницы рас.
-  const links = page.locator('.race-card .race-card-link');
+  // 9 строк-ссылок на entity-страницы рас.
+  const links = page.locator('.hub-table[data-sortable] tbody td:first-child a');
   await expect(links).toHaveCount(9);
-  await expect(page.locator('.race-card a[href$="/races/tiefling/"]')).toBeVisible();
+  await expect(page.locator('.hub-table a[href$="/races/tiefling/"]')).toBeVisible();
   // Со страницы расы «в раздел» ведёт на хаб (entity → хаб).
   await page.goto('/ru/dnd/srd-5.1/races/dwarf/');
   await expect(page.locator(`a[href$="/dnd/srd-5.1/races/all/"]`).first()).toBeVisible();

--- a/web/src/components/ReaderShell.astro
+++ b/web/src/components/ReaderShell.astro
@@ -711,3 +711,48 @@ const searchUi = {
   // По ресайзу — прячем открытую (геометрия ссылки могла сместиться).
   window.addEventListener('resize', () => { if (current) hide(); }, { passive: true });
 </script>
+
+{/* Сортируемые хаб-таблицы (issue #20): <table class="hub-table" data-sortable>. Клик/Enter по
+    <th> сортирует строки по колонке. Ключ сортировки — атрибут data-sort ячейки (для CR/уровня —
+    числовой порядок), иначе видимый текст. Колонка сравнивается численно, если все ключи числа,
+    иначе localeCompare по языку страницы. Прогрессивное улучшение: без JS таблица просто статична. */}
+<script>
+  const lang = document.documentElement.lang || undefined;
+  const cellKey = (row: HTMLTableRowElement, i: number): string => {
+    const c = row.cells[i];
+    if (!c) return '';
+    const d = c.getAttribute('data-sort');
+    return d !== null ? d : (c.textContent || '').trim();
+  };
+  for (const table of document.querySelectorAll<HTMLTableElement>('table.hub-table[data-sortable]')) {
+    const tbody = table.tBodies[0];
+    const ths = Array.from(table.tHead?.rows[0]?.cells ?? []);
+    if (!tbody || !ths.length) continue;
+    const sortBy = (i: number, dir: 1 | -1) => {
+      const rows = Array.from(tbody.rows);
+      const keys = rows.map((r) => cellKey(r, i));
+      const numeric = keys.every((k) => k !== '' && !Number.isNaN(Number(k)));
+      rows.sort((a, b) => {
+        const ka = cellKey(a, i), kb = cellKey(b, i);
+        const cmp = numeric ? Number(ka) - Number(kb) : ka.localeCompare(kb, lang);
+        return cmp * dir;
+      });
+      for (const r of rows) tbody.appendChild(r);
+    };
+    ths.forEach((th, i) => {
+      th.tabIndex = 0;
+      th.setAttribute('role', 'button');
+      const activate = () => {
+        const dir: 1 | -1 = th.getAttribute('aria-sort') === 'ascending' ? -1 : 1;
+        for (const o of ths) o.removeAttribute('aria-sort');
+        th.setAttribute('aria-sort', dir === 1 ? 'ascending' : 'descending');
+        sortBy(i, dir);
+      };
+      th.addEventListener('click', activate);
+      th.addEventListener('keydown', (e) => {
+        const k = (e as KeyboardEvent).key;
+        if (k === 'Enter' || k === ' ') { e.preventDefault(); activate(); }
+      });
+    });
+  }
+</script>

--- a/web/src/lib/spell-hubs.ts
+++ b/web/src/lib/spell-hubs.ts
@@ -60,6 +60,20 @@ export const schoolLabel = (raw: string, lang: Lang) => {
   return p ? (lang === 'ru' ? p[1] : p[0]) : raw;
 };
 
+// Школа-хаб (issue #20): слаг языконезависим (EN в lowercase, как у классов) → общий каноникал.
+export const SCHOOL_HUBS: { slug: string; en: string; ru: string }[] =
+  SCHOOLS.map(([en, ru]) => ({ slug: en.toLowerCase(), en, ru }));
+// Сырое поле school любого языка → слаг школы (undefined, если школа неизвестна).
+export const schoolSlug = (raw: string): string | undefined => {
+  const p = SCHOOLS.find(([en, ru]) => en === raw || ru === raw);
+  return p ? p[0].toLowerCase() : undefined;
+};
+export const schoolBySlug = (slug: string) => SCHOOL_HUBS.find((s) => s.slug === slug);
+export const schoolHubLabel = (slug: string, lang: Lang) => {
+  const s = schoolBySlug(slug);
+  return s ? s[lang] : slug;
+};
+
 // Классы заклинания (слаги) — из переведённого поля classes через обратный поиск по языку данных.
 export const spellClassSlugs = (spell: SpellLite, lang: Lang): string[] =>
   (spell.classes || [])

--- a/web/src/pages/[lang]/dnd/[version]/animals/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/animals/all.astro
@@ -1,9 +1,11 @@
 ---
 import ReaderShell from '../../../../../components/ReaderShell.astro';
 import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
+import { crHubForValue, crOrder } from '../../../../../lib/monster-hubs';
 
 // Хаб-справочник всех животных (issue #20, только 5.2): /{lang}/dnd/{version}/animals/all/.
 // Алфавитный индекс со ссылками на страницы животных. Заменяет плоский глоссарий-список.
+// ПО ведёт на общие CR-хабы животных (переиспользуем шкалу CR монстров).
 const PARENT_NAV: Record<string, string> = { srd52: 'd52-animals-hub' };
 
 interface Animal { slug: string; name: string; size?: string; type?: string; cr?: { value?: string }; hp?: { average?: number } }
@@ -45,13 +47,13 @@ const description = t(
   <h1>{heading}</h1>
   <p>
     {t(
-      `${animals.length} животных D&D ${verLabel} по алфавиту. В таблице — размер, тип, ПО и хиты. Нажмите на имя, чтобы открыть страницу животного.`,
-      `${animals.length} D&D ${verLabel} animals alphabetically. The table lists size, type, CR and HP. Select a name to open the animal page.`,
+      `${animals.length} животных D&D ${verLabel} по алфавиту. В таблице — размер, тип, ПО (ссылка на хаб) и хиты. Нажмите на заголовок столбца, чтобы отсортировать.`,
+      `${animals.length} D&D ${verLabel} animals alphabetically. The table lists size, type, CR (linked to hub) and HP. Click a column header to sort.`,
     )}
   </p>
 
   <div class="rd-table-wrap">
-    <table class="hub-table">
+    <table class="hub-table" data-sortable>
       <thead>
         <tr>
           <th>{t('Животное', 'Animal')}</th><th>{t('Размер', 'Size')}</th>
@@ -59,13 +61,18 @@ const description = t(
         </tr>
       </thead>
       <tbody>
-        {animals.map((a) => (
-          <tr>
-            <td><a href={`${base}/${a.slug}/`}>{a.name}</a></td>
-            <td>{a.size ?? '—'}</td><td>{a.type ?? '—'}</td>
-            <td>{a.cr?.value ?? '—'}</td><td>{a.hp?.average ?? '—'}</td>
-          </tr>
-        ))}
+        {animals.map((a) => {
+          const cr = a.cr?.value;
+          const crHub = cr ? crHubForValue(cr) : undefined;
+          return (
+            <tr>
+              <td><a href={`${base}/${a.slug}/`}>{a.name}</a></td>
+              <td>{a.size ?? '—'}</td><td>{a.type ?? '—'}</td>
+              <td data-sort={cr ? crOrder(cr) : -1}>{crHub ? <a href={`${base}/cr/${crHub.slug}/`}>{cr}</a> : (cr ?? '—')}</td>
+              <td data-sort={a.hp?.average ?? -1}>{a.hp?.average ?? '—'}</td>
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   </div>

--- a/web/src/pages/[lang]/dnd/[version]/animals/cr/[cr].astro
+++ b/web/src/pages/[lang]/dnd/[version]/animals/cr/[cr].astro
@@ -1,0 +1,106 @@
+---
+import ReaderShell from '../../../../../../components/ReaderShell.astro';
+import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../../lib/entities';
+import { CR_HUBS, crHubBySlug, crHubTitle, crOrder, type Lang } from '../../../../../../lib/monster-hubs';
+
+// Хаб животных по ПО (issue #20, только 5.2): /{lang}/dnd/{version}/animals/cr/{cr}/.
+// Переиспользуем CR-шкалу монстров (одиночные 0–10 + диапазоны). Животные — почти все звери
+// низкого ПО, тяжёлые диапазоны обычно пусты и отбрасываются (страхуемся `if (!mine.length)`).
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-animals-hub' };
+
+interface Animal { slug: string; name: string; size?: string; type?: string; cr?: { value?: string }; hp?: { average?: number } }
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as Lang },
+    { ver: 'srd52', lang: 'ru' as Lang },
+  ];
+  const paths = [];
+  for (const { ver, lang } of BUILDS) {
+    const all = loadEntities(ver, lang, 'animals') as unknown as Animal[];
+    for (const hub of CR_HUBS) {
+      const set = new Set(hub.values);
+      const mine = all
+        .filter((a) => a.cr?.value && set.has(a.cr.value))
+        .sort((a, b) => crOrder(a.cr!.value!) - crOrder(b.cr!.value!) || a.name.localeCompare(b.name));
+      if (!mine.length) continue;
+      paths.push({
+        params: { lang, version: VERSION_SLUG[ver], cr: hub.slug },
+        props: { ver, lang, crHubSlug: hub.slug, animals: mine },
+      });
+    }
+  }
+  return paths;
+}
+
+const { ver, lang, crHubSlug, animals } = Astro.props as {
+  ver: string; lang: Lang; crHubSlug: string; animals: Animal[];
+};
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+const base = `/${lang}/dnd/${verSlug}/animals`;
+const hub = crHubBySlug(crHubSlug)!;
+const crName = crHubTitle(hub, lang);
+
+const heading = t(`Животные с ${crName}`, `${crName} Animals`);
+const title = `${heading} — D&D ${verLabel} · OmnisGM Rules`;
+const description = t(
+  `Все ${animals.length} животных с ${crName} в D&D ${verLabel}: размер, тип и хиты, со ссылками на страницы животных.`,
+  `All ${animals.length} animals of ${crName} in D&D ${verLabel}: size, type and HP, with links to each animal.`,
+);
+// Другие ПО — только реально присутствующие среди животных (страхуемся от битых ссылок на пустые хабы).
+const presentCr = new Set(
+  (loadEntities(ver, 'en', 'animals') as unknown as Animal[]).map((a) => a.cr?.value).filter(Boolean) as string[],
+);
+const otherCr = CR_HUBS.filter((h) => h.slug !== crHubSlug && h.values.some((v) => presentCr.has(v)));
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={heading}
+  description={description}
+  headings={[]}
+  upLink={{ href: `${base}/`, ru: 'Животные', en: 'Animals' }}
+>
+  <h1>{heading}</h1>
+  <p>
+    {t(
+      `${animals.length} животных с ${crName} в D&D ${verLabel}. В таблице — размер, тип и хиты. Нажмите на имя, чтобы открыть страницу животного.`,
+      `${animals.length} animals of ${crName} in D&D ${verLabel}. The table lists size, type and HP. Select a name to open the animal page.`,
+    )}
+  </p>
+
+  <div class="rd-table-wrap">
+    <table class="hub-table" data-sortable>
+      <thead>
+        <tr>
+          <th>{t('Животное', 'Animal')}</th><th>{t('Размер', 'Size')}</th>
+          <th>{t('Тип', 'Type')}</th><th>{t('ПО', 'CR')}</th><th>{t('Хиты', 'HP')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {animals.map((a) => (
+          <tr>
+            <td><a href={`${base}/${a.slug}/`}>{a.name}</a></td>
+            <td>{a.size ?? '—'}</td><td>{a.type ?? '—'}</td>
+            <td data-sort={a.cr?.value ? crOrder(a.cr.value) : -1}>{a.cr?.value ?? '—'}</td>
+            <td data-sort={a.hp?.average ?? -1}>{a.hp?.average ?? '—'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+
+  {otherCr.length > 0 && (
+    <nav class="hub-links" aria-label={t('Другие хабы животных', 'Other animal hubs')}>
+      <p><strong>{t('Другие ПО:', 'Other CR:')}</strong>{' '}
+        {otherCr.map((h, i) => (
+          <>{i > 0 ? ' · ' : ''}<a href={`${base}/cr/${h.slug}/`}>{crHubTitle(h, lang)}</a></>
+        ))}
+      </p>
+    </nav>
+  )}
+</ReaderShell>

--- a/web/src/pages/[lang]/dnd/[version]/character-origins/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/character-origins/all.astro
@@ -38,9 +38,11 @@ const description = t(
 );
 const upLink = { href: `/${lang}/dnd/${verSlug}/character-origins/`, ru: 'Происхождение (глава)', en: 'Character Origins (chapter)' };
 
-const groups = [
-  { title: t('Виды', 'Species'), items: species, dir: 'species' },
-  { title: t('Предыстории', 'Backgrounds'), items: backgrounds, dir: 'backgrounds' },
+// Единая таблица: вид/предыстория помечены колонкой «Тип» — так строки сортируются вместе
+// (по имени / по типу), а не двумя раздельными списками.
+const rows = [
+  ...species.map((e) => ({ ...e, dir: 'species', kind: t('Вид', 'Species') })),
+  ...backgrounds.map((e) => ({ ...e, dir: 'backgrounds', kind: t('Предыстория', 'Background') })),
 ];
 ---
 
@@ -61,32 +63,27 @@ const groups = [
     )}
   </p>
 
-  {groups.map((g) => (
-    <section class="og-group">
-      <h2>{g.title}</h2>
-      <ul class="og-grid">
-        {g.items.map((e) => (
-          <li class="og-card">
-            <a class="og-card-link" href={`/${lang}/dnd/${verSlug}/${g.dir}/${e.slug}/`}>{e.name}</a>
-            {lang === 'ru' && e.name_en && <span class="og-card-en">{e.name_en}</span>}
-          </li>
+  <div class="rd-table-wrap">
+    <table class="hub-table" data-sortable>
+      <thead>
+        <tr>
+          <th>{t('Название', 'Name')}</th><th>{t('Тип', 'Kind')}</th>
+          {lang === 'ru' && <th>Оригинал</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((e) => (
+          <tr>
+            <td><a href={`/${lang}/dnd/${verSlug}/${e.dir}/${e.slug}/`}>{e.name}</a></td>
+            <td>{e.kind}</td>
+            {lang === 'ru' && <td class="og-en">{e.name_en ?? '—'}</td>}
+          </tr>
         ))}
-      </ul>
-    </section>
-  ))}
+      </tbody>
+    </table>
+  </div>
 </ReaderShell>
 
 <style>
-  .og-group { margin-top: 28px; }
-  .og-grid {
-    list-style: none; margin: 14px 0 0; padding: 0;
-    display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px;
-  }
-  .og-card {
-    display: flex; flex-direction: column; gap: 3px;
-    padding: 14px 16px; border: 1px solid var(--og-border); border-radius: 10px;
-    background: var(--og-bg-2);
-  }
-  .og-card-link { font-weight: 600; font-size: 16px; }
-  .og-card-en { font-family: var(--font-mono); font-size: 13px; color: var(--og-text-muted); }
+  .og-en { font-family: var(--font-mono); font-size: 13px; color: var(--og-text-muted); }
 </style>

--- a/web/src/pages/[lang]/dnd/[version]/magic-items/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/magic-items/all.astro
@@ -33,6 +33,9 @@ const verLabel = VERSION_LABEL[ver];
 const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
 const base = `/${lang}/dnd/${verSlug}/magic-items`;
 const rarityLabel = (r?: string) => (r && RARITY[r] ? (lang === 'ru' ? RARITY[r][0] : RARITY[r][1]) : (r ?? ''));
+// Порядок редкости для сортировки (обычный → артефакт), а не по алфавиту.
+const RARITY_ORDER = ['common', 'uncommon', 'rare', 'very rare', 'legendary', 'artifact'];
+const rarityRank = (r?: string) => { const i = RARITY_ORDER.indexOf(r ?? ''); return i === -1 ? 99 : i; };
 
 const heading = t('Все магические предметы', 'All Magic Items');
 const title = `${heading} — D&D ${verLabel} · OmnisGM Rules`;
@@ -54,13 +57,13 @@ const description = t(
   <h1>{heading}</h1>
   <p>
     {t(
-      `${items.length} магических предметов D&D ${verLabel} по алфавиту. В таблице — тип, редкость и требуется ли настройка. Нажмите на название, чтобы открыть страницу предмета.`,
-      `${items.length} D&D ${verLabel} magic items alphabetically. The table lists type, rarity and whether attunement is required. Select a name to open the item page.`,
+      `${items.length} магических предметов D&D ${verLabel} по алфавиту. В таблице — тип, редкость и требуется ли настройка. Нажмите на заголовок столбца, чтобы отсортировать.`,
+      `${items.length} D&D ${verLabel} magic items alphabetically. The table lists type, rarity and whether attunement is required. Click a column header to sort.`,
     )}
   </p>
 
   <div class="rd-table-wrap">
-    <table class="hub-table">
+    <table class="hub-table" data-sortable>
       <thead>
         <tr>
           <th>{t('Предмет', 'Item')}</th><th>{t('Тип', 'Type')}</th>
@@ -72,8 +75,8 @@ const description = t(
           <tr>
             <td><a href={`${base}/${it.slug}/`}>{it.name}</a></td>
             <td>{it.type ?? '—'}</td>
-            <td>{rarityLabel(it.rarity)}</td>
-            <td>{it.attunement?.required ? t('да', 'yes') : '—'}</td>
+            <td data-sort={rarityRank(it.rarity)}>{rarityLabel(it.rarity)}</td>
+            <td data-sort={it.attunement?.required ? 1 : 0}>{it.attunement?.required ? t('да', 'yes') : '—'}</td>
           </tr>
         ))}
       </tbody>

--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/all.astro
@@ -1,7 +1,7 @@
 ---
 import ReaderShell from '../../../../../components/ReaderShell.astro';
 import { VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
-import { monstersWithFacets, typeLabel, type Lang, type MonsterLite } from '../../../../../lib/monster-hubs';
+import { monstersWithFacets, typeLabel, crHubForValue, crOrder, type Lang, type MonsterLite } from '../../../../../lib/monster-hubs';
 
 // Хаб-справочник всех монстров (issue #20): /{lang}/dnd/{version}/monsters-a-z/all/.
 // Алфавитный индекс со ссылками на страницы монстров + колонка типа (ссылка на type-хаб).
@@ -47,13 +47,13 @@ const description = t(
   <h1>{heading}</h1>
   <p>
     {t(
-      `${monsters.length} монстров D&D ${verLabel} по алфавиту. В таблице — тип (ссылка на список типа), размер, ПО и хиты. Нажмите на имя, чтобы открыть страницу монстра.`,
-      `${monsters.length} D&D ${verLabel} monsters alphabetically. The table lists type (linked to its list), size, CR and HP. Select a name to open the monster page.`,
+      `${monsters.length} монстров D&D ${verLabel} по алфавиту. В таблице — тип и ПО (ссылки на хабы), размер и хиты. Нажмите на заголовок столбца, чтобы отсортировать.`,
+      `${monsters.length} D&D ${verLabel} monsters alphabetically. The table lists type and CR (linked to hubs), size and HP. Click a column header to sort.`,
     )}
   </p>
 
   <div class="rd-table-wrap">
-    <table class="hub-table">
+    <table class="hub-table" data-sortable>
       <thead>
         <tr>
           <th>{t('Монстр', 'Monster')}</th><th>{t('Тип', 'Type')}</th>
@@ -61,13 +61,18 @@ const description = t(
         </tr>
       </thead>
       <tbody>
-        {monsters.map((m) => (
-          <tr>
-            <td><a href={`${base}/${m.slug}/`}>{m.name}</a></td>
-            <td><a href={`${base}/type/${m.typeSlug}/`}>{typeLabel(m.typeSlug, lang)}</a></td>
-            <td>{m.size}</td><td>{m.cr}</td><td>{m.hp ?? '—'}</td>
-          </tr>
-        ))}
+        {monsters.map((m) => {
+          const crHub = crHubForValue(m.cr);
+          return (
+            <tr>
+              <td><a href={`${base}/${m.slug}/`}>{m.name}</a></td>
+              <td><a href={`${base}/type/${m.typeSlug}/`}>{typeLabel(m.typeSlug, lang)}</a></td>
+              <td>{m.size}</td>
+              <td data-sort={crOrder(m.cr)}>{crHub ? <a href={`${base}/cr/${crHub.slug}/`}>{m.cr}</a> : m.cr}</td>
+              <td data-sort={m.hp ?? -1}>{m.hp ?? '—'}</td>
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   </div>

--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/cr/[cr].astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/cr/[cr].astro
@@ -2,7 +2,7 @@
 import ReaderShell from '../../../../../../components/ReaderShell.astro';
 import { VERSION_SLUG, VERSION_LABEL } from '../../../../../../lib/entities';
 import {
-  CR_HUBS, typeLabel, crHubTitle, crHubBySlug, byCrThenName, monstersWithFacets, activeMonsterTypes,
+  CR_HUBS, typeLabel, crHubTitle, crHubBySlug, byCrThenName, crOrder, monstersWithFacets, activeMonsterTypes,
   type Lang, type MonsterLite,
 } from '../../../../../../lib/monster-hubs';
 
@@ -72,7 +72,7 @@ const otherCr = CR_HUBS.filter((h) => h.slug !== crHubSlug);
   </p>
 
   <div class="rd-table-wrap">
-    <table class="hub-table">
+    <table class="hub-table" data-sortable>
       <thead>
         <tr>
           <th>{t('Монстр', 'Monster')}</th><th>{t('ПО', 'CR')}</th>
@@ -83,9 +83,9 @@ const otherCr = CR_HUBS.filter((h) => h.slug !== crHubSlug);
         {monsters.map((m) => (
           <tr>
             <td><a href={monHref(m.slug)}>{m.name}</a></td>
-            <td>{m.cr}</td>
+            <td data-sort={crOrder(m.cr)}>{m.cr}</td>
             <td><a href={`${base}/type/${m.typeSlug}/`}>{typeLabel(m.typeSlug, lang)}</a></td>
-            <td>{m.size}</td><td>{m.hp ?? '—'}</td>
+            <td>{m.size}</td><td data-sort={m.hp ?? -1}>{m.hp ?? '—'}</td>
           </tr>
         ))}
       </tbody>

--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/type/[type].astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/type/[type].astro
@@ -2,7 +2,7 @@
 import ReaderShell from '../../../../../../components/ReaderShell.astro';
 import { VERSION_SLUG, VERSION_LABEL } from '../../../../../../lib/entities';
 import {
-  MONSTER_TYPES, CR_HUBS, typeLabel, crHubTitle, byCrThenName, monstersWithFacets, activeMonsterTypes,
+  MONSTER_TYPES, CR_HUBS, typeLabel, crHubTitle, byCrThenName, crOrder, monstersWithFacets, activeMonsterTypes,
   type Lang, type MonsterLite,
 } from '../../../../../../lib/monster-hubs';
 
@@ -69,7 +69,7 @@ const otherTypes = activeMonsterTypes(ver).filter((x) => x.slug !== typeSlug);
   </p>
 
   <div class="rd-table-wrap">
-    <table class="hub-table">
+    <table class="hub-table" data-sortable>
       <thead>
         <tr>
           <th>{t('Монстр', 'Monster')}</th><th>{t('ПО', 'CR')}</th>
@@ -80,8 +80,8 @@ const otherTypes = activeMonsterTypes(ver).filter((x) => x.slug !== typeSlug);
         {monsters.map((m) => (
           <tr>
             <td><a href={monHref(m.slug)}>{m.name}</a></td>
-            <td>{m.cr}</td><td>{m.size}</td>
-            <td>{m.hp ?? '—'}</td><td>{m.ac ?? '—'}</td>
+            <td data-sort={crOrder(m.cr)}>{m.cr}</td><td>{m.size}</td>
+            <td data-sort={m.hp ?? -1}>{m.hp ?? '—'}</td><td data-sort={m.ac ?? -1}>{m.ac ?? '—'}</td>
           </tr>
         ))}
       </tbody>

--- a/web/src/pages/[lang]/dnd/[version]/races/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/races/all.astro
@@ -2,7 +2,7 @@
 import ReaderShell from '../../../../../components/ReaderShell.astro';
 import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
 
-// Хаб-справочник рас (SRD 5.1): /{lang}/dnd/{version}/races/all/. Групповая страница со ссылками
+// Хаб-справочник рас (SRD 5.1): /{lang}/dnd/{version}/races/all/. Сортируемая таблица со ссылками
 // на все страницы рас — точка входа в entity-страницы (имена рас в главе не автолинкуются, в
 // отличие от заклинаний/монстров). Статический роут `all` приоритетнее `[slug]` (слага «all» нет).
 const PARENT_NAV: Record<string, string> = { srd51: 'd51-races-hub' };
@@ -17,7 +17,11 @@ export function getStaticPaths() {
   ];
   return BUILDS.map(({ ver, lang }) => ({
     params: { lang, version: VERSION_SLUG[ver] },
-    props: { ver, lang, races: loadEntities(ver, lang, 'races') as unknown as Race[] },
+    props: {
+      ver, lang,
+      races: (loadEntities(ver, lang, 'races') as unknown as Race[])
+        .slice().sort((a, b) => a.name.localeCompare(b.name)),
+    },
   }));
 }
 
@@ -49,37 +53,32 @@ const upLink = { href: `${base}/`, ru: 'Расы (глава)', en: 'Races (chap
   <h1>{heading}</h1>
   <p>
     {t(
-      `${races.length} рас D&D ${verLabel}. Нажмите на расу, чтобы открыть её страницу с особенностями и подрасами. Общие расовые правила — в главе «Расы».`,
-      `${races.length} D&D ${verLabel} races. Select a race to open its page with traits and subraces. General racial rules are in the Races chapter.`,
+      `${races.length} рас D&D ${verLabel}. В таблице — подрасы каждой расы. Нажмите на название, чтобы открыть страницу с особенностями. Общие расовые правила — в главе «Расы».`,
+      `${races.length} D&D ${verLabel} races. The table lists each race's subraces. Select a name to open its page with traits. General racial rules are in the Races chapter.`,
     )}
   </p>
 
-  <ul class="race-grid">
-    {races.map((r) => (
-      <li class="race-card">
-        <a class="race-card-link" href={`${base}/${r.slug}/`}>{r.name}</a>
-        {lang === 'ru' && r.name_en && <span class="race-card-en">{r.name_en}</span>}
-        {r.subraces.length > 0 && (
-          <span class="race-card-subs">
-            {t('Подрасы:', 'Subraces:')} {r.subraces.map((s) => s.name).join(', ')}
-          </span>
-        )}
-      </li>
-    ))}
-  </ul>
+  <div class="rd-table-wrap">
+    <table class="hub-table" data-sortable>
+      <thead>
+        <tr>
+          <th>{t('Раса', 'Race')}</th><th>{t('Подрасы', 'Subraces')}</th>
+          {lang === 'ru' && <th>Оригинал</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {races.map((r) => (
+          <tr>
+            <td><a href={`${base}/${r.slug}/`}>{r.name}</a></td>
+            <td data-sort={r.subraces.length}>{r.subraces.length > 0 ? r.subraces.map((s) => s.name).join(', ') : '—'}</td>
+            {lang === 'ru' && <td class="og-en">{r.name_en ?? '—'}</td>}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
 </ReaderShell>
 
 <style>
-  .race-grid {
-    list-style: none; margin: 24px 0 0; padding: 0;
-    display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 12px;
-  }
-  .race-card {
-    display: flex; flex-direction: column; gap: 4px;
-    padding: 14px 16px; border: 1px solid var(--og-border); border-radius: 10px;
-    background: var(--og-bg-2);
-  }
-  .race-card-link { font-weight: 600; font-size: 16px; }
-  .race-card-en { font-family: var(--font-mono); font-size: 13px; color: var(--og-text-muted); }
-  .race-card-subs { font-size: 13px; color: var(--og-text-2); margin-top: 2px; }
+  .og-en { font-family: var(--font-mono); font-size: 13px; color: var(--og-text-muted); }
 </style>

--- a/web/src/pages/[lang]/dnd/[version]/spells/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/all.astro
@@ -2,7 +2,7 @@
 import ReaderShell from '../../../../../components/ReaderShell.astro';
 import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
 import {
-  classLabel, levelShort, schoolLabel, spellClassSlugs, byName,
+  classLabel, levelShort, schoolLabel, schoolSlug, spellClassSlugs, byName,
   type Lang, type SpellLite,
 } from '../../../../../lib/spell-hubs';
 
@@ -50,13 +50,13 @@ const description = t(
   <h1>{heading}</h1>
   <p>
     {t(
-      `${spells.length} заклинаний D&D ${verLabel} по алфавиту. В таблице — уровень, школа и классы (ссылки на класс-хабы). Нажмите на название, чтобы открыть страницу заклинания.`,
-      `${spells.length} D&D ${verLabel} spells alphabetically. The table lists level, school and classes (linked to class hubs). Select a name to open the spell page.`,
+      `${spells.length} заклинаний D&D ${verLabel} по алфавиту. В таблице — уровень, школа и классы (все ссылки ведут на хабы). Нажмите на заголовок столбца, чтобы отсортировать.`,
+      `${spells.length} D&D ${verLabel} spells alphabetically. The table lists level, school and classes (all linked to hubs). Click a column header to sort.`,
     )}
   </p>
 
   <div class="rd-table-wrap">
-    <table class="hub-table">
+    <table class="hub-table" data-sortable>
       <thead>
         <tr>
           <th>{t('Заклинание', 'Spell')}</th><th>{t('Уровень', 'Level')}</th>
@@ -64,18 +64,21 @@ const description = t(
         </tr>
       </thead>
       <tbody>
-        {spells.map((s) => (
-          <tr>
-            <td><a href={`${base}/${s.slug}/`}>{s.name}</a></td>
-            <td>{levelShort(s.level, lang)}</td>
-            <td>{schoolLabel(s.school, lang)}</td>
-            <td>
-              {spellClassSlugs(s, lang).map((cs, i) => (
-                <>{i > 0 ? ', ' : ''}<a href={`${base}/class/${cs}/`}>{classLabel(cs, lang)}</a></>
-              ))}
-            </td>
-          </tr>
-        ))}
+        {spells.map((s) => {
+          const ss = schoolSlug(s.school);
+          return (
+            <tr>
+              <td><a href={`${base}/${s.slug}/`}>{s.name}</a></td>
+              <td data-sort={s.level}><a href={`${base}/level/${s.level}/`}>{levelShort(s.level, lang)}</a></td>
+              <td>{ss ? <a href={`${base}/school/${ss}/`}>{schoolLabel(s.school, lang)}</a> : schoolLabel(s.school, lang)}</td>
+              <td>
+                {spellClassSlugs(s, lang).map((cs, i) => (
+                  <>{i > 0 ? ', ' : ''}<a href={`${base}/class/${cs}/`}>{classLabel(cs, lang)}</a></>
+                ))}
+              </td>
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   </div>

--- a/web/src/pages/[lang]/dnd/[version]/spells/class/[class].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/class/[class].astro
@@ -2,8 +2,8 @@
 import ReaderShell from '../../../../../../components/ReaderShell.astro';
 import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../../lib/entities';
 import {
-  SPELL_CLASSES, LEVELS, classLabel, classHubName, classNameInData, levelLabel, schoolLabel, byName,
-  type Lang, type SpellLite,
+  SPELL_CLASSES, LEVELS, SCHOOL_HUBS, classLabel, classHubName, classNameInData, levelLabel,
+  schoolLabel, schoolSlug, schoolHubLabel, byName, type Lang, type SpellLite,
 } from '../../../../../../lib/spell-hubs';
 
 // Хаб заклинаний по классу (issue #20, SEO §2.3): /{lang}/dnd/{version}/spells/class/{class}/.
@@ -89,7 +89,7 @@ const otherClasses = SPELL_CLASSES.filter((c) => c.slug !== classSlug);
             {sec.items.map((s) => (
               <tr>
                 <td><a href={spellHref(s.slug)}>{s.name}</a></td>
-                <td>{schoolLabel(s.school, lang)}</td>
+                <td>{schoolSlug(s.school) ? <a href={`${base}/school/${schoolSlug(s.school)}/`}>{schoolLabel(s.school, lang)}</a> : schoolLabel(s.school, lang)}</td>
               </tr>
             ))}
           </tbody>
@@ -107,6 +107,11 @@ const otherClasses = SPELL_CLASSES.filter((c) => c.slug !== classSlug);
     <p><strong>{t('По уровню:', 'By level:')}</strong>{' '}
       {LEVELS.map((n, i) => (
         <>{i > 0 ? ' · ' : ''}<a href={`${base}/level/${n}/`}>{levelLabel(n, lang)}</a></>
+      ))}
+    </p>
+    <p><strong>{t('По школе:', 'By school:')}</strong>{' '}
+      {SCHOOL_HUBS.map((s, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/school/${s.slug}/`}>{schoolHubLabel(s.slug, lang)}</a></>
       ))}
     </p>
   </nav>

--- a/web/src/pages/[lang]/dnd/[version]/spells/level/[level].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/level/[level].astro
@@ -2,8 +2,8 @@
 import ReaderShell from '../../../../../../components/ReaderShell.astro';
 import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../../lib/entities';
 import {
-  SPELL_CLASSES, LEVELS, classLabel, levelLabel, schoolLabel, spellClassSlugs, byName,
-  type Lang, type SpellLite,
+  SPELL_CLASSES, LEVELS, SCHOOL_HUBS, classLabel, levelLabel, schoolLabel, schoolSlug, schoolHubLabel,
+  spellClassSlugs, byName, type Lang, type SpellLite,
 } from '../../../../../../lib/spell-hubs';
 
 // Хаб заклинаний по уровню (issue #20, SEO §2.3): /{lang}/dnd/{version}/spells/level/{n}/.
@@ -71,7 +71,7 @@ const otherLevels = LEVELS.filter((n) => n !== level);
   </p>
 
   <div class="rd-table-wrap">
-    <table class="hub-table">
+    <table class="hub-table" data-sortable>
       <thead>
         <tr><th>{t('Заклинание', 'Spell')}</th><th>{t('Школа', 'School')}</th><th>{t('Классы', 'Classes')}</th></tr>
       </thead>
@@ -79,7 +79,7 @@ const otherLevels = LEVELS.filter((n) => n !== level);
         {spells.map((s) => (
           <tr>
             <td><a href={spellHref(s.slug)}>{s.name}</a></td>
-            <td>{schoolLabel(s.school, lang)}</td>
+            <td>{schoolSlug(s.school) ? <a href={`${base}/school/${schoolSlug(s.school)}/`}>{schoolLabel(s.school, lang)}</a> : schoolLabel(s.school, lang)}</td>
             <td>
               {spellClassSlugs(s, lang).map((cs, i) => (
                 <>{i > 0 ? ', ' : ''}<a href={`${base}/class/${cs}/`}>{classLabel(cs, lang)}</a></>
@@ -100,6 +100,11 @@ const otherLevels = LEVELS.filter((n) => n !== level);
     <p><strong>{t('По классу:', 'By class:')}</strong>{' '}
       {SPELL_CLASSES.map((c, i) => (
         <>{i > 0 ? ' · ' : ''}<a href={`${base}/class/${c.slug}/`}>{classLabel(c.slug, lang)}</a></>
+      ))}
+    </p>
+    <p><strong>{t('По школе:', 'By school:')}</strong>{' '}
+      {SCHOOL_HUBS.map((s, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/school/${s.slug}/`}>{schoolHubLabel(s.slug, lang)}</a></>
       ))}
     </p>
   </nav>

--- a/web/src/pages/[lang]/dnd/[version]/spells/school/[school].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/school/[school].astro
@@ -1,0 +1,111 @@
+---
+import ReaderShell from '../../../../../../components/ReaderShell.astro';
+import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../../lib/entities';
+import {
+  SPELL_CLASSES, LEVELS, SCHOOL_HUBS, classLabel, levelShort, levelLabel,
+  schoolSlug, schoolHubLabel, spellClassSlugs, byName,
+  type Lang, type SpellLite,
+} from '../../../../../../lib/spell-hubs';
+
+// Хаб заклинаний по школе магии (issue #20, SEO §2.3): /{lang}/dnd/{version}/spells/school/{school}/.
+// Все заклинания школы (Ограждения/Воплощения/…) с колонками уровня и классов. Ловит
+// «evocation spells 5e» / «заклинания школы воплощения». EN/RU делят EN-слаг → каноникал + hreflang.
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-spells', srd51: 'd51-spells' };
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as Lang },
+    { ver: 'srd52', lang: 'ru' as Lang },
+    { ver: 'srd51', lang: 'en' as Lang },
+    { ver: 'srd51', lang: 'ru' as Lang },
+  ];
+  const paths = [];
+  for (const { ver, lang } of BUILDS) {
+    const spells = loadEntities(ver, lang, 'spells') as unknown as SpellLite[];
+    for (const sc of SCHOOL_HUBS) {
+      const mine = spells.filter((s) => schoolSlug(s.school) === sc.slug).sort(byName);
+      if (!mine.length) continue;
+      paths.push({
+        params: { lang, version: VERSION_SLUG[ver], school: sc.slug },
+        props: { ver, lang, schoolSlug: sc.slug, spells: mine },
+      });
+    }
+  }
+  return paths;
+}
+
+const { ver, lang, schoolSlug: sSlug, spells } = Astro.props as {
+  ver: string; lang: Lang; schoolSlug: string; spells: SpellLite[];
+};
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+const base = `/${lang}/dnd/${verSlug}/spells`;
+const spellHref = (slug: string) => `${base}/${slug}/`;
+const schoolName = schoolHubLabel(sSlug, lang);
+
+const heading = t(`Заклинания школы ${schoolName}`, `${schoolName} Spells`);
+const title = `${heading} — D&D ${verLabel} · OmnisGM Rules`;
+const description = t(
+  `Все ${spells.length} заклинаний школы ${schoolName} в D&D ${verLabel}: уровень, классы и ссылки на страницы заклинаний.`,
+  `All ${spells.length} ${schoolName} spells in D&D ${verLabel}: level, classes and links to each spell.`,
+);
+const otherSchools = SCHOOL_HUBS.filter((s) => s.slug !== sSlug);
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={heading}
+  description={description}
+  headings={[]}
+  upLink={{ href: `${base}/`, ru: 'Заклинания', en: 'Spells' }}
+>
+  <h1>{heading}</h1>
+  <p>
+    {t(
+      `${spells.length} заклинаний школы ${schoolName} в D&D ${verLabel}. В таблице — уровень и классы, которым доступно заклинание. Нажмите на название, чтобы открыть страницу заклинания.`,
+      `${spells.length} ${schoolName} spells in D&D ${verLabel}. The table lists level and the classes that can cast each spell. Select a name to open the spell page.`,
+    )}
+  </p>
+
+  <div class="rd-table-wrap">
+    <table class="hub-table" data-sortable>
+      <thead>
+        <tr><th>{t('Заклинание', 'Spell')}</th><th>{t('Уровень', 'Level')}</th><th>{t('Классы', 'Classes')}</th></tr>
+      </thead>
+      <tbody>
+        {spells.map((s) => (
+          <tr>
+            <td><a href={spellHref(s.slug)}>{s.name}</a></td>
+            <td data-sort={s.level}><a href={`${base}/level/${s.level}/`}>{levelShort(s.level, lang)}</a></td>
+            <td>
+              {spellClassSlugs(s, lang).map((cs, i) => (
+                <>{i > 0 ? ', ' : ''}<a href={`${base}/class/${cs}/`}>{classLabel(cs, lang)}</a></>
+              ))}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+
+  <nav class="hub-links" aria-label={t('Другие хабы заклинаний', 'Other spell hubs')}>
+    <p><strong>{t('Другие школы:', 'Other schools:')}</strong>{' '}
+      {otherSchools.map((s, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/school/${s.slug}/`}>{schoolHubLabel(s.slug, lang)}</a></>
+      ))}
+    </p>
+    <p><strong>{t('По уровню:', 'By level:')}</strong>{' '}
+      {LEVELS.map((n, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/level/${n}/`}>{levelLabel(n, lang)}</a></>
+      ))}
+    </p>
+    <p><strong>{t('По классу:', 'By class:')}</strong>{' '}
+      {SPELL_CLASSES.map((c, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/class/${c.slug}/`}>{classLabel(c.slug, lang)}</a></>
+      ))}
+    </p>
+  </nav>
+</ReaderShell>

--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -247,6 +247,14 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 .rd-doc tbody td { color: var(--og-text-2); line-height: 1.5; }
 .rd-doc tbody td:first-child { color: var(--og-text); font-weight: 500; }
 
+/* Сортируемые хаб-таблицы (issue #20): клик по <th> сортирует колонку; стрелка отражает aria-sort. */
+.rd-doc .hub-table[data-sortable] thead th { cursor: pointer; user-select: none; white-space: nowrap; }
+.rd-doc .hub-table[data-sortable] thead th::after { content: '↕'; margin-left: 6px; opacity: 0.3; font-size: 0.9em; }
+.rd-doc .hub-table[data-sortable] thead th[aria-sort="ascending"]::after { content: '↑'; opacity: 0.85; }
+.rd-doc .hub-table[data-sortable] thead th[aria-sort="descending"]::after { content: '↓'; opacity: 0.85; }
+.rd-doc .hub-table[data-sortable] thead th:hover { color: var(--og-text-2); }
+.rd-doc .hub-table[data-sortable] thead th:focus-visible { outline: 2px solid var(--og-accent); outline-offset: -2px; }
+
 /* Хабы заклинаний (issue #20): счётчик у заголовка уровня + блок перелинковки на соседние хабы. */
 .rd-doc .hub-count { color: var(--og-text-muted); font-weight: 400; font-size: 0.85em; }
 .rd-doc .hub-links { margin: 28px 0 0; padding: 16px 0 0; border-top: 1px solid var(--og-border-soft); font-size: 14px; }


### PR DESCRIPTION
PR **A из 3** по улучшениям хаб/глоссарий-таблиц (issue #20). Эта — D&D (5.2 + 5.1). Далее: Daggerheart, BRP.

## Что сделано
- **Виды/предыстории** (`character-origins/all`): карточки → единая **сортируемая таблица** (Название · Тип · Оригинал).
- **Все заклинания**: колонки **Уровень** и **Школа** кликабельны. «Школа» → **новый фасет-хаб** `spells/school/[school]` (8 школ × 5.2/5.1). Для симметрии школа кликабельна и на `level`/`class`-страницах + строка «По школе» в футере.
- **Все монстры**: **ПО** → cr-хаб. **Все животные**: **ПО** → **новый фасет** `animals/cr/[cr]` (переиспользует CR-шкалу монстров).
- **Сортируемые таблицы**: общий скрипт в `ReaderShell` улучшает любую `<table class="hub-table" data-sortable>` — клик/Enter по `<th>` сортирует колонку (`data-sort` ячейки для CR/уровня/редкости, иначе текст; числовые — численно, иначе `localeCompare`). Прогрессивное улучшение — без JS таблица статична. **Переиспользуется в PR B/C.**

Помечены `data-sortable`: spells `all`/`level`/`school`, monsters `all`/`cr`/`type`, animals `all`/`cr`, magic-items `all`, character-origins `all`.

## Проверки
- `astro check` — 0 ошибок. Билд — 5700 страниц (добавились 8 школа-хабов ×2×2 + CR-хабы животных).
- e2e (15/15 зелёных): обновлён origins (таблица вместо карточек), + кликабельные колонки, school/animal-CR хабы, **интерактивная сортировка** (клик по `<th>` меняет порядок + `aria-sort`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)