### PR TITLE
SEO: 301 дублей D&D-глоссария на хабы + убрать hidden-узлы (#106, п.2)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -45,6 +45,41 @@
         "source": "/:lang/brp/srd-1.0/glossary/professions",
         "destination": "/:lang/brp/srd-1.0/professions/all/",
         "type": 301
+      },
+      {
+        "source": "/:lang/dnd/srd-5.2/glossary/spells",
+        "destination": "/:lang/dnd/srd-5.2/spells/all/",
+        "type": 301
+      },
+      {
+        "source": "/:lang/dnd/srd-5.2/glossary/magic-items",
+        "destination": "/:lang/dnd/srd-5.2/magic-items/all/",
+        "type": 301
+      },
+      {
+        "source": "/:lang/dnd/srd-5.2/glossary/monsters",
+        "destination": "/:lang/dnd/srd-5.2/monsters-a-z/all/",
+        "type": 301
+      },
+      {
+        "source": "/:lang/dnd/srd-5.2/glossary/animals",
+        "destination": "/:lang/dnd/srd-5.2/animals/all/",
+        "type": 301
+      },
+      {
+        "source": "/:lang/dnd/srd-5.1/glossary/spells",
+        "destination": "/:lang/dnd/srd-5.1/spells/all/",
+        "type": 301
+      },
+      {
+        "source": "/:lang/dnd/srd-5.1/glossary/magic-items",
+        "destination": "/:lang/dnd/srd-5.1/magic-items/all/",
+        "type": 301
+      },
+      {
+        "source": "/:lang/dnd/srd-5.1/glossary/monsters",
+        "destination": "/:lang/dnd/srd-5.1/monsters-a-z/all/",
+        "type": 301
       }
     ],
     "headers": [

--- a/web/e2e/dnd-all-hubs.spec.ts
+++ b/web/e2e/dnd-all-hubs.spec.ts
@@ -37,15 +37,6 @@ test('хаб в сайдбаре (глоссарий) виден и подсве
   await expect(page.locator('.rd-nav a[href$="/14_glossary/02_spells/"]')).toHaveCount(0);
 });
 
-test('заменённая глоссарий-страница жива и держит nav-контекст (не сирота)', async ({ page }) => {
-  const res = await page.goto('/ru/dnd/srd-5.2/glossary/spells/');
-  expect(res?.status()).toBe(200);
-  await expect(page.locator('.rd-doc')).toBeVisible();
-  // Крошки/таб резолвятся через скрытый узел → активная система D&D 5.2, не «home»
-  // (у сироты title был бы без «D&D SRD 5.2.1»).
-  await expect(page).toHaveTitle(/D&D SRD 5\.2\.1/);
-});
-
 test('spells/all: уровень и школа кликабельны; школа-хаб рендерится', async ({ page }) => {
   await page.goto('/ru/dnd/srd-5.2/spells/all/');
   // Уровень → level-хаб, школа → school-хаб (оба новые).

--- a/web/e2e/seo-glossary.spec.ts
+++ b/web/e2e/seo-glossary.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 // Глоссарные страницы по умолчанию выведены из индекса: meta noindex,follow + вне sitemap
 // (issue #37). ИСКЛЮЧЕНИЕ (#106, этап 1): содержательные справочники без entity-хаба
 // (DH оружие/броня/предметы/расходники, BRP оружие/броня) — индексируемы. Контентные — как прежде.
-const GLOSSARY = '/en/dnd/srd-5.2/glossary/spells/';    // дубль хаба (hidden) → noindex
+const GLOSSARY = '/en/dnd/srd-5.2/glossary/glossary/';  // индекс-термины 14_Glossary → noindex (не редиректится)
 const CONTENT = '/en/dnd/srd-5.2/legal/';
 const RULES_GLOSSARY = '/en/dnd/srd-5.2/rules-glossary/'; // реальная глава, НЕ /glossary/ — индексируется
 const GLOSSARY_INDEXED = '/en/daggerheart/srd-1.0/glossary/weapons/'; // справочник без хаба → индексируем

--- a/web/src/lib/nav.ts
+++ b/web/src/lib/nav.ts
@@ -80,15 +80,12 @@ export const NAV: NavNode[] = [
         page('d52-rulesterms-hub', 'Глоссарий правил (все термины)', 'Rules Glossary (All Terms)', '/dnd/srd-5.2/rules-glossary/all/'),
         page('d52-origins-hub', 'Виды и предыстории', 'Species & Backgrounds', '/dnd/srd-5.2/character-origins/all/'),
         // Плоские глоссарий-списки заменены нашими /all/-хабами (ссылки на entity-страницы +
-        // фасеты); сами списки скрыты (hidden), но их страницы остаются доступны по URL.
+        // фасеты). Сами дубли-списки (14_Glossary/02-05) редиректятся 301 на хабы (firebase.json)
+        // → узлы им больше не нужны (были hidden ради nav-контекста; теперь страницы не отдаются).
         page('d52-spells-hub', 'Заклинания (справочник)', 'Spells (Reference)', '/dnd/srd-5.2/spells/all/'),
         page('d52-magicitems-hub', 'Магические предметы (справочник)', 'Magic Items (Reference)', '/dnd/srd-5.2/magic-items/all/'),
         page('d52-monsters-hub', 'Монстры (справочник)', 'Monsters (Reference)', '/dnd/srd-5.2/monsters-a-z/all/'),
         page('d52-animals-hub', 'Животные (справочник)', 'Animals (Reference)', '/dnd/srd-5.2/animals/all/'),
-        hidden('d52-g-spells', 'Заклинания (справочник)', 'Spells (Reference)', '/dnd/srd-5.2/14_Glossary/02_Spells/'),
-        hidden('d52-g-magicitems', 'Магические предметы (справочник)', 'Magic Items (Reference)', '/dnd/srd-5.2/14_Glossary/03_MagicItems/'),
-        hidden('d52-g-monsters', 'Монстры (справочник)', 'Monsters (Reference)', '/dnd/srd-5.2/14_Glossary/04_Monsters/'),
-        hidden('d52-g-animals', 'Животные (справочник)', 'Animals (Reference)', '/dnd/srd-5.2/14_Glossary/05_Animals/'),
       ]),
     ]),
     group('d51', 'SRD 5.1', 'SRD 5.1', [
@@ -111,13 +108,11 @@ export const NAV: NavNode[] = [
       group('d51-glossary', 'Глоссарий', 'Glossary', [
         page('d51-g-terms', 'Термины', 'Terms', '/dnd/srd-5.1/16_Glossary/00_Glossary/'),
         page('d51-races-hub', 'Расы (справочник)', 'Races (Reference)', '/dnd/srd-5.1/races/all/'),
-        // Плоские глоссарий-списки заменены /all/-хабами; списки скрыты (страницы живы).
+        // Плоские глоссарий-списки заменены /all/-хабами; дубли (16_Glossary/02-04) редиректятся
+        // 301 на хабы (firebase.json) → узлы им больше не нужны.
         page('d51-spells-hub', 'Заклинания (справочник)', 'Spells (Reference)', '/dnd/srd-5.1/spells/all/'),
         page('d51-magicitems-hub', 'Магические предметы (справочник)', 'Magic Items (Reference)', '/dnd/srd-5.1/magic-items/all/'),
         page('d51-monsters-hub', 'Монстры (справочник)', 'Monsters (Reference)', '/dnd/srd-5.1/monsters-a-z/all/'),
-        hidden('d51-g-spells', 'Заклинания (справочник)', 'Spells (Reference)', '/dnd/srd-5.1/16_Glossary/02_Spells/'),
-        hidden('d51-g-magicitems', 'Магические предметы (справочник)', 'Magic Items (Reference)', '/dnd/srd-5.1/16_Glossary/03_MagicItems/'),
-        hidden('d51-g-monsters', 'Монстры (справочник)', 'Monsters (Reference)', '/dnd/srd-5.1/16_Glossary/04_Monsters/'),
       ]),
     ]),
     page('d52-converting', 'Конвертация в SRD 5.2.1', 'Converting to SRD 5.2.1', '/dnd/converting-srd-5.2/converting-to-srd-5.2.1/'),


### PR DESCRIPTION
Симметрично #160 (DH/BRP) — закрывает **п.2 роадмапа #106** для D&D.

## Проблема
Плоские справочники `14_Glossary` (5.2) и `16_Glossary` (5.1) после #152 заменены алфавитными `/all/`-хабами. Сами таблицы скрыты из дерева, под `noindex`, **но живы по URL** — Гугл держит их в устаревшем индексе (как было с DH adversaries до #160).

## Фикс
Серверный **301** (Firebase, `:lang`-параметр) сводит 7 дублей к их хабам:

| Дубль | → Хаб |
|---|---|
| `srd-5.2/glossary/spells` | `spells/all` |
| `srd-5.2/glossary/magic-items` | `magic-items/all` |
| `srd-5.2/glossary/monsters` | `monsters-a-z/all` |
| `srd-5.2/glossary/animals` | `animals/all` |
| `srd-5.1/glossary/spells` | `spells/all` |
| `srd-5.1/glossary/magic-items` | `magic-items/all` |
| `srd-5.1/glossary/monsters` | `monsters-a-z/all` |

ru+en. Плюс **убрал 7 hidden-узлов** из nav (замечание из ревью #160): держались ради «страница жива по URL», теперь дубли не отдаются → узлы бесфункциональны.

*(5.1 без `glossary/animals` — там звери в монстрах, отдельного хаба нет. Терм-индексы `glossary/glossary` не тронуты — нет хаб-эквивалента, остаются noindex.)*

## Проверка
- Hosting-эмулятор: все 7 → 301 на хаб (со слэшем/без, ru+en); `glossary/glossary` → 200.
- `astro check` 0 ошибок, e2e **176/176** (удалён 1 устаревший тест «страница-дубль жива», перенаправлена GLOSSARY-константа seo-теста).

## После деплоя
IndexNow-пинг 7 старых URL (×2 = 14) для ускорения склейки 301 — как в #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)