### PR TITLE
chore(deps): @omnisgm-app/brand 0.8.0 → 0.9.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/sitemap": "^3.3.0",
-        "@omnisgm-app/brand": "^0.8.0",
+        "@omnisgm-app/brand": "^0.9.0",
         "astro": "^5.7.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-html": "^9.0.5",
@@ -2868,9 +2868,9 @@
       }
     },
     "node_modules/@omnisgm-app/brand": {
-      "version": "0.8.0",
-      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.8.0/264e9e703af385a96e98f1cac79e48460a1b3dfc",
-      "integrity": "sha512-bLgeaPm/vBBo3zQS3X4HN12gDsNUi1pB18zppx2rufOQjZpqZ1ftU6RoIr2ZDQ9C4qkH7oA/xj+eJY3VV4YSsQ=="
+      "version": "0.9.0",
+      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.9.0/15ff6bab6ace3e1d5058ed5ce7cbf86629bdecec",
+      "integrity": "sha512-2g1ehtCeSkVVxN5XmUEFcYAplXryOWSHLetpFCrIGk8NANzRXtrlwOaWEbfC5b+te9ONT/hRF9wxye/lhTW0+w=="
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.3.0",
-    "@omnisgm-app/brand": "^0.8.0",
+    "@omnisgm-app/brand": "^0.9.0",
     "astro": "^5.7.0",
     "hast-util-from-html": "^2.0.3",
     "hast-util-to-html": "^9.0.5",


### PR DESCRIPTION
Кит 0.9.0 опубликован (07.08.2026, вслед за 0.8.0) — подтягиваем в Rules.

## Что в ките изменилось
- **Новые ассеты**: иконки приложений (`app-character` / `app-news` / `app-rules`), контурный знак, фоновые паттерны
- **`dist/tokens.css`**: тронуты **только комментарии** — добавлены `/* @kind font */` и `/* @kind other */` для классификатора панели DS. Значения токенов идентичны 0.8.0
- `build.mjs`: сборка новых ассетов

Визуальных последствий нет by construction.

## Про размер
Паттерны весят ~5 МБ, но в `public/` они **не попадают**: `web/scripts/copy-brand-assets.mjs` копирует по явной карте (плюс `assets/fonts/*.woff2`), а не рекурсивно весь `assets/`. Сборка не растёт.

## Проверка локально
- `astro check` — 0 errors, 0 warnings
- `astro build` — 6010 страниц
- `playwright test` — **176 passed**

Те же бампы идут в News (#51) и Table (#299 подтянут до 0.9.0 прямо в открытой ветке).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP