### PR TITLE
SEO глоссариев DH/BRP: 301 дублей на хабы + возврат справочников в индекс (#106, #20)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -15,6 +15,26 @@
         "source": "/sitemap.xml",
         "destination": "/sitemap-index.xml",
         "type": 301
+      },
+      {
+        "source": "/:lang/daggerheart/srd-1.0/glossary/adversaries",
+        "destination": "/:lang/daggerheart/srd-1.0/adversaries/all/",
+        "type": 301
+      },
+      {
+        "source": "/:lang/daggerheart/srd-1.0/glossary/abilities",
+        "destination": "/:lang/daggerheart/srd-1.0/domain-cards/all/",
+        "type": 301
+      },
+      {
+        "source": "/:lang/daggerheart/srd-1.0/glossary/ancestries",
+        "destination": "/:lang/daggerheart/srd-1.0/ancestries/all/",
+        "type": 301
+      },
+      {
+        "source": "/:lang/daggerheart/srd-1.0/glossary/communities",
+        "destination": "/:lang/daggerheart/srd-1.0/communities/all/",
+        "type": 301
       }
     ],
     "headers": [

--- a/firebase.json
+++ b/firebase.json
@@ -35,6 +35,16 @@
         "source": "/:lang/daggerheart/srd-1.0/glossary/communities",
         "destination": "/:lang/daggerheart/srd-1.0/communities/all/",
         "type": 301
+      },
+      {
+        "source": "/:lang/brp/srd-1.0/glossary/skills",
+        "destination": "/:lang/brp/srd-1.0/skills/all/",
+        "type": 301
+      },
+      {
+        "source": "/:lang/brp/srd-1.0/glossary/professions",
+        "destination": "/:lang/brp/srd-1.0/professions/all/",
+        "type": 301
       }
     ],
     "headers": [

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -8,6 +8,7 @@ import rehypeSortableGlossary from './src/lib/rehype-sortable-glossary.mjs';
 import rehypeEntityAutolink from './src/lib/rehype-entity-autolink.mjs';
 import rehypeKeywordHighlight from './src/lib/keyword-highlight.mjs';
 import rehypeRulesGloss from './src/lib/rules-gloss.mjs';
+import { isIndexableGlossary } from './src/lib/glossary-seo.mjs';
 
 // rules.omnisgm.com — статический (SSG) ридер SRD экосистемы OmnisGM.
 // Контент — Markdown из ../src/{game}/{version}/{en,ru}/**.md (вход контентного пайплайна),
@@ -18,11 +19,12 @@ export default defineConfig({
   // работают с относительными ссылками; Firebase trailingSlash:true их не ломает редиректом.
   trailingSlash: 'always',
   integrations: [
-    // Глоссарные страницы noindex (см. Reader.astro) — исключаем их и из sitemap,
-    // чтобы не тратить краул-бюджет и не слать противоречивый сигнал (issue #37).
-    // Ожидаемо ~223 → ~167 URL. IndexNow берёт URL из dist-sitemap → glossary
-    // перестанут пинговаться автоматически.
-    sitemap({ filter: (page) => !page.includes('/glossary/') }),
+    // Глоссарные страницы по умолчанию noindex (см. Reader.astro) — исключаем их и из sitemap
+    // (issue #37: не тратить краул-бюджет, не слать противоречивый сигнал). ИСКЛЮЧЕНИЕ (#106,
+    // этап 1): содержательные справочники без entity-хаба (DH оружие/броня/предметы/расходники,
+    // BRP оружие/броня) возвращаем в индекс и sitemap — спрос подтверждён кликами. Дубли хабов
+    // и оглавления-термины остаются вне sitemap. IndexNow берёт URL из dist-sitemap.
+    sitemap({ filter: (page) => !page.includes('/glossary/') || isIndexableGlossary(page) }),
     pagefind(),
     AstroPWA({
       registerType: 'autoUpdate',

--- a/web/e2e/seo-glossary.spec.ts
+++ b/web/e2e/seo-glossary.spec.ts
@@ -1,10 +1,12 @@
 import { test, expect } from '@playwright/test';
 
-// Глоссарные страницы (справочные таблицы) выведены из индекса: meta noindex,follow
-// + исключены из sitemap (issue #37). Контентные страницы — индексируемы как прежде.
-const GLOSSARY = '/en/dnd/srd-5.2/glossary/spells/';
+// Глоссарные страницы по умолчанию выведены из индекса: meta noindex,follow + вне sitemap
+// (issue #37). ИСКЛЮЧЕНИЕ (#106, этап 1): содержательные справочники без entity-хаба
+// (DH оружие/броня/предметы/расходники, BRP оружие/броня) — индексируемы. Контентные — как прежде.
+const GLOSSARY = '/en/dnd/srd-5.2/glossary/spells/';    // дубль хаба (hidden) → noindex
 const CONTENT = '/en/dnd/srd-5.2/legal/';
 const RULES_GLOSSARY = '/en/dnd/srd-5.2/rules-glossary/'; // реальная глава, НЕ /glossary/ — индексируется
+const GLOSSARY_INDEXED = '/en/daggerheart/srd-1.0/glossary/weapons/'; // справочник без хаба → индексируем
 
 test('глоссарий: noindex,follow и без hreflang', async ({ page }) => {
   await page.goto(GLOSSARY);
@@ -26,9 +28,22 @@ test('rules-glossary — контентная глава, НЕ noindex', async (
   await expect(page.locator('head meta[name="robots"]')).toHaveCount(0);
 });
 
-test('sitemap не содержит /glossary/', async ({ page }) => {
+test('справочник без хаба (#106): индексируем — без robots-meta, с hreflang', async ({ page }) => {
+  await page.goto(GLOSSARY_INDEXED);
+  await expect(page.locator('head meta[name="robots"]')).toHaveCount(0);
+  await expect(page.locator('head link[rel="alternate"][hreflang]')).toHaveCount(3);
+});
+
+test('sitemap: содержит справочники без хаба (#106), но НЕ дубли/термы-глоссарий', async ({ page }) => {
   const res = await page.request.get('/sitemap-0.xml');
   expect(res.ok()).toBeTruthy();
   const xml = await res.text();
-  expect(xml).not.toContain('/glossary/');
+  // Возвращённые справочники — в sitemap.
+  expect(xml).toContain('/daggerheart/srd-1.0/glossary/weapons/');
+  expect(xml).toContain('/brp/srd-1.0/glossary/armor/');
+  // Дубли хабов (301) и оглавления-термины — НЕ в sitemap.
+  expect(xml).not.toContain('/glossary/adversaries/');
+  expect(xml).not.toContain('/glossary/skills/');
+  expect(xml).not.toContain('/glossary/glossary/');
+  expect(xml).not.toContain('/dnd/srd-5.2/glossary/');
 });

--- a/web/src/layouts/Reader.astro
+++ b/web/src/layouts/Reader.astro
@@ -3,6 +3,7 @@ import '@omnisgm-app/brand/tokens.css';
 import '@omnisgm-app/brand/fonts.css'; // self-host @font-face (Spectral/Inter/JetBrains), woff2 в public/fonts/ (#10)
 import '@omnisgm-app/brand/base.css';
 import '../styles/reader.css';
+import { isIndexableGlossary } from '../lib/glossary-seo.mjs';
 
 export interface Props {
   title: string;
@@ -18,11 +19,13 @@ export interface Props {
 const { title, description = '', lang = 'en', canonical, bilingual = false, titleRu, image = '/og.png', jsonLd, alternates } = Astro.props;
 const canonicalURL = canonical ?? new URL(Astro.url.pathname, Astro.site).toString();
 const ORIGIN = Astro.site ? Astro.site.origin : 'https://rules.omnisgm.com';
-// Глоссарные страницы (справочные таблицы-выжимки) выводим из индекса: noindex,follow
-// — ссылочный вес продолжает течь по внутренним ссылкам, но сами страницы не конкурируют
-// за краул-бюджет с контентными и programmatic-страницами (issue #37). Их же исключаем
-// из sitemap (astro.config). robots.txt НЕ трогаем (Disallow скрыл бы сам noindex).
-const isGlossary = Astro.url.pathname.includes('/glossary/');
+// Глоссарные страницы (справочные таблицы-выжимки) по умолчанию выводим из индекса:
+// noindex,follow — вес течёт по внутренним ссылкам, но страницы не конкурируют за краул-
+// бюджет (issue #37). ИСКЛЮЧЕНИЕ (#106, этап 1): содержательные справочники без entity-хаба
+// (DH оружие/броня/предметы/расходники, BRP оружие/броня) — их индексируем (спрос по кликам),
+// поэтому им НЕ ставим noindex и оставляем hreflang-alternates. Дубли хабов (301) и оглавления-
+// термины остаются noindex. Синхронно с sitemap-фильтром (astro.config, тот же allow-list).
+const isGlossary = Astro.url.pathname.includes('/glossary/') && !isIndexableGlossary(Astro.url.pathname);
 const imageURL = new URL(image, ORIGIN).toString();
 const ogLocale = lang === 'ru' ? 'ru_RU' : 'en_US';
 const ogAltLocale = lang === 'ru' ? 'en_US' : 'ru_RU';

--- a/web/src/lib/glossary-seo.mjs
+++ b/web/src/lib/glossary-seo.mjs
@@ -1,0 +1,26 @@
+// SEO-классификация глоссарных страниц (issue #106, этап 1).
+//
+// Чистка #37 накрыла ВСЕ `/glossary/` одинаково (noindex + вне sitemap). Но контент разный:
+//  • Дубли хабов (DH: способности/противники/происхождения/сообщества; BRP: навыки/профессии)
+//    — у них есть функциональные entity-хабы. Со старых URL — 301 на хаб (см. firebase.json),
+//    в индекс/sitemap НЕ возвращаем.
+//  • Оглавления-термины (00_Glossary) — тонкие списки; оставляем noindex (наполнение
+//    per-term programmatic-страницами — отдельный этап #106).
+//  • Содержательные справочники БЕЗ хаба (DH: оружие/броня/предметы/расходники; BRP:
+//    оружие/броня) — это аналог D&D rules-glossary. Их ВОЗВРАЩАЕМ в индекс и sitemap.
+//
+// Список — явный allow-list (а не «всё кроме дублей»): так безопаснее — новые/прочие
+// `/glossary/` по умолчанию остаются вне индекса, пока их сюда явно не добавят.
+export const INDEXABLE_GLOSSARY = [
+  '/daggerheart/srd-1.0/glossary/weapons/',
+  '/daggerheart/srd-1.0/glossary/armor/',
+  '/daggerheart/srd-1.0/glossary/items/',
+  '/daggerheart/srd-1.0/glossary/consumables/',
+  '/brp/srd-1.0/glossary/weapons/',
+  '/brp/srd-1.0/glossary/armor/',
+];
+
+// Глоссарная страница, которую возвращаем в индекс (принимает pathname или полный URL —
+// матч по подстроке, язык-агностично: /ru/… и /en/… оба ловятся).
+export const isIndexableGlossary = (urlOrPath) =>
+  INDEXABLE_GLOSSARY.some((s) => urlOrPath.includes(s));


### PR DESCRIPTION
Консолидация SEO глоссариев Daggerheart и BRP — реализует **этап 1 #106** + чинит замеченный владельцем случай (`glossary/adversaries` в выдаче).

Чистка #37 накрыла все `/glossary/` одинаково (noindex + вне sitemap), но контент разный. Разделяем на три класса:

### 1. Дубли хабов → 301 (в индекс не возвращаем)
Скрытые glossary-списки, у которых есть функциональные entity-хабы (сортировка, фасеты, кликабельные карточки). Плоские таблицы нефункциональны (имена в ячейках не слинкованы). Серверный **301** (Firebase) сводит их к хабам — вес переезжает, а не сгорает:

| Дубль | → Хаб |
|---|---|
| DH `glossary/adversaries` | `adversaries/all` |
| DH `glossary/abilities` | `domain-cards/all` |
| DH `glossary/ancestries` | `ancestries/all` |
| DH `glossary/communities` | `communities/all` |
| BRP `glossary/skills` | `skills/all` |
| BRP `glossary/professions` | `professions/all` |

ru+en (`:lang`). Проверено hosting-эмулятором: 301 со слэшем и без.

### 2. Справочники без хаба → возвращаем в индекс (#106 этап 1)
Содержательные таблицы, у которых нет entity-эквивалента (аналог D&D `rules-glossary`); спрос подтверждён кликами:
- DH: оружие, броня, предметы, расходники
- BRP: оружие, броня

`glossary-seo.mjs` — единый **allow-list** `INDEXABLE_GLOSSARY`, который синхронно используют sitemap-фильтр (`astro.config`) и noindex-гейт (`Reader.astro`): справочникам снимаем `noindex` и возвращаем hreflang-alternates. **+12 URL в sitemap** (6 ×ru/en). Титулы уже уникальны (nav-подписи).

### 3. Оглавления-термины (00_Glossary) и D&D-глоссарий → без изменений
Остаются `noindex` + вне sitemap (наполнение per-term programmatic-страницами D&D — отдельный этап #106; DH/BRP-термы — тоже позже).

## Проверка
- Эмулятор: все 6 дублей → 301 на хаб (ru+en, со слэшем и без); справочники → 200.
- Sitemap: ровно 12 функциональных glossary-URL, 0 дублей/термов/D&D-глоссария.
- noindex/hreflang: справочники `noindex=0, hreflang×3`; дубли/термы `noindex=1`.
- e2e `seo-glossary` 5/5; `astro check` 0 ошибок.

## После мёржа/деплоя
IndexNow автоматически пингнёт новые sitemap-URL (справочники). Старые дубли — 301 (де-индексируются при перекраулинге).

Закрывает этап 1 #106 для DH/BRP. Осталось по #106: наполнить D&D `rules-glossary` всеми 156 терминами (этап 1, п.2) и entity-конверсия оружия/брони DH/BRP (этап 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)