### PR TITLE
Паритет обогащения текста: .kw / gloss / автолинк для 5.1, DH, BRP (#20)

### DIFF
--- a/.github/scripts/config.py
+++ b/.github/scripts/config.py
@@ -49,6 +49,7 @@ SOURCES = [
     {"ver": "srd51", "lang": "ru", "type": "condition",   "file": "srd-5.1/ru/11_Conditions.md",   "h": 4},
     {"ver": "srd51", "lang": "ru", "type": "feat",        "file": "srd-5.1/ru/08_Feats.md",        "h": 4},
     {"ver": "srd51", "lang": "ru", "type": "race",        "file": "srd-5.1/ru/04_Races.md",        "h": 2},
+    {"ver": "srd51", "lang": "ru", "type": "section_tables","file": "srd-5.1/ru/16_Glossary/00_Glossary.md", "out": "rules-terms"},
     # SRD 5.1 EN
     {"ver": "srd51", "lang": "en", "type": "spell",      "file": "srd-5.1/en/10_Spells.md",       "h": 3},
     {"ver": "srd51", "lang": "en", "type": "monster",     "file": "srd-5.1/en/15_MonstersA-Z.md",  "h": 3},
@@ -59,6 +60,7 @@ SOURCES = [
     {"ver": "srd51", "lang": "en", "type": "condition",   "file": "srd-5.1/en/11_Conditions.md",   "h": 4},
     {"ver": "srd51", "lang": "en", "type": "feat",        "file": "srd-5.1/en/08_Feats.md",        "h": 4},
     {"ver": "srd51", "lang": "en", "type": "race",        "file": "srd-5.1/en/04_Races.md",        "h": 2},
+    {"ver": "srd51", "lang": "en", "type": "section_tables","file": "srd-5.1/en/16_Glossary/00_Glossary.md", "out": "rules-terms"},
 ]
 
 # Heading patterns that are NOT entity entries (section headers, rules text, etc.)

--- a/.github/scripts/generate_api.py
+++ b/.github/scripts/generate_api.py
@@ -27,7 +27,7 @@ import importlib
 from parsers import (parse_spells, parse_monsters, parse_magic_items,
                      parse_weapons, parse_armor, parse_equipment,
                      parse_conditions, parse_feats, parse_races, parse_origins,
-                     parse_defs, parse_tagged_defs, parse_untagged_defs,
+                     parse_defs, parse_tagged_defs, parse_untagged_defs, parse_section_tables,
                      parse_ancestries, parse_communities, parse_domain_cards,
                      parse_adversaries, parse_environments, parse_dh_glossary,
                      parse_brp_skills, parse_brp_professions, parse_brp_spot_rules)
@@ -192,6 +192,11 @@ def align_positional_name_en(all_data: dict, resources: tuple[str, ...]) -> None
     """
     for (ver, lang, resource), ru_entities in list(all_data.items()):
         if lang != "ru" or resource not in resources:
+            continue
+        # Записи, у которых name_en уже проставлен (напр. rules-terms 5.1 берёт слаг из
+        # EN-колонки RU-таблицы) — не выравниваем позиционно и не считаем расхождением.
+        pending = [r for r in ru_entities if not r.get("name_en")]
+        if not pending:
             continue
         en_entities = all_data.get((ver, "en", resource))
         if not en_entities:
@@ -523,6 +528,9 @@ def main():
             resource = out_resource
         elif entity_type == "untagged_defs":
             entities = parse_untagged_defs(text)
+            resource = out_resource
+        elif entity_type == "section_tables":
+            entities = parse_section_tables(text, lang)
             resource = out_resource
         elif entity_type == "ancestry":
             entities = parse_ancestries(text, lang)

--- a/.github/scripts/parsers/__init__.py
+++ b/.github/scripts/parsers/__init__.py
@@ -8,7 +8,7 @@ from .condition import parse_conditions
 from .feat import parse_feats
 from .race import parse_races
 from .origin import parse_origins
-from .glossary_defs import parse_defs, parse_tagged_defs, parse_untagged_defs
+from .glossary_defs import parse_defs, parse_tagged_defs, parse_untagged_defs, parse_section_tables
 from .daggerheart import (parse_ancestries, parse_communities, parse_domain_cards,
                           parse_adversaries, parse_environments, parse_dh_glossary)
 from .brp import parse_brp_skills, parse_brp_professions, parse_brp_spot_rules

--- a/.github/scripts/parsers/glossary_defs.py
+++ b/.github/scripts/parsers/glossary_defs.py
@@ -117,7 +117,10 @@ def parse_section_tables(text: str, lang: str) -> list[dict]:
                 name_en = None
                 effect = cells[1] if len(cells) >= 2 else ""
                 slug = slugify(name)
-            if not slug or slug in seen:
+            # Пустой эффект = строка-список имён без определения (Damage Types, Schools of Magic
+            # и пр. одноколоночные EN-таблицы / 2-колоночные RU). Такие термы — не «карточка»;
+            # выкидываем, чтобы гейт по-слагу не мог однажды показать пустую подсказку.
+            if not effect or not slug or slug in seen:
                 continue
             seen.add(slug)
             defs.append({

--- a/.github/scripts/parsers/glossary_defs.py
+++ b/.github/scripts/parsers/glossary_defs.py
@@ -72,6 +72,63 @@ def parse_untagged_defs(text: str) -> list[dict]:
     return defs
 
 
+def parse_section_tables(text: str, lang: str) -> list[dict]:
+    """Глоссарий 5.1: секции ### с таблицами → термины ядра (rules-terms).
+
+    В отличие от 5.2 (08_RulesGlossary: #### Имя + абзац), глоссарий 5.1 (16_Glossary/
+    00_Glossary) — компактные таблицы по секциям. Формат колонок:
+      • EN: | Термин | Эффект |          → slug из термина.
+      • RU: | Термин | Original | Эффект | → RU-таблицы содержат колонку EN-оригинала (col 1),
+        поэтому канонический (EN) слаг и name_en берём ПРЯМО из неё — без позиционного
+        выравнивания EN↔RU (глоссарии не идеально параллельны построчно).
+
+    Заголовки/разделители таблиц пропускаем. Питает gloss-подсказки 5.1 (частичное покрытие:
+    глоссятся лишь термы, чей слаг ∈ CORE_TERMS — по-слаговый гейт на стороне ридера).
+    """
+    defs = []
+    seen = set()
+    lines = text.split("\n")
+    i, n = 0, len(lines)
+    while i < n:
+        if not lines[i].strip().startswith("|"):
+            i += 1
+            continue
+        block = []
+        while i < n and lines[i].strip().startswith("|"):
+            block.append(lines[i])
+            i += 1
+        for row_idx, ln in enumerate(block):
+            cells = [c.strip() for c in ln.strip().strip("|").split("|")]
+            if row_idx == 0:
+                continue  # строка-заголовок таблицы
+            if not any(cells) or all(set(c) <= set("-: ") for c in cells if c):
+                continue  # разделитель |---|---|
+            if not cells[0]:
+                continue
+            if lang == "ru":
+                if len(cells) < 2:
+                    continue  # нет EN-оригинала → слаг не вывести, пропускаем
+                name = cells[0]
+                name_en = cells[1]
+                effect = cells[2] if len(cells) >= 3 else ""
+                slug = slugify(name_en)
+            else:
+                name = cells[0]
+                name_en = None
+                effect = cells[1] if len(cells) >= 2 else ""
+                slug = slugify(name)
+            if not slug or slug in seen:
+                continue
+            seen.add(slug)
+            defs.append({
+                "slug": slug,
+                "name": name,
+                "name_en": name_en,
+                "description_md": effect,
+            })
+    return defs
+
+
 def parse_tagged_defs(text: str, tags: list[str]) -> list[dict]:
     """Собрать определения #### «Имя [Тег]» по всему файлу, где Тег ∈ tags.
 

--- a/web/e2e/brp.spec.ts
+++ b/web/e2e/brp.spec.ts
@@ -63,6 +63,12 @@ test('хабы: навыки по категориям + фасет катего
   await expect(page.locator('.og-card a[href$="/spot-rules/ambush/"]')).toBeVisible();
 });
 
+test('автолинк: таблица навыков в глоссарии линкует навыки (grid-режим) + hovercard', async ({ page }) => {
+  await page.goto('/ru/brp/srd-1.0/glossary/skills/');
+  const link = page.locator('.rd-doc a.ent-link[href*="/skills/"][data-hc^="brp/srd10/ru/skills/"]').first();
+  await expect(link).toBeVisible();
+});
+
 test('SEO: hreflang-тройка + сущности в sitemap', async ({ page, request }) => {
   const res = await page.goto('/en/brp/srd-1.0/skills/dodge/');
   expect(res?.status()).toBe(200);

--- a/web/e2e/daggerheart.spec.ts
+++ b/web/e2e/daggerheart.spec.ts
@@ -73,6 +73,13 @@ test('хабы: происхождения, доменные карты (по д
   await expect(page.locator('a[href$="/adversaries/acid-burrower/"]')).toBeVisible();
 });
 
+test('автолинк: глава «Домены» линкует доменные карты (grid-режим) + hovercard', async ({ page }) => {
+  await page.goto('/ru/daggerheart/srd-1.0/domains/');
+  // Ячейки-имена карт в сетке домена стали ссылками на страницы карт с data-hc.
+  const link = page.locator('.rd-doc a.ent-link[href*="/domain-cards/"][data-hc^="daggerheart/srd10/ru/domain-cards/"]').first();
+  await expect(link).toBeVisible();
+});
+
 test('канонический слаг EN↔RU: RU-сущность на английском слаге', async ({ page }) => {
   expect((await page.goto('/ru/daggerheart/srd-1.0/ancestries/goblin/'))?.status()).toBe(200);
   expect((await page.goto('/ru/daggerheart/srd-1.0/domain-cards/rune-ward/'))?.status()).toBe(200);

--- a/web/e2e/srd51.spec.ts
+++ b/web/e2e/srd51.spec.ts
@@ -34,26 +34,37 @@ test('канонический слаг EN↔RU: таблично-парсиру
   }
 });
 
-test('независимость: 5.1-страница линкует ТОЛЬКО 5.1, hovercard-бакет srd51, без «мёртвого» gloss', async ({ page }) => {
+test('независимость: 5.1-страница линкует и глоссит ТОЛЬКО через бакет srd51', async ({ page }) => {
   await page.goto('/ru/dnd/srd-5.1/monsters-a-z/imp/');
   const doc = page.locator('.rd-doc');
   // Все автоссылки в теле → srd-5.1.
   const hrefs = await doc.locator('a.ent-link').evaluateAll((els) =>
     els.map((e) => (e as HTMLAnchorElement).getAttribute('href') || ''));
   for (const h of hrefs) expect(h, `ent-link ${h}`).toContain('/dnd/srd-5.1/');
-  // data-hc в теле → бакет srd51 (не srd52).
+  // Любой data-hc в теле (автолинк ИЛИ gloss ядра) → бакет srd51, не srd52 (изоляция версий).
   const hc = await doc.locator('[data-hc]').evaluateAll((els) =>
     els.map((e) => e.getAttribute('data-hc') || ''));
   for (const b of hc) expect(b, `data-hc ${b}`).toContain('dnd/srd51/');
-  // rules-terms/actions в 5.1 нет → gloss ядра выключен (иначе data-hc указывал бы на пустой бакет).
-  await expect(doc.locator('.gloss[data-hc*="rules-terms"]')).toHaveCount(0);
 });
 
-test('5.1-глава не даёт rules-terms-gloss (независимость от 5.2), а 5.2 — даёт', async ({ page }) => {
-  await page.goto('/ru/dnd/srd-5.1/combat/');
-  await expect(page.locator('.rd-doc .gloss[data-hc*="rules-terms"]')).toHaveCount(0);
+test('5.1 gloss: свой rules-terms-бакет (srd51), изолирован от 5.2', async ({ page }) => {
+  // 5.1 теперь глоссит термины ядра из собственного глоссария (парсер секций-таблиц).
+  await page.goto('/ru/dnd/srd-5.1/classes/barbarian/');
+  await expect(page.locator('.rd-doc .gloss[data-hc^="dnd/srd51/ru/rules-terms/"]').first()).toBeVisible();
+  // Изоляция: ни одной 5.2-подсказки на 5.1-странице.
+  await expect(page.locator('.rd-doc .gloss[data-hc*="srd52"]')).toHaveCount(0);
+  // 5.2 тоже глоссит (не сломали).
   await page.goto('/ru/dnd/srd-5.2/playing-the-game/');
   await expect(page.locator('.rd-doc .gloss[data-hc*="rules-terms"]').first()).toBeVisible();
+});
+
+test('5.1 gloss-бакет отдаёт карточки терминов (нет мёртвых подсказок)', async ({ request }) => {
+  const res = await request.get('/hc/dnd/srd51/ru.json');
+  expect(res.status()).toBe(200);
+  const map = await res.json();
+  // Символические термы, покрытые глоссарием 5.1 (симметрично EN/RU).
+  expect(map['rules-terms/initiative']).toBeTruthy();
+  expect(map['rules-terms/concentration']).toBeTruthy();
 });
 
 test('монстр 5.1: чистый тип (запятая в скобках подтипа) + бэклинк в type-хаб', async ({ page }) => {
@@ -118,6 +129,7 @@ test('hovercard-эндпоинт srd51: непустой, карточки за�
   expect(Object.keys(ru).length).toBeGreaterThan(500);
   expect(ru['spells/fireball']?.name_en).toBe('Fireball');
   expect(ru['magic-items/bag-of-holding']?.name_en).toBe('Bag of Holding');
-  // rules-terms/actions в 5.1 отсутствуют → бакет их не содержит.
-  expect(Object.keys(ru).some((k) => k.startsWith('rules-terms/'))).toBe(false);
+  // 5.1 теперь имеет rules-terms (парсер секций-таблиц глоссария) → бакет их содержит.
+  expect(Object.keys(ru).some((k) => k.startsWith('rules-terms/'))).toBe(true);
+  expect(ru['rules-terms/initiative']?.name_en).toBe('Initiative');
 });

--- a/web/src/lib/keyword-highlight.mjs
+++ b/web/src/lib/keyword-highlight.mjs
@@ -89,18 +89,24 @@ function brpSkills(lang) {
   return names;
 }
 
-// Термсет по игре: { abil, skill } на язык. abil — всегда; skill — в контексте.
-function gameTerms(game, lang) {
-  if (game === 'daggerheart') return { abil: DH_ABIL[lang] || [], skill: [] };
-  if (game === 'brp') return { abil: BRP_ABIL[lang] || [], skill: [...(BRP_CHAR_FULL[lang] || []), ...brpSkills(lang)] };
-  return { abil: DND_ABIL[lang] || [], skill: DND_SKILL[lang] || [] };
-}
-
-// Контекст-слова, легитимирующие подсветку навыка/характеристики (если не в скобках). Общие.
-const SKILL_CTX = {
+// Контекст-слова, легитимирующие подсветку навыка/характеристики (если не в скобках). ПО ИГРАМ,
+// чтобы наборы не тянули друг друга: BRP добавляет «характеристик*/characteristic/roll» — это не
+// должно влиять на D&D (иначе следующее расширение молча поедет на чужую систему).
+const DND_CTX = {
+  ru: /(?:навык\w*|владе\w+|проверк\w+|спасброс\w+|Навыки)\s*$/u,
+  en: /(?:proficiency|proficient|check|save|saving throw|skill|Skills|\bin)\s*$/iu,
+};
+const BRP_CTX = {
   ru: /(?:навык\w*|владе\w+|проверк\w+|спасброс\w+|характеристик\w*|Навыки)\s*$/u,
   en: /(?:proficiency|proficient|check|save|saving throw|skill|characteristic|roll|Skills|\bin)\s*$/iu,
 };
+
+// Термсет по игре: { abil, skill, ctx } на язык. abil — всегда; skill — в контексте ctx.
+function gameTerms(game, lang) {
+  if (game === 'daggerheart') return { abil: DH_ABIL[lang] || [], skill: [], ctx: DND_CTX };
+  if (game === 'brp') return { abil: BRP_ABIL[lang] || [], skill: [...(BRP_CHAR_FULL[lang] || []), ...brpSkills(lang)], ctx: BRP_CTX };
+  return { abil: DND_ABIL[lang] || [], skill: DND_SKILL[lang] || [], ctx: DND_CTX };
+}
 
 // Разделитель списка навыков: запятая и/или союз («A, B, or C», «A, B … или F»). Если два
 // соседних навыка разделены только им — они члены одного перечисления. Пустой зазор (только
@@ -113,13 +119,13 @@ const cache = new Map(); // `${game}/${lang}` → { re, abil:Set, skill:Set, ctx
 function build(game, lang) {
   const cacheKey = `${game}/${lang}`;
   if (cache.has(cacheKey)) return cache.get(cacheKey);
-  const { abil, skill } = gameTerms(game, lang);
+  const { abil, skill, ctx } = gameTerms(game, lang);
   if (!abil.length && !skill.length) { cache.set(cacheKey, null); return null; }
   // Длинные формы раньше коротких (в альтернации побеждает первый матч).
   const all = [...abil, ...skill].sort((a, b) => b.length - a.length);
   const alt = all.map(escapeRegExp).join('|');
   const re = new RegExp(`(?<![\\p{L}\\p{N}_])(${alt})(?![\\p{L}\\p{N}_])`, 'gu');
-  const res = { re, abil: new Set(abil), skill: new Set(skill), ctx: SKILL_CTX[lang] };
+  const res = { re, abil: new Set(abil), skill: new Set(skill), ctx: ctx[lang] };
   cache.set(cacheKey, res);
   return res;
 }

--- a/web/src/lib/keyword-highlight.mjs
+++ b/web/src/lib/keyword-highlight.mjs
@@ -14,10 +14,18 @@
 // (rehype с гейтом на /03_Classes/). НЕ на главах-определениях (Как играть, Глоссарий),
 // где термины встречаются сплошь и подсветка стала бы ковром.
 
-const SKIP_TAGS = new Set(['a', 'code', 'pre', 'kbd', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+import fs from 'node:fs';
+import path from 'node:path';
 
-// Формы характеристик (RU — по падежам; EN — одна форма). Заглавная обязательна.
-const ABILITIES = {
+const SKIP_TAGS = new Set(['a', 'code', 'pre', 'kbd', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+const DATA_ROOT = path.resolve(process.cwd(), 'src/data/api');
+
+// Per-game термсеты (issue #20): у каждой системы свои «ключевые» механические слова.
+// В каждом наборе `abil` — подсвечиваем всегда при Заглавной (дистинктивны); `skill` — только
+// в игромеханическом контексте (омонимы обычных слов).
+
+// --- D&D (5.2/5.1): 6 характеристик (по падежам RU) ---
+const DND_ABIL = {
   ru: [
     'Сила', 'Силы', 'Силе', 'Силу', 'Силой', 'Силою',
     'Ловкость', 'Ловкости', 'Ловкостью',
@@ -28,10 +36,8 @@ const ABILITIES = {
   ],
   en: ['Strength', 'Dexterity', 'Constitution', 'Intelligence', 'Wisdom', 'Charisma'],
 };
-
-// Названия навыков (именительный — как в скобках и в статблоке). Длинные раньше коротких,
-// чтобы «Ловкость рук» победила «Ловкость».
-const SKILLS = {
+// Навыки D&D (именительный — как в скобках и в статблоке). Длинные раньше коротких.
+const DND_SKILL = {
   ru: [
     'Уход за животными', 'Ловкость рук', 'Проницательность', 'Внимательность',
     'Выступление', 'Запугивание', 'Скрытность', 'Убеждение', 'Выживание',
@@ -46,10 +52,54 @@ const SKILLS = {
   ],
 };
 
-// Контекст-слова, легитимирующие подсветку навыка (если он не в скобках).
+// --- Daggerheart: 6 черт (по падежам RU). Всегда подсвечиваем — дистинктивны в правилах DH. ---
+const DH_ABIL = {
+  ru: [
+    'Проворство', 'Проворства', 'Проворству', 'Проворством',
+    'Точность', 'Точности', 'Точностью',
+    'Инстинкт', 'Инстинкта', 'Инстинкту', 'Инстинктом',
+    'Обаяние', 'Обаяния', 'Обаянию', 'Обаянием',
+    'Знание', 'Знания', 'Знанию', 'Знанием',
+    'Сила', 'Силы', 'Силе', 'Силу', 'Силой', 'Силою',
+  ],
+  en: ['Agility', 'Strength', 'Finesse', 'Instinct', 'Presence', 'Knowledge'],
+};
+
+// --- BRP: аббревиатуры характеристик — всегда (жаргон, дистинктивны); полные имена — в контексте. ---
+const BRP_ABIL = {
+  ru: ['СИЛ', 'ВЫН', 'РАЗ', 'ИНТ', 'ВОЛ', 'ЛОВ', 'ВНШ'],
+  en: ['STR', 'CON', 'SIZ', 'INT', 'POW', 'DEX', 'APP'],
+};
+const BRP_CHAR_FULL = {
+  ru: ['Выносливость', 'Внешность', 'Интеллект', 'Ловкость', 'Размер', 'Сила', 'Воля'],
+  en: ['Constitution', 'Intelligence', 'Appearance', 'Dexterity', 'Strength', 'Power', 'Size'],
+};
+
+// Навыки BRP (56) омонимичны обычным словам (Лазание, Драка) → грузим из данных, подсвечиваем
+// ТОЛЬКО в контексте (как навыки D&D). Ленивая загрузка + кэш по языку.
+const brpSkillCache = new Map();
+function brpSkills(lang) {
+  if (brpSkillCache.has(lang)) return brpSkillCache.get(lang);
+  let names = [];
+  try {
+    const data = JSON.parse(fs.readFileSync(path.join(DATA_ROOT, 'brp', 'srd10', lang, 'skills', 'all.json'), 'utf8'));
+    names = data.map((s) => String(s.name || '').replace(/\s*\([^)]*\)\s*$/, '').trim()).filter(Boolean);
+  } catch { names = []; }
+  brpSkillCache.set(lang, names);
+  return names;
+}
+
+// Термсет по игре: { abil, skill } на язык. abil — всегда; skill — в контексте.
+function gameTerms(game, lang) {
+  if (game === 'daggerheart') return { abil: DH_ABIL[lang] || [], skill: [] };
+  if (game === 'brp') return { abil: BRP_ABIL[lang] || [], skill: [...(BRP_CHAR_FULL[lang] || []), ...brpSkills(lang)] };
+  return { abil: DND_ABIL[lang] || [], skill: DND_SKILL[lang] || [] };
+}
+
+// Контекст-слова, легитимирующие подсветку навыка/характеристики (если не в скобках). Общие.
 const SKILL_CTX = {
-  ru: /(?:навык\w*|владе\w+|проверк\w+|спасброс\w+|Навыки)\s*$/u,
-  en: /(?:proficiency|proficient|check|save|saving throw|skill|Skills|\bin)\s*$/iu,
+  ru: /(?:навык\w*|владе\w+|проверк\w+|спасброс\w+|характеристик\w*|Навыки)\s*$/u,
+  en: /(?:proficiency|proficient|check|save|saving throw|skill|characteristic|roll|Skills|\bin)\s*$/iu,
 };
 
 // Разделитель списка навыков: запятая и/или союз («A, B, or C», «A, B … или F»). Если два
@@ -58,19 +108,19 @@ const SKILL_CTX = {
 const SKILL_LIST_SEP = /^\s*(?:,\s*(?:или|и|or|and)?|(?:или|и|or|and))\s*$/iu;
 
 const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-const cache = new Map(); // lang → { re, abil:Set, skill:Set, ctx }
+const cache = new Map(); // `${game}/${lang}` → { re, abil:Set, skill:Set, ctx }
 
-function build(lang) {
-  if (cache.has(lang)) return cache.get(lang);
-  const abil = ABILITIES[lang] || [];
-  const skill = SKILLS[lang] || [];
-  if (!abil.length && !skill.length) { cache.set(lang, null); return null; }
+function build(game, lang) {
+  const cacheKey = `${game}/${lang}`;
+  if (cache.has(cacheKey)) return cache.get(cacheKey);
+  const { abil, skill } = gameTerms(game, lang);
+  if (!abil.length && !skill.length) { cache.set(cacheKey, null); return null; }
   // Длинные формы раньше коротких (в альтернации побеждает первый матч).
   const all = [...abil, ...skill].sort((a, b) => b.length - a.length);
   const alt = all.map(escapeRegExp).join('|');
   const re = new RegExp(`(?<![\\p{L}\\p{N}_])(${alt})(?![\\p{L}\\p{N}_])`, 'gu');
   const res = { re, abil: new Set(abil), skill: new Set(skill), ctx: SKILL_CTX[lang] };
-  cache.set(lang, res);
+  cache.set(cacheKey, res);
   return res;
 }
 
@@ -124,9 +174,9 @@ function highlightText(value, m) {
   return nodes;
 }
 
-// Ядро: подсвечивает ключевые слова прямо в hast-дереве.
-export function highlightKeywords(tree, { lang }) {
-  const m = build(lang);
+// Ядро: подсвечивает ключевые слова прямо в hast-дереве. game — термсет системы (по умолчанию dnd).
+export function highlightKeywords(tree, { lang, game = 'dnd' }) {
+  const m = build(game, lang);
   if (!m) return tree;
   const walk = (node, insideSkip) => {
     if (!node.children) return;
@@ -147,15 +197,28 @@ export function highlightKeywords(tree, { lang }) {
   return tree;
 }
 
-// rehype-обёртка: подсветка ТОЛЬКО в главе классов (умения классов). Остальные главы
-// (Как играть, Глоссарий) — определения терминов, там подсветка была бы шумом.
+// Главы прозы, где подсветка уместна (классы/создание персонажа — там механику обсуждают явно).
+// Остальные главы (Как играть, Глоссарий) — сплошные определения → подсветка была бы ковром.
+//  • dnd: классы 5.2 (03_Classes) и 5.1 (06_Classes).
+//  • daggerheart: классы (04_Classes) — там черты в описаниях.
+//  • brp: НЕ гейтим главы. Единственная характеристико-/навыко-плотная глава (02_CharacterCreation)
+//    — это по сути полный список навыков → подсветка там стала бы ковром (200+). BRP-подсветка
+//    остаётся на entity-страницах (навык/профессия/точечное правило), где она контекстна.
+const PROSE_GATE = {
+  dnd: /\/(03_Classes|06_Classes)\//,
+  daggerheart: /\/04_Classes\//,
+};
+
+// rehype-обёртка: подсветка ТОЛЬКО в разрешённых главах системы (PROSE_GATE).
 export default function rehypeKeywordHighlight() {
   return (tree, file) => {
     const p = (file && (file.path || (file.history && file.history[0]))) || '';
     const norm = p.replace(/\\/g, '/');
-    if (!/\/03_Classes\//.test(norm)) return;
     const m = norm.match(/\/(dnd|daggerheart|brp)\/[^/]+\/(en|ru)\//);
     if (!m) return;
-    highlightKeywords(tree, { lang: m[2] });
+    const [, game, lang] = m;
+    const gate = PROSE_GATE[game];
+    if (!gate || !gate.test(norm)) return;
+    highlightKeywords(tree, { lang, game });
   };
 }

--- a/web/src/lib/rehype-entity-autolink.mjs
+++ b/web/src/lib/rehype-entity-autolink.mjs
@@ -18,10 +18,11 @@ import path from 'node:path';
 // (страницы сущностей). import.meta.url под Vite указывает не туда.
 const DATA_ROOT = path.resolve(process.cwd(), 'src/data/api');
 
-// Ресурсы с программными страницами. mode: 'text' | 'exact'. container (для exact) — тег-обёртка
-// разметки-сигнала SRD: 'em' (курсив, заклинания) или 'strong' (жирный, монстры). versions —
-// ограничение по версиям (где реально есть страницы); без него — все версии.
-const RESOURCES = [
+// Ресурсы с программными страницами. mode: 'text' | 'exact' | 'feats' | 'cells' | 'grid'.
+// container (для exact) — тег-обёртка сигнала SRD: 'em' (курсив, заклинания) / 'strong' (жирный,
+// монстры). versions — где реально есть страницы. chapters (для grid) — regex главы-источника.
+// Наборы ресурсов — ПО ИГРАМ: у D&D свои ресурсы/разметка, у Daggerheart/BRP — свои.
+const DND_RESOURCES = [
   { key: 'conditions', urlParent: 'rules-glossary/conditions', mode: 'text' },
   { key: 'spells', urlParent: 'spells', mode: 'exact', container: 'em', versions: ['srd-5.2', 'srd-5.1'] },
   { key: 'monsters', urlParent: 'monsters-a-z', mode: 'exact', container: 'strong', versions: ['srd-5.2', 'srd-5.1'] },
@@ -47,6 +48,22 @@ const RESOURCES = [
   { key: 'armor', urlParent: 'armor', mode: 'cells', versions: ['srd-5.2', 'srd-5.1'] },
   { key: 'equipment', urlParent: 'equipment', mode: 'cells', versions: ['srd-5.2', 'srd-5.1'] },
 ];
+
+// Daggerheart: имена сущностей в прозе НЕ размечены (нет курсив/жирный-сигнала, как в D&D).
+// Единственная безопасная поверхность — таблица-сетка доменных карт в главе «Домены»
+// (03_Domains: Уровень × Опция 1–3, ячейки = имена карт). Режим 'grid': линкуем ЛЮБУЮ ячейку
+// <td>, точно равную имени карты, ТОЛЬКО в этой главе (chapters) → точное совпадение = 0 ложных.
+const DH_RESOURCES = [
+  { key: 'domain-cards', urlParent: 'domain-cards', mode: 'grid', versions: ['srd-1.0'], chapters: /\/03_Domains/ },
+];
+
+// BRP: имена в прозе тоже не размечены. Безопасная поверхность — таблица навыков в глоссарии
+// (09_Glossary/01_Skills, первая колонка = имя навыка). Режим 'grid' с гейтом на эту главу.
+const BRP_RESOURCES = [
+  { key: 'skills', urlParent: 'skills', mode: 'grid', versions: ['srd-1.0'], chapters: /\/09_Glossary\/01_Skills/ },
+];
+
+const RESOURCES_BY_GAME = { dnd: DND_RESOURCES, daggerheart: DH_RESOURCES, brp: BRP_RESOURCES };
 
 // Заголовок первой колонки таблицы спелл-листа класса (по языку) — сигнал линковать её ячейки.
 const SPELL_TABLE_HEAD = new Set(['Заклинание', 'Spell']);
@@ -137,11 +154,13 @@ function loadMap(game, version, lang) {
   const feats = new Map();
   // Оружие/доспехи/снаряжение: карта «имя → сущность» для матча точных ячеек таблиц.
   const cells = new Map();
+  // Grid (DH/BRP): «имя → сущность (+chapters)» — линкуем любую ячейку = имя, только в своей главе.
+  const grid = new Map();
   // Имена magic-items/monsters — зарезервированы: их не линкуем как cells (редкие кросс-ресурс
   // коллизии: «Свиток заклинания» = equipment+magic-item, «Страж-щит» = magic-item+monster).
   // magic-items/monsters идут в RESOURCES раньше оружия → к моменту cells набор полон.
   const reserved = new Set();
-  for (const { key, urlParent, mode, container, versions } of RESOURCES) {
+  for (const { key, urlParent, mode, container, versions, chapters } of (RESOURCES_BY_GAME[game] || [])) {
     if (versions && !versions.includes(version)) continue;
     const file = path.join(DATA_ROOT, game, verKey, lang, key, 'all.json');
     let data;
@@ -174,6 +193,10 @@ function loadMap(game, version, lang) {
       } else if (mode === 'cells') {
         const k = e.name.toLowerCase();
         if (!reserved.has(k) && !cells.has(k)) cells.set(k, entry);
+      } else if (mode === 'grid') {
+        // Любая ячейка = имя сущности → ссылка, но только в главе-источнике (chapters).
+        const k = e.name.toLowerCase();
+        if (!grid.has(k)) grid.set(k, { ...entry, chapters });
       } else {
         textEntries.push(entry);
         for (const alias of aliases[e.slug] || []) textEntries.push({ ...entry, name: alias });
@@ -189,8 +212,8 @@ function loadMap(game, version, lang) {
     const alt = textEntries.map((e) => escapeRegExp(e.name)).join('|');
     text = { regexSource: `(?<![\\p{L}\\p{N}_])(${alt})(?![\\p{L}\\p{N}_])`, byName };
   }
-  const result = text || exact.em.size || exact.strong.size || feats.size || cells.size
-    ? { text, exact, feats, cells, verKey } : null;
+  const result = text || exact.em.size || exact.strong.size || feats.size || cells.size || grid.size
+    ? { text, exact, feats, cells, grid, verKey } : null;
   mapCache.set(cacheKey, result);
   return result;
 }
@@ -247,7 +270,7 @@ function collectRows(node, out) {
 
 // Ядро: линкует имена сущностей прямо в hast-дереве. Общая логика для глав (rehype) и страниц
 // сущностей (marked → hast). selfSlug — не линковать саму сущность на её же странице.
-export function autolinkTree(tree, { game, version, lang, selfSlug }) {
+export function autolinkTree(tree, { game, version, lang, selfSlug, chapterPath = '' }) {
   const map = loadMap(game, version, lang);
   if (!map) return tree;
   const skip = new Set();
@@ -325,6 +348,24 @@ export function autolinkTree(tree, { game, version, lang, selfSlug }) {
     }
   };
 
+  // Grid (DH/BRP): любая ячейка <td>, точно равная имени сущности → ссылка, ТОЛЬКО в главе-
+  // источнике (entry.chapters vs chapterPath). Точное совпадение + гейт главы → 0 ложных.
+  const linkGridCells = (table) => {
+    const rows = [];
+    collectRows(table, rows);
+    for (const tr of rows) {
+      for (const cell of tr.children) {
+        if (cell.type !== 'element' || cell.tagName !== 'td') continue;
+        const txt = directText(cell);
+        if (txt == null) continue;
+        const entry = map.grid.get(txt.trim().toLowerCase());
+        if (entry && !skip.has(entry.slug) && (!entry.chapters || entry.chapters.test(chapterPath || ''))) {
+          cell.children = [linkNode(entry, txt.trim(), ctx)];
+        }
+      }
+    }
+  };
+
   const walk = (node, insideSkip) => {
     if (!node.children) return;
     for (let i = 0; i < node.children.length; i++) {
@@ -333,6 +374,8 @@ export function autolinkTree(tree, { game, version, lang, selfSlug }) {
         const tag = child.tagName;
         // Спелл-таблица класса: линкуем первую колонку (данные), затем обычный обход остального.
         if (tag === 'table' && map.exact.em.size && isSpellTable(child)) linkSpellTable(child);
+        // Grid-режим (DH доменные карты, BRP навыки) — любая ячейка = имя, в главе-источнике.
+        if (tag === 'table' && map.grid && map.grid.size && chapterPath) linkGridCells(child);
         // Черты в ячейках любых таблиц (таблицы прогрессии классов и т.п.).
         if (tag === 'table' && map.feats && map.feats.size) linkFeatCells(child);
         // Оружие/доспехи/снаряжение — первая колонка таблиц-перечней (глава «Снаряжение»).
@@ -369,6 +412,6 @@ export default function rehypeEntityAutolink() {
     const m = p.replace(/\\/g, '/').match(/\/(dnd|daggerheart|brp)\/([^/]+)\/(en|ru)\//);
     if (!m) return;
     const [, game, version, lang] = m;
-    autolinkTree(tree, { game, version, lang });
+    autolinkTree(tree, { game, version, lang, chapterPath: p.replace(/\\/g, '/') });
   };
 }

--- a/web/src/lib/rules-gloss.mjs
+++ b/web/src/lib/rules-gloss.mjs
@@ -133,14 +133,24 @@ function loadGloss(game, version, lang) {
   // пересекаются (изоляция бакетов game/ver/lang → подсказки не смешиваются).
   const terms = TERMS_BY_GAME[game] || [];
   let coreRe = null;
-  if (terms.length && read('rules-terms')) {
-    const field = lang === 'en' ? 'en' : 'ru';
-    const parts = terms.map((t) => `(?<${grp(t.slug)}>${t[field]})`).join('|');
-    const flags = lang === 'en' ? 'gu' : 'giu';
-    coreRe = new RegExp(`(?<![\\p{L}\\p{N}_])(?:${parts})(?![\\p{L}\\p{N}_])`, flags);
+  // termSlugs — слаги, реально присутствующие в rules-terms версии. Глоссим ТОЛЬКО их: если у
+  // версии нет карточки для терма (частичный глоссарий, напр. 5.1), span не создаётся — иначе
+  // была бы «мёртвая» подсказка в пустой бакет. Для 5.2 набор полный → поведение не меняется.
+  let termSlugs = null;
+  const rtData = read('rules-terms');
+  if (terms.length && rtData) {
+    termSlugs = new Set(rtData.map((e) => e && e.slug).filter(Boolean));
+    // В альтернацию берём только термы, у которых есть карточка (иначе матч → мёртвый span).
+    const present = terms.filter((t) => termSlugs.has(t.slug));
+    if (present.length) {
+      const field = lang === 'en' ? 'en' : 'ru';
+      const parts = present.map((t) => `(?<${grp(t.slug)}>${t[field]})`).join('|');
+      const flags = lang === 'en' ? 'gu' : 'giu';
+      coreRe = new RegExp(`(?<![\\p{L}\\p{N}_])(?:${parts})(?![\\p{L}\\p{N}_])`, flags);
+    }
   }
 
-  const res = actionRe || coreRe ? { actionRe, actionByName, coreRe, terms, verKey } : null;
+  const res = actionRe || coreRe ? { actionRe, actionByName, coreRe, terms, termSlugs, verKey } : null;
   cache.set(cacheKey, res);
   return res;
 }

--- a/web/src/pages/[lang]/brp/[version]/professions/[slug].astro
+++ b/web/src/pages/[lang]/brp/[version]/professions/[slug].astro
@@ -39,7 +39,7 @@ const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
 
 const tree = fromHtml(marked.parse(entity.description_md ?? '', { async: false }), { fragment: true });
 autolinkTree(tree, { game: GAME, version: verSlug, lang, selfSlug: entity.slug });
-highlightKeywords(tree, { lang });
+highlightKeywords(tree, { lang, game: 'brp' });
 glossRules(tree, { game: GAME, version: verSlug, lang });
 const bodyHtml = toHtml(tree);
 const description = excerpt(entity.description_md as string);

--- a/web/src/pages/[lang]/brp/[version]/skills/[slug].astro
+++ b/web/src/pages/[lang]/brp/[version]/skills/[slug].astro
@@ -44,7 +44,7 @@ const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
 
 const tree = fromHtml(marked.parse(entity.description_md ?? '', { async: false }), { fragment: true });
 autolinkTree(tree, { game: GAME, version: verSlug, lang, selfSlug: entity.slug });
-highlightKeywords(tree, { lang });
+highlightKeywords(tree, { lang, game: 'brp' });
 glossRules(tree, { game: GAME, version: verSlug, lang });
 const bodyHtml = toHtml(tree);
 const description = excerpt(entity.description_md as string);

--- a/web/src/pages/[lang]/brp/[version]/spot-rules/[slug].astro
+++ b/web/src/pages/[lang]/brp/[version]/spot-rules/[slug].astro
@@ -39,7 +39,7 @@ const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
 
 const tree = fromHtml(marked.parse(entity.description_md ?? '', { async: false }), { fragment: true });
 autolinkTree(tree, { game: GAME, version: verSlug, lang, selfSlug: entity.slug });
-highlightKeywords(tree, { lang });
+highlightKeywords(tree, { lang, game: 'brp' });
 glossRules(tree, { game: GAME, version: verSlug, lang });
 const bodyHtml = toHtml(tree);
 const description = excerpt(entity.description_md as string);

--- a/web/src/pages/[lang]/daggerheart/[version]/adversaries/[slug].astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/adversaries/[slug].astro
@@ -42,7 +42,7 @@ const tierLabel = t(`Ранг ${tier}`, `Tier ${tier}`);
 
 const tree = fromHtml(marked.parse(entity.description_md ?? '', { async: false }), { fragment: true });
 autolinkTree(tree, { game: GAME, version: verSlug, lang, selfSlug: entity.slug });
-highlightKeywords(tree, { lang });
+highlightKeywords(tree, { lang, game: 'daggerheart' });
 glossRules(tree, { game: GAME, version: verSlug, lang });
 const bodyHtml = toHtml(tree);
 const description = excerpt(entity.description_md as string);

--- a/web/src/pages/[lang]/daggerheart/[version]/ancestries/[slug].astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/ancestries/[slug].astro
@@ -40,7 +40,7 @@ const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
 
 const tree = fromHtml(marked.parse(entity.description_md ?? '', { async: false }), { fragment: true });
 autolinkTree(tree, { game: GAME, version: verSlug, lang, selfSlug: entity.slug });
-highlightKeywords(tree, { lang });
+highlightKeywords(tree, { lang, game: 'daggerheart' });
 glossRules(tree, { game: GAME, version: verSlug, lang });
 const bodyHtml = toHtml(tree);
 const description = excerpt(entity.description_md as string);

--- a/web/src/pages/[lang]/daggerheart/[version]/communities/[slug].astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/communities/[slug].astro
@@ -40,7 +40,7 @@ const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
 
 const tree = fromHtml(marked.parse(entity.description_md ?? '', { async: false }), { fragment: true });
 autolinkTree(tree, { game: GAME, version: verSlug, lang, selfSlug: entity.slug });
-highlightKeywords(tree, { lang });
+highlightKeywords(tree, { lang, game: 'daggerheart' });
 glossRules(tree, { game: GAME, version: verSlug, lang });
 const bodyHtml = toHtml(tree);
 const description = excerpt(entity.description_md as string);

--- a/web/src/pages/[lang]/daggerheart/[version]/domain-cards/[slug].astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/domain-cards/[slug].astro
@@ -40,7 +40,7 @@ const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
 
 const tree = fromHtml(marked.parse(entity.description_md ?? '', { async: false }), { fragment: true });
 autolinkTree(tree, { game: GAME, version: verSlug, lang, selfSlug: entity.slug });
-highlightKeywords(tree, { lang });
+highlightKeywords(tree, { lang, game: 'daggerheart' });
 glossRules(tree, { game: GAME, version: verSlug, lang });
 const bodyHtml = toHtml(tree);
 const description = excerpt(entity.description_md as string);

--- a/web/src/pages/[lang]/daggerheart/[version]/environments/[slug].astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/environments/[slug].astro
@@ -40,7 +40,7 @@ const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
 
 const tree = fromHtml(marked.parse(entity.description_md ?? '', { async: false }), { fragment: true });
 autolinkTree(tree, { game: GAME, version: verSlug, lang, selfSlug: entity.slug });
-highlightKeywords(tree, { lang });
+highlightKeywords(tree, { lang, game: 'daggerheart' });
 glossRules(tree, { game: GAME, version: verSlug, lang });
 const bodyHtml = toHtml(tree);
 const description = excerpt(entity.description_md as string);

--- a/web/src/pages/hc/[game]/[ver]/[lang].json.ts
+++ b/web/src/pages/hc/[game]/[ver]/[lang].json.ts
@@ -184,6 +184,23 @@ function defHtml(md: string | undefined): string {
     .join('');
 }
 
+// ── Daggerheart доменная карта: «уровень · домен · стоимость отзыва» + выдержка описания.
+function dhCardHtml(e: Record<string, unknown>, lang: string): string {
+  const lvl = e.level != null ? (lang === 'ru' ? `Ур. ${e.level}` : `Lv ${e.level}`) : '';
+  const domain = (e.domain as string) ?? '';
+  const recall = e.recall_cost != null ? (lang === 'ru' ? `Отзыв ${e.recall_cost}` : `Recall ${e.recall_cost}`) : '';
+  const sub = [lvl, domain, recall].filter(Boolean).join(' · ');
+  const ex = excerpt(e.description_md as string | undefined, 190);
+  return (sub ? `<p class="hc-sub">${escapeHtml(sub)}</p>` : '') + (ex ? `<p>${escapeHtml(ex)}</p>` : '');
+}
+
+// ── BRP навык: «категория · базовый шанс» + выдержка описания.
+function brpSkillHtml(e: Record<string, unknown>, lang: string): string {
+  const sub = [e.category as string, e.base_chance as string].filter(Boolean).join(' · ');
+  const ex = excerpt(e.description_md as string | undefined, 190);
+  return (sub ? `<p class="hc-sub">${escapeHtml(sub)}</p>` : '') + (ex ? `<p>${escapeHtml(ex)}</p>` : '');
+}
+
 // resource → { urlParent, build(entity) → HTML тела карточки }.
 const RESOURCES: { key: string; urlParent: string; body: (e: Record<string, unknown>, lang: string) => string }[] = [
   { key: 'conditions', urlParent: 'rules-glossary/conditions', body: (e) => conditionHtml(e.description_md as string) },
@@ -205,6 +222,10 @@ const RESOURCES: { key: string; urlParent: string; body: (e: Record<string, unkn
   { key: 'rules-terms', urlParent: 'rules-terms', body: (e) => defHtml(e.description_md as string) },
   // Области эффекта — карточка-определение (глосс формы в стат-блоке заклинания).
   { key: 'areas-of-effect', urlParent: 'areas-of-effect', body: (e) => defHtml(e.description_md as string) },
+  // Daggerheart доменные карты (автолинк в главе «Домены») + BRP навыки (таблица глоссария).
+  // Грузятся только для своих игр (loadEntities для чужой игры вернёт []).
+  { key: 'domain-cards', urlParent: 'domain-cards', body: (e, lang) => dhCardHtml(e, lang) },
+  { key: 'skills', urlParent: 'skills', body: (e, lang) => brpSkillHtml(e, lang) },
 ];
 
 // Согласовано со сборкой страниц сущностей: srd52 + srd51 (en/ru). Бакеты по версиям
@@ -214,10 +235,12 @@ const BUILDS = [
   { game: 'dnd', ver: 'srd52', lang: 'ru' },
   { game: 'dnd', ver: 'srd51', lang: 'en' },
   { game: 'dnd', ver: 'srd51', lang: 'ru' },
-  // Daggerheart: бакет rules-terms (gloss-подсказки глоссария). Изолирован ключом
-  // game/ver/lang → не смешивается с D&D.
+  // Daggerheart: rules-terms (gloss) + domain-cards (автолинк «Домены»). Изолирован ключом.
   { game: 'daggerheart', ver: 'srd10', lang: 'en' },
   { game: 'daggerheart', ver: 'srd10', lang: 'ru' },
+  // BRP: навыки (автолинк таблицы глоссария навыков).
+  { game: 'brp', ver: 'srd10', lang: 'en' },
+  { game: 'brp', ver: 'srd10', lang: 'ru' },
 ];
 
 export function getStaticPaths() {


### PR DESCRIPTION
Доводим 5.1 / Daggerheart / BRP до паритета с D&D 5.2 по трём механизмам обогащения текста (аудит в issue #20). **Один PR, коммит на логическую часть.**

### Механизмы
1. 🔴 `.kw` — цветовое выделение ключевых слов
2. 🔗 автолинк + hovercard у имён сущностей
3. 💬 `.gloss` — всплывашки-определения у терминов

### Коммиты
- [x] **🔴 `.kw` per-game** (`0bd6acd`) — черты Daggerheart + характеристики BRP; главы классов 5.1 (`06_Classes`) и DH (`04_Classes`). BRP-главы не гейтим (список навыков → ковёр) → BRP-подсветка на entity-страницах.
- [x] **🔗 автолинк DH/BRP** (`e675362`) — grid-режим (любая ячейка = имя, гейт главы). **DH: 189 доменных карт** в главе «Домены»; **BRP: 56 навыков** в глоссарии. Новый BRP hovercard-бакет.
- [x] **💬 gloss 5.1** (`3c27515`) — новый парсер секций-глоссария 5.1 → rules-terms; канонический слаг из EN-колонки RU-таблиц; по-слаговый гейт (частичное покрытие 14/~22 CORE_TERMS мягкое, 0 мёртвых подсказок). Симметрично EN/RU, изолировано от 5.2.
- [x] **Ниты ревью** (`2990b2a`) — `SKILL_CTX` уведён per-game (D&D/BRP наборы не тянут друг друга); e2e на новые автолинки (DH «Домены», BRP глоссарий).

### Итог (dist + e2e)
- `.kw`: DH черты чисто; BRP характеристики в контексте; 5.1 классы 10; 5.2 без регресса.
- автолинк: DH домены 189 карт, BRP глоссарий 56 навыков; grid гейтится главой (утечки нет).
- gloss 5.1: initiative/concentration/critical-hit/long-rest/… (14), симметрично EN/RU, бакет отдаёт карточки.
- **e2e 160/160**, `astro check` 0 ошибок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)