### PR TITLE
Хабы: фасет магпредметов по редкости, тип противников DH, сортируемый глоссарий (#20)

### DIFF
--- a/.github/scripts/generate_api.py
+++ b/.github/scripts/generate_api.py
@@ -607,6 +607,24 @@ def main():
             print(f"  {msg}", file=sys.stderr)
         sys.exit(1)
 
+    # Тип противника (DH) не должен молча выпасть из type-фасета: у ВСЕХ adversaries `type`
+    # распознан (∈ 10 известных). Схема допускает type=null (общая с environments), поэтому
+    # гарантия — уровнем выше. Ловит опечатку/двусловный тип в будущем апдейте SRD.
+    if SYSTEM == "daggerheart":
+        from parsers.daggerheart import ADVERSARY_TYPE_WORDS
+        type_errors = []
+        for (ver, lang, resource), entities in all_data.items():
+            if resource != "adversaries":
+                continue
+            for e in entities:
+                if e.get("type") not in ADVERSARY_TYPE_WORDS:
+                    type_errors.append(f"{ver}/{lang}: '{e.get('name')}' — тип '{e.get('type')}' не распознан")
+        if type_errors:
+            print("Error: нераспознанный тип противника (выпадет из type-фасета):", file=sys.stderr)
+            for msg in type_errors:
+                print(f"  {msg}", file=sys.stderr)
+            sys.exit(1)
+
     # Write files and collect hierarchy info
     file_count = 0
 

--- a/.github/scripts/parsers/daggerheart.py
+++ b/.github/scripts/parsers/daggerheart.py
@@ -115,6 +115,15 @@ def _parse_tiered(text: str, lang: str, with_type: bool = False) -> list[dict]:
     return out
 
 
+# Известные типы противников (10) — EN + RU слова, как они стоят в стат-блоке. Генератор
+# сверяет извлечённый `type` с этим набором (fail-fast), чтобы опечатка/двусловный тип в
+# будущем апдейте SRD не выпал молча из type-фасета (слаги — на стороне ридера, ADVERSARY_TYPES).
+ADVERSARY_TYPE_WORDS = frozenset({
+    "Bruiser", "Horde", "Leader", "Minion", "Ranged", "Skulk", "Social", "Solo", "Standard", "Support",
+    "Громила", "Орда", "Лидер", "Приспешник", "Стрелок", "Скрытник", "Дипломат", "Одиночка", "Обычный", "Поддержка",
+})
+
+
 def parse_adversaries(text: str, lang: str) -> list[dict]:
     """Противники — стат-блоки по тирам (+ тип: Solo/Bruiser/Minion/…)."""
     return _parse_tiered(text, lang, with_type=True)

--- a/.github/scripts/parsers/daggerheart.py
+++ b/.github/scripts/parsers/daggerheart.py
@@ -88,7 +88,7 @@ def parse_domain_cards(text: str, lang: str) -> list[dict]:
 # ── Adversaries / Environments: `## Ранг N` → `### Имя` (→ `#### Способности`) ──
 # Тир — фасет. Вводная секция «Using …» / «Использование …» без номера — пропускается.
 
-def _parse_tiered(text: str, lang: str) -> list[dict]:
+def _parse_tiered(text: str, lang: str, with_type: bool = False) -> list[dict]:
     out = []
     for parent_heading, parent_body in split_blocks(text, 2):
         m = re.search(r"(?:Tier|Ранга?)\s+(\d+)", parent_heading)
@@ -97,19 +97,27 @@ def _parse_tiered(text: str, lang: str) -> list[dict]:
         tier = int(m.group(1))
         for heading, body in split_blocks(parent_body, 3):
             name, name_en, slug = extract_names(heading.strip(), lang)
-            out.append({
+            body = body.strip()
+            entry = {
                 "slug": slug,
                 "name": name,
                 "name_en": name_en,
                 "tier": tier,
-                "description_md": body.strip(),
-            })
+                "description_md": body,
+            }
+            if with_type:
+                # Тип противника — слово после «Tier N»/«Ранг N» во вводной строке стат-блока:
+                # «**_Tier 1 Solo._**» / «**_Ранг 1 Одиночка._**». Локализованное слово; канонический
+                # слаг сводится на стороне ридера (ADVERSARY_TYPES) по EN/RU-подписи.
+                tm = re.search(r"(?:Tier|Ранга?)\s+\d+\s+([A-Za-zА-ЯЁа-яё]+)", body)
+                entry["type"] = tm.group(1) if tm else None
+            out.append(entry)
     return out
 
 
 def parse_adversaries(text: str, lang: str) -> list[dict]:
-    """Противники — стат-блоки по тирам."""
-    return _parse_tiered(text, lang)
+    """Противники — стат-блоки по тирам (+ тип: Solo/Bruiser/Minion/…)."""
+    return _parse_tiered(text, lang, with_type=True)
 
 
 def parse_environments(text: str, lang: str) -> list[dict]:

--- a/.github/scripts/schemas.py
+++ b/.github/scripts/schemas.py
@@ -495,6 +495,8 @@ DH_STATBLOCK_SCHEMA = {
         "name": {"type": "string"},
         "name_en": {"type": ["string", "null"]},
         "tier": {"type": "integer", "minimum": 1, "maximum": 4},
+        # Тип противника (Solo/Bruiser/Minion/…) — локализованное слово; только у adversaries.
+        "type": {"type": ["string", "null"]},
         "description_md": {"type": "string"},
     },
     "required": ["slug", "name", "name_en", "tier", "description_md"],

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -4,6 +4,7 @@ import pagefind from 'astro-pagefind';
 import AstroPWA from '@vite-pwa/astro';
 import rehypePromoteHeadings from './src/lib/rehype-promote-headings.mjs';
 import rehypeWrapTables from './src/lib/rehype-wrap-tables.mjs';
+import rehypeSortableGlossary from './src/lib/rehype-sortable-glossary.mjs';
 import rehypeEntityAutolink from './src/lib/rehype-entity-autolink.mjs';
 import rehypeKeywordHighlight from './src/lib/keyword-highlight.mjs';
 import rehypeRulesGloss from './src/lib/rules-gloss.mjs';
@@ -124,6 +125,6 @@ export default defineConfig({
     // Порядок важен (issue #20): rehypeEntityAutolink оборачивает имена сущностей в <a>, затем
     // rehypeKeywordHighlight красит ключевые слова — последним, чтобы не лезть внутрь ссылок
     // (<a> в его SKIP_TAGS) и работать по уже готовому дереву.
-    rehypePlugins: [rehypePromoteHeadings, rehypeWrapTables, rehypeEntityAutolink, rehypeKeywordHighlight, rehypeRulesGloss],
+    rehypePlugins: [rehypePromoteHeadings, rehypeSortableGlossary, rehypeWrapTables, rehypeEntityAutolink, rehypeKeywordHighlight, rehypeRulesGloss],
   },
 });

--- a/web/e2e/daggerheart.spec.ts
+++ b/web/e2e/daggerheart.spec.ts
@@ -119,6 +119,17 @@ test('prev/next пропускает скрытые глоссарий-спис�
   expect(nextHref, 'next не ведёт в скрытый /glossary/ список').not.toContain('/glossary/');
 });
 
+test('глоссарий: markdown-таблица оружия сортируема (клик по <th> переупорядочивает)', async ({ page }) => {
+  await page.goto('/ru/daggerheart/srd-1.0/glossary/weapons/');
+  const table = page.locator('.rd-doc table[data-sortable]').first();
+  await expect(table).toBeVisible();
+  const firstBefore = await table.locator('tbody tr td:first-child').first().textContent();
+  await table.locator('thead th').first().click();
+  await expect(table.locator('thead th').first()).toHaveAttribute('aria-sort', 'ascending');
+  const firstAfter = await table.locator('tbody tr td:first-child').first().textContent();
+  expect(firstAfter).not.toBe(firstBefore);
+});
+
 test('hovercard-бакет daggerheart отдаёт карточки терминов', async ({ request }) => {
   const res = await request.get('/hc/daggerheart/srd10/ru.json');
   expect(res.status()).toBe(200);

--- a/web/e2e/daggerheart.spec.ts
+++ b/web/e2e/daggerheart.spec.ts
@@ -75,6 +75,15 @@ test('хабы: сортируемые таблицы (происхождени�
   await expect(page.locator('a[href$="/adversaries/acid-burrower/"]')).toBeVisible();
 });
 
+test('противники: колонка «Тип» кликабельна → type-фасет (Solo/Bruiser/…)', async ({ page }) => {
+  await page.goto('/ru/daggerheart/srd-1.0/adversaries/all/');
+  await expect(page.locator('.hub-table[data-sortable] a[href*="/adversaries/type/"]').first()).toBeVisible();
+  const res = await page.goto('/en/daggerheart/srd-1.0/adversaries/type/solo/');
+  expect(res?.status()).toBe(200);
+  await expect(page.locator('.rd-doc h1')).toContainText('Solo');
+  await expect(page.locator('.hub-table[data-sortable] a[href*="/adversaries/tier/"]').first()).toBeVisible();
+});
+
 test('глоссарий «Способности» = доменные карты → скрыт из сайдбара (как D&D), но страница жива', async ({ page }) => {
   await page.goto('/ru/daggerheart/srd-1.0/domain-cards/all/');
   // Дубль-список скрыт из nav, показан наш хаб доменных карт.

--- a/web/e2e/dnd-all-hubs.spec.ts
+++ b/web/e2e/dnd-all-hubs.spec.ts
@@ -79,6 +79,15 @@ test('сортировка: клик по заголовку столбца пе
   expect(firstAfter).not.toBe(firstBefore); // порядок изменился (алфавит → по CR)
 });
 
+test('magic-items/all: редкость кликабельна → rarity-хаб', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/magic-items/all/');
+  await expect(page.locator('.hub-table[data-sortable] a[href*="/magic-items/rarity/"]').first()).toBeVisible();
+  const res = await page.goto('/en/dnd/srd-5.2/magic-items/rarity/rare/');
+  expect(res?.status()).toBe(200);
+  await expect(page.locator('.rd-doc h1')).toContainText('Rare');
+  await expect(page.locator('.hub-table[data-sortable]')).toBeVisible();
+});
+
 test('SEO: hreflang-тройка + /all/-хабы в sitemap', async ({ page, request }) => {
   const res = await page.goto('/en/dnd/srd-5.2/spells/all/');
   expect(res?.status()).toBe(200);

--- a/web/src/components/ReaderShell.astro
+++ b/web/src/components/ReaderShell.astro
@@ -724,7 +724,7 @@ const searchUi = {
     const d = c.getAttribute('data-sort');
     return d !== null ? d : (c.textContent || '').trim();
   };
-  for (const table of document.querySelectorAll<HTMLTableElement>('table.hub-table[data-sortable]')) {
+  for (const table of document.querySelectorAll<HTMLTableElement>('table[data-sortable]')) {
     const tbody = table.tBodies[0];
     const ths = Array.from(table.tHead?.rows[0]?.cells ?? []);
     if (!tbody || !ths.length) continue;

--- a/web/src/lib/adversary-hubs.ts
+++ b/web/src/lib/adversary-hubs.ts
@@ -1,0 +1,38 @@
+// Хабы противников Daggerheart (issue #20): фасет по ТИПУ (Solo/Bruiser/Minion/…).
+// Роут: adversaries/type/[type]. Тип в данных — локализованное слово (EN «Solo» / RU
+// «Одиночка»); URL-слаг языконезависим ('solo') → каноникал + hreflang. Ранг (tier) —
+// отдельный фасет (adversaries/tier/[tier]), уже существует.
+export type Lang = 'en' | 'ru';
+
+export interface AdversaryLite {
+  slug: string;
+  name: string;
+  name_en?: string | null;
+  tier: number;
+  type?: string | null; // локализованное слово типа
+}
+
+// 10 типов противников DH. slug = EN в lowercase. en/ru — подписи из SRD (по обеим сверено 129/129).
+export const ADVERSARY_TYPES: { slug: string; en: string; ru: string }[] = [
+  { slug: 'bruiser', en: 'Bruiser', ru: 'Громила' },
+  { slug: 'horde', en: 'Horde', ru: 'Орда' },
+  { slug: 'leader', en: 'Leader', ru: 'Лидер' },
+  { slug: 'minion', en: 'Minion', ru: 'Приспешник' },
+  { slug: 'ranged', en: 'Ranged', ru: 'Стрелок' },
+  { slug: 'skulk', en: 'Skulk', ru: 'Скрытник' },
+  { slug: 'social', en: 'Social', ru: 'Дипломат' },
+  { slug: 'solo', en: 'Solo', ru: 'Одиночка' },
+  { slug: 'standard', en: 'Standard', ru: 'Обычный' },
+  { slug: 'support', en: 'Support', ru: 'Поддержка' },
+];
+
+export const advTypeBySlug = (slug: string) => ADVERSARY_TYPES.find((t) => t.slug === slug);
+// Локализованное слово типа ('Solo'/'Одиночка') → слаг ('solo'); undefined, если не распознано.
+export const advTypeSlug = (raw?: string | null): string | undefined =>
+  ADVERSARY_TYPES.find((t) => t.en === raw || t.ru === raw)?.slug;
+export const advTypeLabel = (slug: string, lang: Lang): string => {
+  const t = advTypeBySlug(slug);
+  return t ? t[lang] : slug;
+};
+
+export const byName = (a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name);

--- a/web/src/lib/magic-item-hubs.ts
+++ b/web/src/lib/magic-item-hubs.ts
@@ -1,0 +1,47 @@
+// Хабы магических предметов (issue #20): фасетные списки по редкости.
+// Роут: magic-items/rarity/[rarity]. Редкость в данных — английский ключ ('very rare');
+// URL-слаг языконезависим ('very-rare') → общий каноникал + hreflang.
+export type Lang = 'en' | 'ru';
+
+export interface ItemLite {
+  slug: string;
+  name: string;
+  name_en?: string | null;
+  type?: string;
+  rarity?: string; // EN-ключ: 'common' | 'uncommon' | 'rare' | 'very rare' | 'legendary' | 'artifact'
+  attunement?: { required?: boolean };
+}
+
+// Порядок = возрастание редкости (обычный → артефакт). slug — языконезависимый.
+export const RARITIES: { slug: string; en: string; ru: string }[] = [
+  { slug: 'common', en: 'common', ru: 'обычные' },
+  { slug: 'uncommon', en: 'uncommon', ru: 'необычные' },
+  { slug: 'rare', en: 'rare', ru: 'редкие' },
+  { slug: 'very-rare', en: 'very rare', ru: 'очень редкие' },
+  { slug: 'legendary', en: 'legendary', ru: 'легендарные' },
+  { slug: 'artifact', en: 'artifact', ru: 'артефакты' },
+];
+
+export const rarityBySlug = (slug: string) => RARITIES.find((r) => r.slug === slug);
+// Сырое поле rarity ('very rare') → слаг ('very-rare'); undefined, если редкость не задана/неизвестна.
+export const raritySlug = (raw?: string): string | undefined => RARITIES.find((r) => r.en === raw)?.slug;
+// Подпись редкости в единственном числе (для колонки таблицы): 'редкий' / 'rare'.
+const SINGULAR: Record<string, [string, string]> = {
+  common: ['обычный', 'common'], uncommon: ['необычный', 'uncommon'], rare: ['редкий', 'rare'],
+  'very-rare': ['очень редкий', 'very rare'], legendary: ['легендарный', 'legendary'], artifact: ['артефакт', 'artifact'],
+};
+export const rarityLabel = (raw: string | undefined, lang: Lang): string => {
+  const slug = raritySlug(raw);
+  return slug && SINGULAR[slug] ? SINGULAR[slug][lang === 'ru' ? 0 : 1] : (raw ?? '');
+};
+// Заголовок хаба редкости (мн. число): «Редкие предметы» / «Rare items».
+export const rarityHubLabel = (slug: string, lang: Lang): string => {
+  const r = rarityBySlug(slug);
+  return r ? r[lang] : slug;
+};
+export const rarityRank = (raw?: string): number => {
+  const i = RARITIES.findIndex((r) => r.en === raw);
+  return i === -1 ? 99 : i;
+};
+
+export const byName = (a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name);

--- a/web/src/lib/rehype-sortable-glossary.mjs
+++ b/web/src/lib/rehype-sortable-glossary.mjs
@@ -1,0 +1,26 @@
+// Делает markdown-таблицы глав ГЛОССАРИЯ сортируемыми (issue #20): помечает каждую <table>
+// атрибутом data-sortable. Тот же общий sort-скрипт в ReaderShell (клик по <th>) подхватывает
+// любую table[data-sortable] — и наши хаб-таблицы, и эти markdown-таблицы (оружие/броня/
+// предметы/расходники DH, оружие/броня BRP, списки терминов 5.1 и т.п.).
+//
+// Гейт — только главы глоссария (NN_Glossary/*): там таблицы-справочники, сортировка полезна.
+// Прочие главы (проза) не трогаем — их редкие таблицы обычно не для сортировки.
+const GLOSSARY = /\/\d+_Glossary\//;
+
+export default function rehypeSortableGlossary() {
+  return (tree, file) => {
+    const p = (file && (file.path || (file.history && file.history[0]))) || '';
+    if (!GLOSSARY.test(p.replace(/\\/g, '/'))) return;
+    const walk = (node) => {
+      if (!node || !node.children) return;
+      for (const child of node.children) {
+        if (child.type === 'element' && child.tagName === 'table') {
+          child.properties = child.properties || {};
+          child.properties['data-sortable'] = '';
+        }
+        walk(child);
+      }
+    };
+    walk(tree);
+  };
+}

--- a/web/src/lib/rehype-sortable-glossary.mjs
+++ b/web/src/lib/rehype-sortable-glossary.mjs
@@ -6,6 +6,25 @@
 // Гейт — только главы глоссария (NN_Glossary/*): там таблицы-справочники, сортировка полезна.
 // Прочие главы (проза) не трогаем — их редкие таблицы обычно не для сортировки.
 const GLOSSARY = /\/\d+_Glossary\//;
+// Порог строк-данных: крошечные таблицы (аббревиатуры, 1–2 строки) сортировать бессмысленно —
+// не вешаем на них role=button/стрелки. ≥3 строки → сортируемая.
+const MIN_ROWS = 3;
+
+// Число строк-данных таблицы (<tr> внутри <tbody>; при отсутствии tbody — все <tr> минус шапка).
+function dataRowCount(table) {
+  const rows = [];
+  const collect = (n) => {
+    for (const c of n.children || []) {
+      if (c.type !== 'element') continue;
+      if (c.tagName === 'tr') rows.push(c);
+      else collect(c);
+    }
+  };
+  const tbody = (table.children || []).find((c) => c.type === 'element' && c.tagName === 'tbody');
+  if (tbody) { collect(tbody); return rows.length; }
+  collect(table);
+  return Math.max(0, rows.length - 1); // без <tbody> первая строка — шапка
+}
 
 export default function rehypeSortableGlossary() {
   return (tree, file) => {
@@ -14,7 +33,7 @@ export default function rehypeSortableGlossary() {
     const walk = (node) => {
       if (!node || !node.children) return;
       for (const child of node.children) {
-        if (child.type === 'element' && child.tagName === 'table') {
+        if (child.type === 'element' && child.tagName === 'table' && dataRowCount(child) >= MIN_ROWS) {
           child.properties = child.properties || {};
           child.properties['data-sortable'] = '';
         }

--- a/web/src/pages/[lang]/daggerheart/[version]/adversaries/all.astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/adversaries/all.astro
@@ -1,15 +1,16 @@
 ---
 import ReaderShell from '../../../../../components/ReaderShell.astro';
 import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
+import { ADVERSARY_TYPES, advTypeSlug, advTypeLabel } from '../../../../../lib/adversary-hubs';
 
 // Хаб-справочник противников (Daggerheart SRD 1.0): /{lang}/daggerheart/{version}/adversaries/all/.
-// Сортируемая таблица со ссылками на все страницы противников; «Ранг» ведёт на фасет по рангу.
+// Сортируемая таблица со ссылками на все страницы противников; «Тип» и «Ранг» ведут на фасеты.
 // Статический роут `all` приоритетнее `[slug]`.
 const GAME = 'daggerheart';
 const PARENT_NAV: Record<string, string> = { srd10: 'dh-adversaries-hub' };
 const TIERS = [1, 2, 3, 4] as const;
 
-interface Ent { slug: string; name: string; name_en?: string | null; tier: number }
+interface Ent { slug: string; name: string; name_en?: string | null; tier: number; type?: string | null }
 
 export function getStaticPaths() {
   const BUILDS = [
@@ -30,8 +31,10 @@ const base = `/${lang}/${GAME}/${verSlug}/adversaries`;
 const tierLabel = (tier: number) => t(`Ранг ${tier}`, `Tier ${tier}`);
 const tierHref = (tier: number) => `/${lang}/${GAME}/${verSlug}/adversaries/tier/${tier}/`;
 
+const typeHref = (slug: string) => `${base}/type/${slug}/`;
 const sorted = items.slice().sort((a, b) => a.name.localeCompare(b.name));
 const presentTiers = TIERS.filter((tier) => items.some((r) => r.tier === tier));
+const presentTypes = ADVERSARY_TYPES.filter((x) => items.some((r) => advTypeSlug(r.type) === x.slug));
 
 const heading = t('Противники', 'Adversaries');
 const title = `${heading} — Daggerheart ${verLabel} · OmnisGM Rules`;
@@ -54,8 +57,8 @@ const upLink = { href: `/${lang}/${GAME}/${verSlug}/13_Adversaries/`, ru: 'Пр�
   <h1>{heading}</h1>
   <p>
     {t(
-      `${items.length} противников Daggerheart ${verLabel} по 4 рангам сложности. В таблице — ранг (ссылка на список ранга). Нажмите на заголовок столбца, чтобы отсортировать. Общие правила — в главе «Противники».`,
-      `${items.length} Daggerheart ${verLabel} adversaries across 4 tiers. The table lists tier (linked to its list). Click a column header to sort. General rules are in the Adversaries chapter.`,
+      `${items.length} противников Daggerheart ${verLabel}. В таблице — тип (Одиночка/Громила/…) и ранг, оба ведут на списки. Нажмите на заголовок столбца, чтобы отсортировать. Общие правила — в главе «Противники».`,
+      `${items.length} Daggerheart ${verLabel} adversaries. The table lists type (Solo/Bruiser/…) and tier, both linked to their lists. Click a column header to sort. General rules are in the Adversaries chapter.`,
     )}
   </p>
 
@@ -63,23 +66,32 @@ const upLink = { href: `/${lang}/${GAME}/${verSlug}/13_Adversaries/`, ru: 'Пр�
     <table class="hub-table" data-sortable>
       <thead>
         <tr>
-          <th>{t('Противник', 'Adversary')}</th><th>{t('Ранг', 'Tier')}</th>
+          <th>{t('Противник', 'Adversary')}</th><th>{t('Тип', 'Type')}</th><th>{t('Ранг', 'Tier')}</th>
           {lang === 'ru' && <th>Оригинал</th>}
         </tr>
       </thead>
       <tbody>
-        {sorted.map((r) => (
-          <tr>
-            <td><a href={`${base}/${r.slug}/`}>{r.name}</a></td>
-            <td data-sort={r.tier}><a href={tierHref(r.tier)}>{tierLabel(r.tier)}</a></td>
-            {lang === 'ru' && <td class="og-en">{r.name_en ?? '—'}</td>}
-          </tr>
-        ))}
+        {sorted.map((r) => {
+          const ts = advTypeSlug(r.type);
+          return (
+            <tr>
+              <td><a href={`${base}/${r.slug}/`}>{r.name}</a></td>
+              <td>{ts ? <a href={typeHref(ts)}>{advTypeLabel(ts, lang)}</a> : (r.type ?? '—')}</td>
+              <td data-sort={r.tier}><a href={tierHref(r.tier)}>{tierLabel(r.tier)}</a></td>
+              {lang === 'ru' && <td class="og-en">{r.name_en ?? '—'}</td>}
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   </div>
 
-  <nav class="hub-links" aria-label={t('Хабы противников по рангу', 'Adversary hubs by tier')}>
+  <nav class="hub-links" aria-label={t('Хабы противников', 'Adversary hubs')}>
+    <p><strong>{t('По типу:', 'By type:')}</strong>{' '}
+      {presentTypes.map((x, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={typeHref(x.slug)}>{advTypeLabel(x.slug, lang)}</a></>
+      ))}
+    </p>
     <p><strong>{t('По рангу:', 'By tier:')}</strong>{' '}
       {presentTiers.map((tier, i) => (
         <>{i > 0 ? ' · ' : ''}<a href={tierHref(tier)}>{tierLabel(tier)}</a></>

--- a/web/src/pages/[lang]/daggerheart/[version]/adversaries/type/[type].astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/adversaries/type/[type].astro
@@ -1,0 +1,112 @@
+---
+import ReaderShell from '../../../../../../components/ReaderShell.astro';
+import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../../lib/entities';
+import {
+  ADVERSARY_TYPES, advTypeBySlug, advTypeSlug, advTypeLabel, byName,
+  type Lang, type AdversaryLite,
+} from '../../../../../../lib/adversary-hubs';
+
+// Хаб противников по ТИПУ (issue #20): /{lang}/daggerheart/{version}/adversaries/type/{type}/.
+// Все противники одного типа (Solo/Bruiser/Minion/…). «Ранг» ведёт на tier-фасет. EN/RU делят
+// слаг типа → каноникал + hreflang.
+const GAME = 'daggerheart';
+const PARENT_NAV: Record<string, string> = { srd10: 'dh-adversaries-hub' };
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd10', lang: 'en' as Lang },
+    { ver: 'srd10', lang: 'ru' as Lang },
+  ];
+  const paths = [];
+  for (const { ver, lang } of BUILDS) {
+    const all = loadEntities(ver, lang, 'adversaries', 'daggerheart') as unknown as AdversaryLite[];
+    for (const tp of ADVERSARY_TYPES) {
+      const mine = all.filter((a) => advTypeSlug(a.type) === tp.slug).slice().sort(byName);
+      if (!mine.length) continue;
+      paths.push({
+        params: { lang, version: VERSION_SLUG[ver], type: tp.slug },
+        props: { ver, lang, typeSlug: tp.slug, adversaries: mine },
+      });
+    }
+  }
+  return paths;
+}
+
+const { ver, lang, typeSlug: tSlug, adversaries } = Astro.props as {
+  ver: string; lang: Lang; typeSlug: string; adversaries: AdversaryLite[];
+};
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+const base = `/${lang}/${GAME}/${verSlug}/adversaries`;
+const tierLabel = (tier: number) => t(`Ранг ${tier}`, `Tier ${tier}`);
+const typeName = advTypeLabel(tSlug, lang);
+
+const heading = t(`Противники: ${typeName}`, `${typeName} Adversaries`);
+const title = `${heading} — Daggerheart ${verLabel} · OmnisGM Rules`;
+const description = t(
+  `Все ${adversaries.length} противников типа «${typeName}» в Daggerheart ${verLabel} со ссылками на стат-блоки.`,
+  `All ${adversaries.length} ${typeName} adversaries in Daggerheart ${verLabel} with links to each stat block.`,
+);
+// Другие типы — только реально присутствующие (без битых ссылок).
+const present = new Set(
+  (loadEntities(ver, 'en', 'adversaries', 'daggerheart') as unknown as AdversaryLite[]).map((a) => advTypeSlug(a.type)).filter(Boolean),
+);
+const otherTypes = ADVERSARY_TYPES.filter((x) => x.slug !== tSlug && present.has(x.slug));
+const tiers = [...new Set(adversaries.map((a) => a.tier))].sort((a, b) => a - b);
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={heading}
+  description={description}
+  headings={[]}
+  upLink={{ href: `${base}/all/`, ru: 'Все противники', en: 'All Adversaries' }}
+>
+  <h1>{heading}</h1>
+  <p>
+    {t(
+      `${adversaries.length} противников типа «${typeName}» в Daggerheart ${verLabel}. «Ранг» ведёт на список ранга. Нажмите на имя, чтобы открыть стат-блок.`,
+      `${adversaries.length} ${typeName} adversaries in Daggerheart ${verLabel}. Tier links to its list. Select a name to open the stat block.`,
+    )}
+  </p>
+
+  <div class="rd-table-wrap">
+    <table class="hub-table" data-sortable>
+      <thead>
+        <tr>
+          <th>{t('Противник', 'Adversary')}</th><th>{t('Ранг', 'Tier')}</th>
+          {lang === 'ru' && <th>Оригинал</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {adversaries.map((a) => (
+          <tr>
+            <td><a href={`${base}/${a.slug}/`}>{a.name}</a></td>
+            <td data-sort={a.tier}><a href={`${base}/tier/${a.tier}/`}>{tierLabel(a.tier)}</a></td>
+            {lang === 'ru' && <td class="og-en">{a.name_en ?? '—'}</td>}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+
+  <nav class="hub-links" aria-label={t('Другие хабы противников', 'Other adversary hubs')}>
+    <p><strong>{t('По типу:', 'By type:')}</strong>{' '}
+      {otherTypes.map((x, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/type/${x.slug}/`}>{advTypeLabel(x.slug, lang)}</a></>
+      ))}
+    </p>
+    <p><strong>{t('По рангу:', 'By tier:')}</strong>{' '}
+      {tiers.map((tier, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/tier/${tier}/`}>{tierLabel(tier)}</a></>
+      ))}
+    </p>
+  </nav>
+</ReaderShell>
+
+<style>
+  .og-en { font-family: var(--font-mono); font-size: 13px; color: var(--og-text-muted); }
+</style>

--- a/web/src/pages/[lang]/dnd/[version]/magic-items/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/magic-items/all.astro
@@ -1,18 +1,11 @@
 ---
 import ReaderShell from '../../../../../components/ReaderShell.astro';
 import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../lib/entities';
+import { RARITIES, raritySlug, rarityLabel, rarityRank, rarityHubLabel, type ItemLite as Item } from '../../../../../lib/magic-item-hubs';
 
 // Хаб-справочник всех магических предметов (issue #20): /{lang}/dnd/{version}/magic-items/all/.
-// Алфавитный индекс со ссылками на страницы предметов. Заменяет плоский глоссарий-список.
+// Алфавитный индекс со ссылками на страницы предметов + колонка редкости (ссылка на rarity-хаб).
 const PARENT_NAV: Record<string, string> = { srd52: 'd52-magicitems-hub', srd51: 'd51-magicitems-hub' };
-
-interface Item { slug: string; name: string; name_en?: string | null; type?: string; rarity?: string; attunement?: { required?: boolean } }
-
-// Редкость в данных — английский ключ; отображаем по языку.
-const RARITY: Record<string, [string, string]> = {
-  common: ['обычный', 'common'], uncommon: ['необычный', 'uncommon'], rare: ['редкий', 'rare'],
-  'very rare': ['очень редкий', 'very rare'], legendary: ['легендарный', 'legendary'], artifact: ['артефакт', 'artifact'],
-};
 
 export function getStaticPaths() {
   const BUILDS = [
@@ -32,10 +25,8 @@ const verSlug = VERSION_SLUG[ver];
 const verLabel = VERSION_LABEL[ver];
 const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
 const base = `/${lang}/dnd/${verSlug}/magic-items`;
-const rarityLabel = (r?: string) => (r && RARITY[r] ? (lang === 'ru' ? RARITY[r][0] : RARITY[r][1]) : (r ?? ''));
-// Порядок редкости для сортировки (обычный → артефакт), а не по алфавиту.
-const RARITY_ORDER = ['common', 'uncommon', 'rare', 'very rare', 'legendary', 'artifact'];
-const rarityRank = (r?: string) => { const i = RARITY_ORDER.indexOf(r ?? ''); return i === -1 ? 99 : i; };
+// Редкости, реально присутствующие в версии — для футер-навигации на rarity-хабы.
+const presentRarities = RARITIES.filter((r) => items.some((it) => raritySlug(it.rarity) === r.slug));
 
 const heading = t('Все магические предметы', 'All Magic Items');
 const title = `${heading} — D&D ${verLabel} · OmnisGM Rules`;
@@ -71,15 +62,26 @@ const description = t(
         </tr>
       </thead>
       <tbody>
-        {items.map((it) => (
-          <tr>
-            <td><a href={`${base}/${it.slug}/`}>{it.name}</a></td>
-            <td>{it.type ?? '—'}</td>
-            <td data-sort={rarityRank(it.rarity)}>{rarityLabel(it.rarity)}</td>
-            <td data-sort={it.attunement?.required ? 1 : 0}>{it.attunement?.required ? t('да', 'yes') : '—'}</td>
-          </tr>
-        ))}
+        {items.map((it) => {
+          const rs = raritySlug(it.rarity);
+          return (
+            <tr>
+              <td><a href={`${base}/${it.slug}/`}>{it.name}</a></td>
+              <td>{it.type ?? '—'}</td>
+              <td data-sort={rarityRank(it.rarity)}>{rs ? <a href={`${base}/rarity/${rs}/`}>{rarityLabel(it.rarity, lang)}</a> : rarityLabel(it.rarity, lang)}</td>
+              <td data-sort={it.attunement?.required ? 1 : 0}>{it.attunement?.required ? t('да', 'yes') : '—'}</td>
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   </div>
+
+  <nav class="hub-links" aria-label={t('Хабы предметов по редкости', 'Magic item hubs by rarity')}>
+    <p><strong>{t('По редкости:', 'By rarity:')}</strong>{' '}
+      {presentRarities.map((r, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/rarity/${r.slug}/`}>{rarityHubLabel(r.slug, lang)}</a></>
+      ))}
+    </p>
+  </nav>
 </ReaderShell>

--- a/web/src/pages/[lang]/dnd/[version]/magic-items/rarity/[rarity].astro
+++ b/web/src/pages/[lang]/dnd/[version]/magic-items/rarity/[rarity].astro
@@ -1,0 +1,101 @@
+---
+import ReaderShell from '../../../../../../components/ReaderShell.astro';
+import { loadEntities, VERSION_SLUG, VERSION_LABEL } from '../../../../../../lib/entities';
+import {
+  RARITIES, rarityBySlug, raritySlug, rarityHubLabel, byName,
+  type Lang, type ItemLite,
+} from '../../../../../../lib/magic-item-hubs';
+
+// Хаб магических предметов по редкости (issue #20): /{lang}/dnd/{version}/magic-items/rarity/{rarity}/.
+// Все предметы одной редкости (обычные…артефакты). Ловит «rare magic items 5e» / «редкие
+// магические предметы». EN/RU делят слаг редкости → каноникал + hreflang.
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-magicitems-hub', srd51: 'd51-magicitems-hub' };
+
+export function getStaticPaths() {
+  const BUILDS = [
+    { ver: 'srd52', lang: 'en' as Lang },
+    { ver: 'srd52', lang: 'ru' as Lang },
+    { ver: 'srd51', lang: 'en' as Lang },
+    { ver: 'srd51', lang: 'ru' as Lang },
+  ];
+  const paths = [];
+  for (const { ver, lang } of BUILDS) {
+    const all = loadEntities(ver, lang, 'magic-items') as unknown as ItemLite[];
+    for (const r of RARITIES) {
+      const mine = all.filter((it) => raritySlug(it.rarity) === r.slug).slice().sort(byName);
+      if (!mine.length) continue;
+      paths.push({
+        params: { lang, version: VERSION_SLUG[ver], rarity: r.slug },
+        props: { ver, lang, raritySlug: r.slug, items: mine },
+      });
+    }
+  }
+  return paths;
+}
+
+const { ver, lang, raritySlug: rSlug, items } = Astro.props as {
+  ver: string; lang: Lang; raritySlug: string; items: ItemLite[];
+};
+const verSlug = VERSION_SLUG[ver];
+const verLabel = VERSION_LABEL[ver];
+const t = (ru: string, en: string) => (lang === 'ru' ? ru : en);
+const base = `/${lang}/dnd/${verSlug}/magic-items`;
+const rName = rarityHubLabel(rSlug, lang);
+
+const heading = t(`Магические предметы: ${rName}`, `${rName[0].toUpperCase()}${rName.slice(1)} magic items`);
+const title = `${heading} — D&D ${verLabel} · OmnisGM Rules`;
+const description = t(
+  `Все ${items.length} ${rName} магических предметов D&D ${verLabel}: тип и настройка со ссылками на страницы предметов.`,
+  `All ${items.length} ${rName} magic items in D&D ${verLabel}: type and attunement with links to each item.`,
+);
+// Другие редкости — только реально присутствующие в версии (без битых ссылок на пустые хабы).
+const present = new Set(
+  (loadEntities(ver, 'en', 'magic-items') as unknown as ItemLite[]).map((it) => raritySlug(it.rarity)).filter(Boolean),
+);
+const otherRarities = RARITIES.filter((r) => r.slug !== rSlug && present.has(r.slug));
+---
+
+<ReaderShell
+  lang={lang}
+  currentId={PARENT_NAV[ver]}
+  title={title}
+  searchTitle={heading}
+  description={description}
+  headings={[]}
+  upLink={{ href: `${base}/all/`, ru: 'Все магические предметы', en: 'All Magic Items' }}
+>
+  <h1>{heading}</h1>
+  <p>
+    {t(
+      `${items.length} ${rName} магических предметов D&D ${verLabel}. В таблице — тип и требуется ли настройка. Нажмите на название, чтобы открыть страницу предмета.`,
+      `${items.length} ${rName} magic items in D&D ${verLabel}. The table lists type and whether attunement is required. Select a name to open the item page.`,
+    )}
+  </p>
+
+  <div class="rd-table-wrap">
+    <table class="hub-table" data-sortable>
+      <thead>
+        <tr>
+          <th>{t('Предмет', 'Item')}</th><th>{t('Тип', 'Type')}</th><th>{t('Настройка', 'Attunement')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((it) => (
+          <tr>
+            <td><a href={`${base}/${it.slug}/`}>{it.name}</a></td>
+            <td>{it.type ?? '—'}</td>
+            <td data-sort={it.attunement?.required ? 1 : 0}>{it.attunement?.required ? t('да', 'yes') : '—'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+
+  <nav class="hub-links" aria-label={t('Другие редкости', 'Other rarities')}>
+    <p><strong>{t('По редкости:', 'By rarity:')}</strong>{' '}
+      {otherRarities.map((r, i) => (
+        <>{i > 0 ? ' · ' : ''}<a href={`${base}/rarity/${r.slug}/`}>{rarityHubLabel(r.slug, lang)}</a></>
+      ))}
+    </p>
+  </nav>
+</ReaderShell>

--- a/web/src/styles/reader.css
+++ b/web/src/styles/reader.css
@@ -247,13 +247,15 @@ html[data-rootlang="ru"] .rd-lang-btn[data-l="ru"] { color: var(--og-accent); ba
 .rd-doc tbody td { color: var(--og-text-2); line-height: 1.5; }
 .rd-doc tbody td:first-child { color: var(--og-text); font-weight: 500; }
 
-/* Сортируемые хаб-таблицы (issue #20): клик по <th> сортирует колонку; стрелка отражает aria-sort. */
-.rd-doc .hub-table[data-sortable] thead th { cursor: pointer; user-select: none; white-space: nowrap; }
-.rd-doc .hub-table[data-sortable] thead th::after { content: '↕'; margin-left: 6px; opacity: 0.3; font-size: 0.9em; }
-.rd-doc .hub-table[data-sortable] thead th[aria-sort="ascending"]::after { content: '↑'; opacity: 0.85; }
-.rd-doc .hub-table[data-sortable] thead th[aria-sort="descending"]::after { content: '↓'; opacity: 0.85; }
-.rd-doc .hub-table[data-sortable] thead th:hover { color: var(--og-text-2); }
-.rd-doc .hub-table[data-sortable] thead th:focus-visible { outline: 2px solid var(--og-accent); outline-offset: -2px; }
+/* Сортируемые таблицы (issue #20): клик по <th> сортирует колонку; стрелка отражает aria-sort.
+   Наши хаб-таблицы (.hub-table) + markdown-таблицы глоссария (rehype-sortable-glossary) — обе
+   через общий селектор table[data-sortable]. */
+.rd-doc table[data-sortable] thead th { cursor: pointer; user-select: none; white-space: nowrap; }
+.rd-doc table[data-sortable] thead th::after { content: '↕'; margin-left: 6px; opacity: 0.3; font-size: 0.9em; }
+.rd-doc table[data-sortable] thead th[aria-sort="ascending"]::after { content: '↑'; opacity: 0.85; }
+.rd-doc table[data-sortable] thead th[aria-sort="descending"]::after { content: '↓'; opacity: 0.85; }
+.rd-doc table[data-sortable] thead th:hover { color: var(--og-text-2); }
+.rd-doc table[data-sortable] thead th:focus-visible { outline: 2px solid var(--og-accent); outline-offset: -2px; }
 
 /* Хабы заклинаний (issue #20): счётчик у заголовка уровня + блок перелинковки на соседние хабы. */
 .rd-doc .hub-count { color: var(--og-text-muted); font-weight: 400; font-size: 0.85em; }


### PR DESCRIPTION
Три доработки хабов/глоссария по замечаниям (issue #20). **Коммит на логическую часть.**

- [x] **Магические предметы — фасет по редкости** (`0d86ef4`): новый роут `magic-items/rarity/[rarity]` (обычные…артефакты, 5.2+5.1, EN/RU); колонка «Редкость» в хабе кликабельна + футер «По редкости». Общий `lib/magic-item-hubs`.
- [x] **Сортируемые markdown-таблицы глоссария** (`4a8a4cc`): `rehype-sortable-glossary` помечает `data-sortable` таблицы в главах `NN_Glossary/*` (DH оружие/броня/предметы/расходники, BRP оружие/броня, списки 5.1). Sort-скрипт и CSS расширены с `.hub-table[data-sortable]` на `table[data-sortable]`.
- [x] **Противники DH — фасет по типу** (`36a1849`): генератор извлекает `type` (Solo/Bruiser/Minion/…, 129/129) из стат-блока; новый роут `adversaries/type/[type]`; в хабе `adversaries/all` колонка «Тип» кликабельна + футер «По типу» (рядом с «По рангу»). Как type-хабы у монстров D&D.

## Проверки
- `astro check` 0 ошибок; генератор DH с валидацией схемы — чисто (129/129 type).
- e2e **164/164** (+3: rarity-фасет, интерактивная сортировка markdown-глоссария, type-фасет противников).

🤖 Generated with [Claude Code](https://claude.com/claude-code)