### PR TITLE
SEO: содержательные сниппеты класс-страниц + кириллическое «днд» (#173)

### DIFF
--- a/web/src/lib/class-facts.ts
+++ b/web/src/lib/class-facts.ts
@@ -1,0 +1,91 @@
+// Извлечение фактов класса из markdown-тела для содержательного <meta description>
+// класс-страниц (issue #173, п.1). Класс-страницы рендерит catch-all [...slug].astro, где
+// раньше был бойлерплейт «{Имя} — D&D SRD 5.2.1 на русском…» на самом крупном кластере
+// спроса («плут днд»: 513 запросов). Здесь тянем умения 1-го уровня прямо из таблицы
+// прогрессии класса — они уже локализованы в контенте, так что перевод не дублируется и
+// не дрейфует. Версия таблиц 5.1 и 5.2 разъехалась (в 5.1 колонка умений последняя, в 5.2 —
+// третья), поэтому колонку ищем по заголовку, а не по фикс-индексу.
+
+// Разбить строку markdown-таблицы в ячейки (без ведущего/замыкающего «|»).
+function cells(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\|/, '')
+    .replace(/\|$/, '')
+    .split('|')
+    .map((c) => c.trim());
+}
+
+const isTableRow = (line: string) => /^\s*\|/.test(line);
+// Строка-разделитель шапки: «|---|:--:|…».
+const isSeparator = (line: string) => /^\s*\|[\s:|-]+\|?\s*$/.test(line) && line.includes('-');
+
+// Первая ячейка строки-заголовка таблицы прогрессии («Уровень»/«Level»).
+const isLevelHeader = (c: string) => /^(уровень|level)$/i.test(c);
+// Заголовок колонки умений: «Классовые умения»/«Умения»/«Class Features»/«Features».
+const isFeatureHeader = (c: string) => /умен|features?/i.test(c);
+// Ячейка уровня, равная 1 (учитываем «1», «1st», «1-й», «1-го»). «10»/«11» не ловим.
+const isLevelOne = (c: string) => /^1(\D|$)/.test(c.replace(/\s+/g, ''));
+
+/**
+ * Умения 1-го уровня класса из таблицы прогрессии (напр. ['Экспертиза', 'Скрытая атака',
+ * 'Воровской жаргон']). Пустой массив, если таблицу/строку не нашли (описание деградирует
+ * к бойлерплейту — сборку это не валит).
+ */
+export function level1Features(body: string | undefined, limit = 3): string[] {
+  if (!body) return [];
+  const lines = body.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (!isTableRow(lines[i])) continue;
+    const header = cells(lines[i]);
+    if (!isLevelHeader(header[0] ?? '')) continue;
+    const featCol = header.findIndex(isFeatureHeader);
+    if (featCol < 0) continue;
+
+    // Идём по строкам данных этой таблицы до её конца; берём строку уровня 1.
+    for (let j = i + 1; j < lines.length && isTableRow(lines[j]); j++) {
+      if (isSeparator(lines[j])) continue;
+      const row = cells(lines[j]);
+      if (!isLevelOne(row[0] ?? '')) continue;
+      return (row[featCol] ?? '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .slice(0, limit);
+    }
+  }
+  return [];
+}
+
+// Слаг версии → издание для сниппета: 5.2 = «D&D 2024», 5.1 = «D&D 2014». Кириллическая
+// форма «(днд)» — частотное написание запросов (issue #173, п.2), одна встреча, не стаффинг.
+const EDITION: Record<string, string> = { 'srd-5.2': '2024', 'srd-5.1': '2014' };
+
+/**
+ * Содержательный <meta description> класс-страницы. null, если умений не извлекли —
+ * вызывающий откатывается к бойлерплейту. verLabel — метка версии из nav («SRD 5.2.1»).
+ */
+export function classDescription(opts: {
+  name: string;
+  body: string | undefined;
+  lang: 'en' | 'ru';
+  version: string;
+  verLabel: string;
+}): string | null {
+  const { name, body, lang, version, verLabel } = opts;
+  const feats = level1Features(body);
+  if (feats.length === 0) return null;
+
+  const ed = EDITION[version];
+  const compose = (n: number) => {
+    const list = feats.slice(0, n).join(', ');
+    return lang === 'ru'
+      ? `${name} — класс D&D${ed ? ` ${ed}` : ''} (днд): ${list}. Умения по уровням 1–20, подклассы. Полные правила ${verLabel} на русском.`
+      : `${name} — a D&D${ed ? ` ${ed}` : ''} class: ${list}. Features by level 1–20 with subclasses. Full ${verLabel} rules.`;
+  };
+
+  // Держим сниппет в пределах ~160 символов: при переполнении срезаем до 2 умений.
+  let out = compose(3);
+  if (out.length > 160 && feats.length > 2) out = compose(2);
+  return out;
+}

--- a/web/src/pages/[lang]/[...slug].astro
+++ b/web/src/pages/[lang]/[...slug].astro
@@ -3,6 +3,7 @@ import { getCollection, render } from 'astro:content';
 import ReaderShell from '../../components/ReaderShell.astro';
 import { parseId, titleFromBody } from '../../lib/slug';
 import { nodeBySlug, findPath, label as navLabel } from '../../lib/nav';
+import { classDescription } from '../../lib/class-facts';
 
 export async function getStaticPaths() {
   const all = await getCollection('srd');
@@ -37,10 +38,19 @@ const verLabel = trail.length > 1 ? navLabel(trail[1], ref.lang) : ref.version;
 
 const t = (ru: string, en: string) => (ref.lang === 'en' ? en : ru);
 const title = `${searchTitle} · ${sysLabel} ${verLabel} · OmnisGM Rules`;
-const description = t(
-  `${searchTitle} — ${sysLabel} ${verLabel} на русском. SRD настольных ролевых игр в экосистеме OmnisGM.`,
-  `${searchTitle} — ${sysLabel} ${verLabel}. Tabletop RPG System Reference Document in the OmnisGM ecosystem.`,
-);
+
+// Класс-страницы (напр. /classes/rogue/) — самый крупный кластер кириллического спроса
+// («плут днд»: 513 запросов, issue #173). Даём содержательный сниппет из умений 1-го уровня
+// класса вместо бойлерплейта; если умений не извлекли — откат к общему шаблону ниже.
+const isClass = ref.game === 'dnd' && ref.slug.startsWith('classes/');
+const description =
+  (isClass
+    ? classDescription({ name: searchTitle, body: entry.body, lang: ref.lang, version: ref.version, verLabel })
+    : null) ??
+  t(
+    `${searchTitle} — ${sysLabel} ${verLabel} на русском. SRD настольных ролевых игр в экосистеме OmnisGM.`,
+    `${searchTitle} — ${sysLabel} ${verLabel}. Tabletop RPG System Reference Document in the OmnisGM ecosystem.`,
+  );
 ---
 <ReaderShell
   lang={ref.lang}

--- a/web/src/pages/[lang]/dnd/[version]/armor/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/armor/[slug].astro
@@ -69,10 +69,11 @@ if (isShield) {
 
 // Подстрока в шапке: «Средний доспех» / «Medium armor»; для щита — просто «Щит»/«Shield».
 const subLine = isShield ? catLabel : t(`${catLabel} доспех`, `${catLabel} armor`);
+// «(днд)» — кириллическая форма запросов (issue #173, п.2), одна встреча рядом с «D&D».
 const description = isShield
-  ? t(`${entity.name} — щит, +${acBase} к КД. D&D ${verLabel}.`,
+  ? t(`${entity.name} — щит, +${acBase} к КД. D&D ${verLabel} (днд).`,
       `${entity.name} — shield, +${acBase} AC. D&D ${verLabel}.`)
-  : t(`${entity.name} — ${catLabel.toLowerCase()} доспех, КД ${acLine}. D&D ${verLabel}.`,
+  : t(`${entity.name} — ${catLabel.toLowerCase()} доспех, КД ${acLine}. D&D ${verLabel} (днд).`,
       `${entity.name} — ${catLabel.toLowerCase()} armor, AC ${acLine}. D&D ${verLabel}.`);
 
 const base = `/${lang}/dnd/${verSlug}/armor`;

--- a/web/src/pages/[lang]/dnd/[version]/weapons/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/weapons/[slug].astro
@@ -99,8 +99,9 @@ const subLine = t(
   `${catLabel} оружие ${typeLabel}`,
   `${catLabel} ${typeLabel.toLowerCase()} weapon`,
 );
+// «(днд)» — кириллическая форма запросов (issue #173, п.2), одна встреча рядом с «D&D».
 const description = t(
-  `${entity.name} — ${catLabel.toLowerCase()} оружие ${typeLabel}, урон ${damageLine}. D&D ${verLabel}.`,
+  `${entity.name} — ${catLabel.toLowerCase()} оружие ${typeLabel}, урон ${damageLine}. D&D ${verLabel} (днд).`,
   `${entity.name} — ${catLabel.toLowerCase()} ${typeLabel.toLowerCase()} weapon, ${damageLine} damage. D&D ${verLabel}.`,
 );
 


### PR DESCRIPTION
Частично закрывает #173 (п.1–3). Refs #173 — ишью остаётся открытым до п.4–5 (переобход в Вебмастере, контрольная точка через 2–4 недели).

## Проблема
Выгрузка Яндекс.Вебмастера: сайт распробован (1251 запрос в топ-10), но клики не отдаёт — на позициях 6–13 наш сниппет проигрывает конкурентам. Крупнейший кластер — «плут днд» (513 запросов, поз. 12–13): класс-страницы отдавали бойлерплейт `«Плут — D&D SRD 5.2.1 на русском. SRD настольных ролевых игр…»`. Плюс кириллическая форма «днд» (в которой идёт спрос) не встречалась в description вовсе.

## Что сделано

**П.1 — содержательный description класс-страниц**
- `web/src/lib/class-facts.ts`: `level1Features(body)` тянет умения 1-го уровня прямо из таблицы прогрессии класса (колонка ищется по заголовку — формат таблиц 5.1/5.2 разъехался: в 5.1 колонка умений последняя, в 5.2 третья). Умения уже локализованы в контенте → перевод не дублируется и не дрейфует. `classDescription()` собирает сниппет; при неудаче парсинга — откат к прежнему бойлерплейту.
- `[...slug].astro`: класс-страницы D&D (`game==='dnd' && slug startsWith 'classes/'`) получают сниппет. Проверено на **всех 48 файлах** (12 классов × 5.1/5.2 × en/ru) — 0 провалов.

  > `Плут — класс D&D 2024 (днд): Экспертиза, Скрытая атака, Воровской жаргон. Умения по уровням 1–20, подклассы. Полные правила SRD 5.2.1 на русском.`

**П.2 — кириллическое «(днд)»**
- В классах — встроено в сниппет. В шаблонных RU-description оружия/доспехов — одна встреча рядом с «D&D» (`…D&D 5.2 (днд).`). EN не трогаем (кириллица нужна под кириллический спрос).

**П.3 — аудит бойлерплейта**
Единственный настоящий бойлерплейт — класс-страницы. species/backgrounds/feats (и equipment, magic-items, spells, monsters, terms…) уже на `excerpt(description_md)` — авто-выдержка из текста правила. Daggerheart-классы намеренно не тронуты (гейт на `game==='dnd'`).

## Проверки
- `npm run build` — 6010 страниц ✓
- `npm run check` (astro check) — 0 ошибок ✓
- `npm run test:e2e` — 176/176 ✓

## Остаётся владельцу (п.4–5)
- 🖐 Вебмастер: сверить версию по «плут днд» (5.1/5.2); переобход горячих URL после деплоя (rope, 5×наборы, oil, rogue, истощение, состояния, belt of giant strength).
- Контрольная точка через 2–4 недели: повторная выгрузка «Запросов».

🤖 Generated with [Claude Code](https://claude.com/claude-code)