### PR TITLE
Доведение gloss 5.1: канонические слаги + гейт ярлыков стат-блоков (#20)

### DIFF
--- a/.github/scripts/parsers/glossary_defs.py
+++ b/.github/scripts/parsers/glossary_defs.py
@@ -10,6 +10,26 @@ import re
 from .base import slugify
 
 
+# ── Канонизация слага термина 5.1 под слаги 5.2 ───────────────────────────────
+# Слаг rules-terms — общий ключ и hovercard-бакета, и gloss-гейта на стороне ридера
+# (CORE_TERMS матчатся по слагу). Глоссарий 5.1 кодирует аббревиатуру прямо в имени
+# («Armor Class (AC)», «Challenge Rating (CR)»), из-за чего слаг выходил armor-class-ac
+# и НЕ совпадал с каноническим armor-class из 5.2 → термин не глоссился, хотя карточка
+# есть. Снимаем хвост «(ABBR)» (короткая всезаглавная аббревиатура в скобках) + точечные
+# орфографические синонимы 5.1→5.2, которые снятие скобок не покрывает.
+_ABBR_TAIL = re.compile(r"\s*\([A-Z]{1,6}\)\s*$")
+# Орфографические различия 5.1↔5.2, не сводимые снятием «(ABBR)» (число, формулировка).
+_SLUG_ALIASES = {
+    "opportunity-attack": "opportunity-attacks",  # 5.1 ед.ч. → канон 5.2 мн.ч.
+}
+
+
+def canonical_term_slug(name: str) -> str:
+    """Канонический (5.2-совместимый) слаг термина из его EN-имени."""
+    base = slugify(_ABBR_TAIL.sub("", name))
+    return _SLUG_ALIASES.get(base, base)
+
+
 def parse_defs(text: str, section: str) -> list[dict]:
     """Собрать определения #### внутри секции ### {section}.
 
@@ -111,12 +131,12 @@ def parse_section_tables(text: str, lang: str) -> list[dict]:
                 name = cells[0]
                 name_en = cells[1]
                 effect = cells[2] if len(cells) >= 3 else ""
-                slug = slugify(name_en)
+                slug = canonical_term_slug(name_en)
             else:
                 name = cells[0]
                 name_en = None
                 effect = cells[1] if len(cells) >= 2 else ""
-                slug = slugify(name)
+                slug = canonical_term_slug(name)
             # Пустой эффект = строка-список имён без определения (Damage Types, Schools of Magic
             # и пр. одноколоночные EN-таблицы / 2-колоночные RU). Такие термы — не «карточка»;
             # выкидываем, чтобы гейт по-слагу не мог однажды показать пустую подсказку.

--- a/web/e2e/srd51.spec.ts
+++ b/web/e2e/srd51.spec.ts
@@ -67,6 +67,37 @@ test('5.1 gloss-бакет отдаёт карточки терминов (не�
   expect(map['rules-terms/concentration']).toBeTruthy();
 });
 
+test('5.1 rules-terms: канонические слаги 5.2 (глоссарий 5.1 кодирует аббревиатуру в имени)', async ({ request }) => {
+  // Глоссарий 5.1 пишет «Armor Class (AC)»/«Challenge Rating (CR)»/«Opportunity Attack» (ед.ч.);
+  // канонизатор слага сводит их к слагам 5.2 → термы глоссятся и подсказки резолвятся.
+  const map = await (await request.get('/hc/dnd/srd51/ru.json')).json();
+  for (const slug of ['armor-class', 'challenge-rating', 'experience-points', 'opportunity-attacks']) {
+    expect(map[`rules-terms/${slug}`], slug).toBeTruthy();
+  }
+  // Старых слагов-с-аббревиатурой/ед.ч. быть не должно (иначе CORE_TERMS-гейт бы промахнулся).
+  for (const dead of ['armor-class-ac', 'challenge-rating-cr', 'experience-points-xp', 'opportunity-attack']) {
+    expect(map[`rules-terms/${dead}`], dead).toBeFalsy();
+  }
+});
+
+test('5.1 gloss: канонические термы подсвечены в прозе (не только в бакете)', async ({ page }) => {
+  // Показатель опасности — в прозе заклинаний призыва («ПО 2 или ниже»): подсказка уместна.
+  await page.goto('/ru/dnd/srd-5.1/spells/conjure-animals/');
+  await expect(page.locator('.rd-doc .gloss[data-hc$="/rules-terms/challenge-rating"]').first()).toBeVisible();
+});
+
+test('5.1 gloss-гейт: ярлыки стат-блоков («Класс Доспеха:») НЕ глоссятся (без ковра)', async ({ page }) => {
+  // Мега-страница главы бестиария: каждый стат-блок пишет «**Класс Доспеха:** 17» словами.
+  // Терм-ярлык — не место для подсказки; гейт (терм = весь жирный узел + двоеточие) их пропускает.
+  await page.goto('/ru/dnd/srd-5.1/monsters-a-z/');
+  const label = page.locator('.rd-doc strong', { hasText: /^Класс Доспеха:$/ }).first();
+  await expect(label).toBeVisible();
+  await expect(label.locator('.gloss')).toHaveCount(0);
+  // Ковра нет: armor-class на всей мега-странице — единицы, не сотни (было 318 до гейта).
+  const carpet = await page.locator('.rd-doc .gloss[data-hc$="/rules-terms/armor-class"]').count();
+  expect(carpet).toBeLessThan(5);
+});
+
 test('монстр 5.1: чистый тип (запятая в скобках подтипа) + бэклинк в type-хаб', async ({ page }) => {
   await page.goto('/en/dnd/srd-5.1/monsters-a-z/imp/');
   // Тип-строка должна быть «… Fiend (Devil, Shapechanger) …», без обрезанного «Fiend (Devil».

--- a/web/src/lib/rules-gloss.mjs
+++ b/web/src/lib/rules-gloss.mjs
@@ -189,7 +189,14 @@ function glossText(value, map, lang, ctx) {
     let m;
     while ((m = map.coreRe.exec(value))) {
       const slug = slugFromGroups(m.groups || {}, map.terms);
-      if (slug) spans.push({ idx: m.index, end: m.index + m[0].length, term: m[0], slug, resource: 'rules-terms' });
+      if (!slug) continue;
+      const end = m.index + m[0].length;
+      // Гейт ярлыка стат-блока: терм — это ВЕСЬ узел «Термин:» (жирный ярлык вроде
+      // «**Класс Доспеха:** 17», «**Показатель опасности:** 10»). В 5.1 стат-блоки пишут
+      // термин словами (в 5.2 — аббревиатурой «КД»/«ПО»), из-за чего КД/ПО глоссились ковром
+      // на каждой строке бестиария. Ярлык-определение — не место для подсказки; пропускаем.
+      if (m.index === 0 && /^:\s*$/.test(value.slice(end))) continue;
+      spans.push({ idx: m.index, end, term: m[0], slug, resource: 'rules-terms' });
     }
   }
   if (!spans.length) return null;


### PR DESCRIPTION
Довожу покрытие gloss-подсказок для D&D 5.1 (issue #20) — продолжение #156.

## Что было
Прошлый апдейт отметил, что в 5.1 глоссятся 12 из 21 CORE_TERMS, а `armor-class`/`challenge-rating`/`bonus-action` «нет строк в глоссарии 5.1». Аудит показал, что вывод был **неточен**: строки есть, но под неканоническим слагом.

## Разбор
Из 9 непокрытых термов:

**Category A — карточка ЕСТЬ, слаг не совпадал** (4). Глоссарий 5.1 кодирует аббревиатуру прямо в имени → слаг с хвостом:
| CORE (= слаг 5.2) | как было в 5.1 | имя в глоссарии 5.1 |
|---|---|---|
| `armor-class` | `armor-class-ac` | Armor Class (AC) |
| `challenge-rating` | `challenge-rating-cr` | Challenge Rating (CR) |
| `experience-points` | `experience-points-xp` | Experience Points (XP) |
| `opportunity-attacks` | `opportunity-attack` | Opportunity Attack (ед.ч.) |

**Category B — реально отсутствует в SRD 5.1** (5): `passive-perception`, `bonus-action`, `carrying-capacity`, `damage-threshold`, `heroic-inspiration` (в 5.1 это «Inspiration»). Их **не добавляю** — это выдумывание контента; по-слаговый гейт корректно оставляет их не-глоссированными (0 мёртвых подсказок).

## Фиксы

### 1. Канонизация слагов (`glossary_defs.py`)
`canonical_term_slug` снимает хвост `(ABBR)` + точечный алиас ед.↔мн. Слаг rules-terms — общий ключ и hovercard-бакета, и gloss-гейта, поэтому чиню на уровне данных (парсер), а не ридера. **Покрытие 5.1: 12→16/21.** Паритет EN↔RU 181=181, коллизий нет.

### 2. Гейт ярлыков стат-блоков (`rules-gloss.mjs`)
Восстановив AC/CR, обнаружил, что стат-блоки 5.1 **и 5.2** пишут терм словами (`**Класс Доспеха:** 17`, `**Показатель опасности:** 10`, `**Инициатива:** +7`) — ковёр на мега-странице бестиария (armor-class 318, challenge-rating 337). Это противоречит исходному замыслу «AC/КД, CR/ПО не глоссим ради чистоты стат-блоков» (в 5.2 он держался лишь потому, что там думали, что стат-блоки на аббревиатурах — а на деле нет).

Гейт: терм ядра пропускается, если он — **весь узел «Термин:»** (`m.index===0` и остаток === двоеточие). Версионно-независим:
- 5.1 бестиарий: armor-class 318→1, challenge-rating 337→20
- 5.2 (тот же ковёр, существовал раньше): armor-class 406→76
- Легитимная проза сохранена (снаряжение, магпредметы, заклинания призыва «ПО 2 или ниже»).

## Тесты
+3 e2e в `srd51.spec.ts`: канонические слаги в бакете (нет мёртвых `-ac/-cr/-xp`), gloss AC/CR в прозе, ярлык стат-блока без gloss. **Полный e2e: 167/167.** `astro check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)