### PR TITLE
Хабы: чистка интро + currentId страниц терминов на хаб (#106)

### DIFF
--- a/web/src/pages/[lang]/brp/[version]/skills/all.astro
+++ b/web/src/pages/[lang]/brp/[version]/skills/all.astro
@@ -61,8 +61,8 @@ const upLink = { href: `/${lang}/${GAME}/${verSlug}/09_Glossary/01_Skills/`, ru:
   <h1>{heading}</h1>
   <p>
     {t(
-      `${skills.length} навыков Basic Roleplaying ${verLabel}. В таблице — категория (ссылка на список категории) и базовый шанс. Нажмите на заголовок столбца, чтобы отсортировать.`,
-      `${skills.length} Basic Roleplaying ${verLabel} skills. The table lists category (linked to its list) and base chance. Click a column header to sort.`,
+      `${skills.length} навыков Basic Roleplaying ${verLabel}. В таблице — категория (ссылка на список категории) и базовый шанс.`,
+      `${skills.length} Basic Roleplaying ${verLabel} skills. The table lists category (linked to its list) and base chance.`,
     )}
   </p>
 

--- a/web/src/pages/[lang]/daggerheart/[version]/adversaries/all.astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/adversaries/all.astro
@@ -57,8 +57,8 @@ const upLink = { href: `/${lang}/${GAME}/${verSlug}/13_Adversaries/`, ru: 'Пр�
   <h1>{heading}</h1>
   <p>
     {t(
-      `${items.length} противников Daggerheart ${verLabel}. В таблице — тип (Одиночка/Громила/…) и ранг, оба ведут на списки. Нажмите на заголовок столбца, чтобы отсортировать. Общие правила — в главе «Противники».`,
-      `${items.length} Daggerheart ${verLabel} adversaries. The table lists type (Solo/Bruiser/…) and tier, both linked to their lists. Click a column header to sort. General rules are in the Adversaries chapter.`,
+      `${items.length} противников Daggerheart ${verLabel}. В таблице — тип (Одиночка/Громила/…) и ранг, оба ведут на списки. Общие правила — в главе «Противники».`,
+      `${items.length} Daggerheart ${verLabel} adversaries. The table lists type (Solo/Bruiser/…) and tier, both linked to their lists. General rules are in the Adversaries chapter.`,
     )}
   </p>
 

--- a/web/src/pages/[lang]/daggerheart/[version]/domain-cards/all.astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/domain-cards/all.astro
@@ -67,8 +67,8 @@ const upLink = { href: `/${lang}/${GAME}/${verSlug}/16_DomainCardReference/`, ru
   <h1>{heading}</h1>
   <p>
     {t(
-      `${items.length} доменных карт Daggerheart ${verLabel}. В таблице — домен (ссылка на список домена), уровень и стоимость отзыва. Нажмите на заголовок столбца, чтобы отсортировать.`,
-      `${items.length} Daggerheart ${verLabel} domain cards. The table lists domain (linked to its list), level and recall cost. Click a column header to sort.`,
+      `${items.length} доменных карт Daggerheart ${verLabel}. В таблице — домен (ссылка на список домена), уровень и стоимость отзыва.`,
+      `${items.length} Daggerheart ${verLabel} domain cards. The table lists domain (linked to its list), level and recall cost.`,
     )}
   </p>
 

--- a/web/src/pages/[lang]/daggerheart/[version]/environments/all.astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/environments/all.astro
@@ -54,8 +54,8 @@ const upLink = { href: `/${lang}/${GAME}/${verSlug}/14_Environments/`, ru: 'Ок
   <h1>{heading}</h1>
   <p>
     {t(
-      `${items.length} окружений Daggerheart ${verLabel} по рангам. В таблице — ранг (ссылка на список ранга). Нажмите на заголовок столбца, чтобы отсортировать. Общие правила — в главе «Окружения».`,
-      `${items.length} Daggerheart ${verLabel} environments by tier. The table lists tier (linked to its list). Click a column header to sort. General rules are in the Environments chapter.`,
+      `${items.length} окружений Daggerheart ${verLabel} по рангам. В таблице — ранг (ссылка на список ранга). Общие правила — в главе «Окружения».`,
+      `${items.length} Daggerheart ${verLabel} environments by tier. The table lists tier (linked to its list). General rules are in the Environments chapter.`,
     )}
   </p>
 

--- a/web/src/pages/[lang]/dnd/[version]/animals/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/animals/all.astro
@@ -47,8 +47,8 @@ const description = t(
   <h1>{heading}</h1>
   <p>
     {t(
-      `${animals.length} животных D&D ${verLabel} по алфавиту. В таблице — размер, тип, ПО (ссылка на хаб) и хиты. Нажмите на заголовок столбца, чтобы отсортировать.`,
-      `${animals.length} D&D ${verLabel} animals alphabetically. The table lists size, type, CR (linked to hub) and HP. Click a column header to sort.`,
+      `${animals.length} животных D&D ${verLabel} по алфавиту. В таблице — размер, тип, ПО (ссылка на хаб) и хиты.`,
+      `${animals.length} D&D ${verLabel} animals alphabetically. The table lists size, type, CR (linked to hub) and HP.`,
     )}
   </p>
 

--- a/web/src/pages/[lang]/dnd/[version]/magic-items/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/magic-items/all.astro
@@ -48,8 +48,8 @@ const description = t(
   <h1>{heading}</h1>
   <p>
     {t(
-      `${items.length} магических предметов D&D ${verLabel} по алфавиту. В таблице — тип, редкость и требуется ли настройка. Нажмите на заголовок столбца, чтобы отсортировать.`,
-      `${items.length} D&D ${verLabel} magic items alphabetically. The table lists type, rarity and whether attunement is required. Click a column header to sort.`,
+      `${items.length} магических предметов D&D ${verLabel} по алфавиту. В таблице — тип, редкость и требуется ли настройка.`,
+      `${items.length} D&D ${verLabel} magic items alphabetically. The table lists type, rarity and whether attunement is required.`,
     )}
   </p>
 

--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/all.astro
@@ -47,8 +47,8 @@ const description = t(
   <h1>{heading}</h1>
   <p>
     {t(
-      `${monsters.length} монстров D&D ${verLabel} по алфавиту. В таблице — тип и ПО (ссылки на хабы), размер и хиты. Нажмите на заголовок столбца, чтобы отсортировать.`,
-      `${monsters.length} D&D ${verLabel} monsters alphabetically. The table lists type and CR (linked to hubs), size and HP. Click a column header to sort.`,
+      `${monsters.length} монстров D&D ${verLabel} по алфавиту. В таблице — тип и ПО (ссылки на хабы), размер и хиты.`,
+      `${monsters.length} D&D ${verLabel} monsters alphabetically. The table lists type and CR (linked to hubs), size and HP.`,
     )}
   </p>
 

--- a/web/src/pages/[lang]/dnd/[version]/rules-glossary/action/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/rules-glossary/action/[slug].astro
@@ -11,7 +11,7 @@ import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../
 // Programmatic-страницы действий Rules Glossary (issue #106): Рывок/Уклонение/Засада/…
 // URL /{lang}/dnd/{version}/rules-glossary/action/{slug}/. Зеркалит состояния; малый набор →
 // показываем список родственных действий.
-const PARENT_NAV: Record<string, string> = { srd52: 'd52-rulesglossary' };
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-rulesterms-hub' };
 
 export function getStaticPaths() {
   const BUILDS = [

--- a/web/src/pages/[lang]/dnd/[version]/rules-glossary/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/rules-glossary/all.astro
@@ -63,8 +63,8 @@ const upLink = { href: `/${lang}/dnd/${verSlug}/rules-glossary/`, ru: 'Глос�
   <h1>{heading}</h1>
   <p>
     {t(
-      `${rows.length} терминов Глоссария правил D&D ${verLabel}. Нажмите на заголовок столбца, чтобы отсортировать. Каждый термин ведёт на свою страницу с выжимкой и ссылкой в главу-источник.`,
-      `${rows.length} D&D ${verLabel} Rules Glossary terms. Click a column header to sort. Each term links to its own page with a summary and a link to the source chapter.`,
+      `${rows.length} терминов Глоссария правил D&D ${verLabel}.`,
+      `${rows.length} D&D ${verLabel} Rules Glossary terms.`,
     )}
   </p>
 

--- a/web/src/pages/[lang]/dnd/[version]/rules-glossary/area-of-effect/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/rules-glossary/area-of-effect/[slug].astro
@@ -10,7 +10,7 @@ import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../
 
 // Programmatic-страницы областей эффекта Rules Glossary (issue #106): Конус/Куб/Сфера/…
 // URL /{lang}/dnd/{version}/rules-glossary/area-of-effect/{slug}/. Зеркалит состояния.
-const PARENT_NAV: Record<string, string> = { srd52: 'd52-rulesglossary' };
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-rulesterms-hub' };
 
 export function getStaticPaths() {
   const BUILDS = [

--- a/web/src/pages/[lang]/dnd/[version]/rules-glossary/term/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/rules-glossary/term/[slug].astro
@@ -12,7 +12,7 @@ import { loadEntities, excerpt, VERSION_SLUG, VERSION_LABEL } from '../../../../
 // 08_RulesGlossary — свой URL /{lang}/dnd/{version}/rules-glossary/term/{slug}/, чтобы ловить
 // точечные запросы («преимущество днд 2024»). Зеркалит паттерн состояний. EN и RU делят
 // канонический (английский) слаг → корректный hreflang (ReaderShell считает его из URL).
-const PARENT_NAV: Record<string, string> = { srd52: 'd52-rulesglossary' };
+const PARENT_NAV: Record<string, string> = { srd52: 'd52-rulesterms-hub' };
 
 export function getStaticPaths() {
   const BUILDS = [

--- a/web/src/pages/[lang]/dnd/[version]/spells/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/all.astro
@@ -50,8 +50,8 @@ const description = t(
   <h1>{heading}</h1>
   <p>
     {t(
-      `${spells.length} заклинаний D&D ${verLabel} по алфавиту. В таблице — уровень, школа и классы (все ссылки ведут на хабы). Нажмите на заголовок столбца, чтобы отсортировать.`,
-      `${spells.length} D&D ${verLabel} spells alphabetically. The table lists level, school and classes (all linked to hubs). Click a column header to sort.`,
+      `${spells.length} заклинаний D&D ${verLabel} по алфавиту. В таблице — уровень, школа и классы (все ссылки ведут на хабы).`,
+      `${spells.length} D&D ${verLabel} spells alphabetically. The table lists level, school and classes (all linked to hubs).`,
     )}
   </p>
 


### PR DESCRIPTION
Мелкая полировка после #161 — по замечаниям владельца.

## 1. Чистка интро хабов
Инструкция «Нажмите на заголовок столбца, чтобы отсортировать» / «Click a column header to sort» — избыточна (стрелки-индикаторы в шапке и так показывают сортируемость). Убрал из **всех 9 хабов**; в `rules-glossary/all` дополнительно снял «Каждый термин ведёт на свою страницу…» (очевидно из таблицы). Описательная часть (кол-во, пояснение колонок-фасетов, ссылка на главу) сохранена; `meta description` не тронут.

## 2. currentId страниц терминов → хаб (нит ревью #161)
`term`/`action`/`area-of-effect` вели currentId на главу `d52-rulesglossary` — в сайдбаре подсвечивалась глава, а не хаб-индекс. Теперь → `d52-rulesterms-hub` (как entity-страницы DH/BRP ведут на свой хаб): подсветка дерева, крошки, prev/next центрируются на индексе терминов. **Влияет только на нав-контекст, не на содержимое.**

Состояния оставлены на `d52-rulesglossary` (были отревьюены так; визуал-снапшоты не трогаю — сознательно не расширяю нит на них).

## Проверка
`astro check` 0 ошибок, e2e **177/177** (визуальные снапшоты состояний зелёные — не задеты).

🤖 Generated with [Claude Code](https://claude.com/claude-code)