### PR TITLE
CI: contents:write для релизных workflow (перегенерация PDF)

### DIFF
--- a/.github/workflows/release-brp.yml
+++ b/.github/workflows/release-brp.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - 'brp-srd-v*'
 
+# Обновление/создание релиза через softprops/action-gh-release требует записи в contents.
+# Дефолтные права токена в репо — read, поэтому объявляем явно (иначе «Create release» падает
+# с «Resource not accessible by integration»).
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-daggerheart.yml
+++ b/.github/workflows/release-daggerheart.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - 'dh-srd-v*'
 
+# Обновление/создание релиза через softprops/action-gh-release требует записи в contents.
+# Дефолтные права токена в репо — read, поэтому объявляем явно (иначе «Create release» падает
+# с «Resource not accessible by integration»).
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - 'dnd-srd-v*'
 
+# Обновление/создание релиза через softprops/action-gh-release требует записи в contents.
+# Дефолтные права токена в репо — read, поэтому объявляем явно (иначе «Create release» падает
+# с «Resource not accessible by integration»).
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Перемещение тегов `dnd-srd-v*`/`dh-srd-v*`/`brp-srd-v*` на актуальный коммит для перегенерации PDF (в md накопились правки, не отражённые в релизных PDF) упёрлось в падение шага **Create release**:

```
Resource not accessible by integration — update-a-release
```

Причина: `default_workflow_permissions` репозитория = `read`, а `softprops/action-gh-release` требует `contents: write` для обновления релиза. Ни в одном релизном workflow не было блока `permissions`.

Фикс: явный `permissions: contents: write` в трёх релизных workflow (least-privilege, в коде). PDF-сборка (pandoc+xetex) уже проходит успешно — падал только финальный шаг публикации.

🤖 Generated with [Claude Code](https://claude.com/claude-code)