### PR TITLE
chore(deps): @omnisgm-app/brand 0.7.1 → 0.8.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/sitemap": "^3.3.0",
-        "@omnisgm-app/brand": "^0.7.1",
+        "@omnisgm-app/brand": "^0.8.0",
         "astro": "^5.7.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-html": "^9.0.5",
@@ -2868,9 +2868,9 @@
       }
     },
     "node_modules/@omnisgm-app/brand": {
-      "version": "0.7.1",
-      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.7.1/727adf16ccd58944a694d4c1ee657e39327a7d0a",
-      "integrity": "sha512-w/X9JPWx0sCtlskFaImh8BQxM5mPI6iJFM3d4ulYatRCDd7LFX+WbZOa+QhBaZcbV7cN6f1+6p9rZI62IRDWxA=="
+      "version": "0.8.0",
+      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.8.0/264e9e703af385a96e98f1cac79e48460a1b3dfc",
+      "integrity": "sha512-bLgeaPm/vBBo3zQS3X4HN12gDsNUi1pB18zppx2rufOQjZpqZ1ftU6RoIr2ZDQ9C4qkH7oA/xj+eJY3VV4YSsQ=="
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.3.0",
-    "@omnisgm-app/brand": "^0.7.1",
+    "@omnisgm-app/brand": "^0.8.0",
     "astro": "^5.7.0",
     "hast-util-from-html": "^2.0.3",
     "hast-util-to-html": "^9.0.5",


### PR DESCRIPTION
Бренд-кит 0.8.0 опубликован в GitHub Packages (07.08.2026) — подтягиваем в Rules.

## Что в ките изменилось
Релиз аддитивный, `dist/components.css` +5 строк:
```css
.og-serif { font-family: var(--og-font-display); }
.og-mono  { font-family: var(--og-font-mono); }
.og-hr    { border: 0; border-top: 1px solid var(--og-border); margin: 0; }
```
Токены (`dist/tokens.css`), существующие компоненты и `dist/404.html` не тронуты — визуальных последствий для Rules нет.

## Проверка локально
- `astro check` — 0 errors, 0 warnings
- `astro build` — 6010 страниц
- `playwright test` — **176 passed**

Параллельно те же бампы уходят в News и Table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP