### PR TITLE
SEO: тайтл корня — 66 символов вместо 76 (Bing «Title too long»)

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -13,7 +13,7 @@ const r = (id: string) => {
   return n && !isGroup(n) ? routeOf(n.slug, 'en') : '/en/';
 };
 
-const title = 'OmnisGM Rules — tabletop RPG reference (D&D, Daggerheart, Basic Roleplaying)';
+const title = 'OmnisGM Rules — tabletop RPG SRD reference (D&D, Daggerheart, BRP)';
 const titleRu = 'OmnisGM Rules — ридер SRD настольных игр (D&D, Daggerheart, BRP)';
 const description =
   'Freely-licensed tabletop RPG System Reference Documents (D&D 5.2.1 / 5.1, Daggerheart, Basic Roleplaying) as Markdown. A project of the OmnisGM ecosystem.';


### PR DESCRIPTION
## Что это

Bing URL Inspection показал **Error «Title too long»** на корне `https://rules.omnisgm.com/`: 76 символов при лимите 70 — тайтл может обрезаться или игнорироваться.

## Правка

Одна строка в `web/src/pages/index.astro`:

- Было: `OmnisGM Rules — tabletop RPG reference (D&D, Daggerheart, Basic Roleplaying)` (76)
- Стало: `OmnisGM Rules — tabletop RPG SRD reference (D&D, Daggerheart, BRP)` (**66**)

Сохранены оба общих ключа («tabletop RPG», «SRD» — добавлен) и все три системы; полное имя «Basic Roleplaying» остаётся в h1/теле страницы и внутренних тайтлах. `titleRu` уже в лимите (64) — не тронут. Языковые версии `/ru/` (24) и `/en/` (20) и внутренние страницы короткие — Bing честно показал «1 instance».

## После мёржа и деплоя

🖐 Bing Webmaster → URL Inspection `https://rules.omnisgm.com/` → Request indexing (перепроверка).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4pEspRYkG4rKeFheJHjpy