### PR TITLE
IndexNow: стриминг только изменённых URL вместо полного sitemap (#186)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,11 @@ on:
       - '.github/scripts/**'
       - 'firebase.json'
   workflow_dispatch:
+    inputs:
+      full_ping:
+        description: 'IndexNow: пингануть ВЕСЬ sitemap (только при смене домена/структуры URL)'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -105,41 +110,84 @@ jobs:
           echo "$resp" | grep -q '"success":true' || { echo "❌ Cloudflare purge не удался"; exit 1; }
           echo "✔ Cloudflare: edge-кэш фикс-файлов rules.omnisgm.com сброшен"
 
-      # IndexNow — мгновенный пинг Bing + Яндекс о задеплоенных страницах (#17).
-      # URL берём из свежесобранного web/dist/sitemap-0.xml (predeploy собрал его тем же билдом,
-      # что ушёл на хостинг) — только реально существующие URL, битых не шлём. Для нового сайта
-      # на первичной индексации шлём весь набор (~177 URL после исключения glossary из
-      # sitemap, см. #37; лимит IndexNow — 10 000/запрос).
-      # KEY — публичный по дизайну, лежит в web/public/${KEY}.txt и совпадает с этой строкой.
+      # IndexNow — стриминг ТОЛЬКО изменённых URL (#186; заведён в #17).
       #
-      # ВАЖНО: это best-effort уведомление ПОСЛЕ уже успешного деплоя — оно НЕ должно ронять ран.
-      # Любой не-2xx (в т.ч. 403 SiteVerificationNotCompleted при самом первом пинге, пока движок
-      # не подтянул ключ-файл) → ::warning::, exit 0. Сайт от этого не страдает; следующий деплой
-      # после завершения верификации вернёт 200/202.
+      # Раньше слали весь sitemap на каждом деплое (5975 URL), из-за чего Bing показывал
+      # рекомендацию «IndexNow is in batch mode». Теперь: манифест «URL → сигнатура содержимого»
+      # кладётся в кэш, следующий деплой берёт прошлый манифест и шлёт разницу.
+      #
+      # Сигнатура — <title> + description + текст страницы без разметки, а не хеш файла: Astro
+      # штампует хеши в имена ассетов и классов, побайтовое сравнение показывало бы «изменилось
+      # всё» каждый раз. Проверено локально: пересборка без правок и правка CSS дают 0 URL,
+      # правка одного файла контента — ровно 1.
+      - name: Восстановить прошлый манифест IndexNow
+        if: success()
+        uses: actions/cache/restore@v4
+        with:
+          path: web/.indexnow/manifest.json
+          key: indexnow-manifest-${{ github.sha }}
+          restore-keys: indexnow-manifest-
+
       - name: IndexNow ping
         if: success()
         env:
           KEY: 94c855220fc93a1e6ccdc3f67fdfbb92
+          FULL: ${{ inputs.full_ping }}
         run: |
+          set -euo pipefail
           host="rules.omnisgm.com"
-          urls=$(grep -ohE '<loc>[^<]+</loc>' web/dist/sitemap-[0-9]*.xml 2>/dev/null | sed -E 's#</?loc>##g')
-          n=$(printf '%s\n' "$urls" | grep -c . || true)
-          if [ "$n" -eq 0 ]; then echo "::warning::IndexNow: sitemap пуст — пинг пропущен."; exit 0; fi
-          # Payload в файл (не в аргумент curl): при >~1500 URL строка --data "$payload"
-          # перешагивает ARG_MAX → «curl: Argument list too long» (грабли #20, sitemap вырос
-          # на страницы животных). --data-binary @file снимает лимит.
-          printf '%s\n' "$urls" | grep . | jq -R . \
-            | jq -sc --arg h "$host" --arg k "$KEY" --arg kl "https://$host/$KEY.txt" \
-                '{host:$h,key:$k,keyLocation:$kl,urlList:.}' > /tmp/indexnow.json
-          resp=$(curl -s -w '\n%{http_code}' -X POST 'https://api.indexnow.org/indexnow' \
-            -H 'Content-Type: application/json; charset=utf-8' --data-binary @/tmp/indexnow.json)
-          code=$(printf '%s' "$resp" | tail -n1)
-          body=$(printf '%s\n' "$resp" | sed '$d')
-          echo "IndexNow: $n URL, HTTP $code"
-          [ -n "$body" ] && echo "$body"
-          case "$code" in
-            200|202) echo "✔ IndexNow принял пинг ($code)";;
-            403) echo "::warning::IndexNow вернул 403 (вероятно верификация ключа ещё идёт) — деплой не затронут, следующий пинг пройдёт.";;
-            *)   echo "::warning::IndexNow вернул $code — пинг best-effort, деплой не затронут.";;
-          esac
+          cd web
+          # Кэш кладёт файл по тому же пути, под которым его сохранили, поэтому прошлый
+          # манифест приезжает как manifest.json — переименовываем, чтобы не перезаписать.
+          mkdir -p .indexnow
+          [ -f .indexnow/manifest.json ] && mv .indexnow/manifest.json .indexnow/prev.json || true
+          # Верхний предел на один прогон: массовая правка шаблона меняет сигнатуру у всех
+          # страниц, и слать 6000 URL — это ровно тот batch-режим, от которого уходим.
+          # Скрипт сортирует изменённые по длине пути, поэтому первыми идут хабы и классы.
+          MAX=1000
+
+          if [ "${FULL:-false}" = "true" ]; then
+            grep -ohE '<loc>[^<]+</loc>' dist/sitemap-[0-9]*.xml | sed -E 's#</?loc>##g' > /tmp/urls.txt
+            echo "::warning::Аварийный режим: шлём ВЕСЬ sitemap ($(wc -l < /tmp/urls.txt) URL)."
+          else
+            node scripts/indexnow_manifest.mjs \
+              --out .indexnow/manifest.json \
+              --prev .indexnow/prev.json \
+              --changed /tmp/urls.txt
+          fi
+
+          n=$(grep -c . /tmp/urls.txt || true)
+          if [ "$n" -eq 0 ]; then echo "IndexNow: изменённых URL нет — пинг не нужен."; exit 0; fi
+          if [ "$n" -gt "$MAX" ]; then
+            echo "::warning::IndexNow: изменилось $n URL, шлём первые $MAX (короткие пути — хабы и классы). Остальные $((n - MAX)) найдутся обходом по sitemap."
+            head -n "$MAX" /tmp/urls.txt > /tmp/urls.capped.txt && mv /tmp/urls.capped.txt /tmp/urls.txt
+            n=$MAX
+          fi
+
+          # Порции по 100 URL с паузой — «streaming» в терминах рекомендации Bing.
+          split -l 100 /tmp/urls.txt /tmp/indexnow-batch-
+          sent=0; failed=0
+          for batch in /tmp/indexnow-batch-*; do
+            jq -R . < "$batch" | jq -sc --arg h "$host" --arg k "$KEY" --arg kl "https://$host/$KEY.txt" \
+              '{host:$h,key:$k,keyLocation:$kl,urlList:.}' > /tmp/indexnow.json
+            code=$(curl -s -o /tmp/indexnow.resp -w '%{http_code}' -X POST 'https://api.indexnow.org/indexnow' \
+              -H 'Content-Type: application/json; charset=utf-8' --data-binary @/tmp/indexnow.json)
+            cnt=$(grep -c . "$batch")
+            case "$code" in
+              200|202) sent=$((sent + cnt)); echo "  ✔ порция $cnt URL — HTTP $code";;
+              *) failed=$((failed + 1)); echo "::warning::порция $cnt URL — HTTP $code: $(cat /tmp/indexnow.resp)";;
+            esac
+            sleep 2
+          done
+          echo "IndexNow: отправлено $sent из $n URL, неуспешных порций: $failed"
+          # Пинг — best-effort уведомление ПОСЛЕ успешного деплоя: он не должен ронять ран.
           exit 0
+
+      # Манифест сохраняем ТОЛЬКО после успешного пинга: иначе следующий деплой сравнил бы
+      # свежий манифест с этим же и решил, что менять нечего, — изменения потерялись бы молча.
+      - name: Сохранить манифест IndexNow
+        if: success() && inputs.full_ping != true
+        uses: actions/cache/save@v4
+        with:
+          path: web/.indexnow/manifest.json
+          key: indexnow-manifest-${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,6 +129,7 @@ jobs:
           restore-keys: indexnow-manifest-
 
       - name: IndexNow ping
+        id: indexnow
         if: success()
         env:
           KEY: 94c855220fc93a1e6ccdc3f67fdfbb92
@@ -157,14 +158,24 @@ jobs:
           fi
 
           n=$(grep -c . /tmp/urls.txt || true)
-          if [ "$n" -eq 0 ]; then echo "IndexNow: изменённых URL нет — пинг не нужен."; exit 0; fi
-          if [ "$n" -gt "$MAX" ]; then
+          if [ "$n" -eq 0 ]; then
+            echo "IndexNow: изменённых URL нет — пинг не нужен."
+            echo "pinged=true" >> "$GITHUB_OUTPUT"   # менять нечего — база актуальна, сохраняем
+            exit 0
+          fi
+          # Кап — только для обычного режима. В аварийном (full_ping) он отменял бы саму функцию:
+          # флаг заведён ради смены домена/структуры URL, там нужен именно полный прогон.
+          if [ "${FULL:-false}" != "true" ] && [ "$n" -gt "$MAX" ]; then
             echo "::warning::IndexNow: изменилось $n URL, шлём первые $MAX (короткие пути — хабы и классы). Остальные $((n - MAX)) найдутся обходом по sitemap."
             head -n "$MAX" /tmp/urls.txt > /tmp/urls.capped.txt && mv /tmp/urls.capped.txt /tmp/urls.txt
             n=$MAX
           fi
 
           # Порции по 100 URL с паузой — «streaming» в терминах рекомендации Bing.
+          # Чистим хвосты прошлого прогона: при повторном запуске job (re-run) старые файлы
+          # порций остались бы в /tmp и попали в цикл — счётчик отправленного врал бы, а часть
+          # URL ушла бы дважды. Поймано на локальном стенде.
+          rm -f /tmp/indexnow-batch-*
           split -l 100 /tmp/urls.txt /tmp/indexnow-batch-
           sent=0; failed=0
           for batch in /tmp/indexnow-batch-*; do
@@ -180,13 +191,27 @@ jobs:
             sleep 2
           done
           echo "IndexNow: отправлено $sent из $n URL, неуспешных порций: $failed"
+          # Манифест сохраняем, только если хоть что-то ушло. Шаг всегда завершается exit 0
+          # (best-effort, деплой ронять нельзя), поэтому одного `if: success()` на шаге
+          # сохранения мало: при 403-окне переверификации ключа или аварии API манифест
+          # обновился бы, а изменения не ушли бы НИКОГДА (ревью #190).
+          # Частичный успех сохраняем сознательно: повторно отправить ушедшее дешевле,
+          # чем потерять неушедшее.
+          if [ "$sent" -eq 0 ]; then
+            echo "::warning::IndexNow: не ушла ни одна порция — манифест НЕ сохраняем, следующий деплой отправит эти URL снова."
+            echo "pinged=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "pinged=true" >> "$GITHUB_OUTPUT"
+          fi
           # Пинг — best-effort уведомление ПОСЛЕ успешного деплоя: он не должен ронять ран.
           exit 0
 
-      # Манифест сохраняем ТОЛЬКО после успешного пинга: иначе следующий деплой сравнил бы
-      # свежий манифест с этим же и решил, что менять нечего, — изменения потерялись бы молча.
+      # Манифест сохраняем только когда пинг реально ушёл (steps.indexnow.outputs.pinged):
+      # иначе следующий деплой сравнил бы свежий манифест с этим же и решил, что менять
+      # нечего, — изменения потерялись бы молча. В аварийном full-режиме манифест не пишется
+      # вовсе, поэтому шаг пропускается.
       - name: Сохранить манифест IndexNow
-        if: success() && inputs.full_ping != true
+        if: success() && steps.indexnow.outputs.pinged == 'true' && inputs.full_ping != true
         uses: actions/cache/save@v4
         with:
           path: web/.indexnow/manifest.json

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -23,3 +23,4 @@ public/fonts/
 
 # Сгенерированные данные сущностей для programmatic-страниц (prebuild)
 src/data/api/
+.indexnow/

--- a/web/scripts/indexnow_manifest.mjs
+++ b/web/scripts/indexnow_manifest.mjs
@@ -1,0 +1,122 @@
+// Манифест сигнатур страниц для стриминга IndexNow — issue #186.
+//
+// Зачем: deploy.yml пинговал IndexNow ВЕСЬ sitemap на каждом деплое (5975 URL за раз), из-за
+// чего Bing показывает рекомендацию «IndexNow is in batch mode» и советует слать только
+// изменённые URL. Чтобы слать изменённые, их надо уметь считать — а сравнивать не с чем:
+// прошлой сборки на раннере нет.
+//
+// Решение: после каждой сборки пишем манифест «URL → сигнатура содержимого», а прошлый
+// манифест приносим из кэша GitHub Actions. Разница двух манифестов и есть список изменённых.
+//
+// Сигнатура НЕ хеш файла: Astro штампует хеши в имена ассетов и в имена классов, поэтому
+// побайтовое сравнение показывало бы «изменилось всё» на каждой сборке. Берём то, что видит
+// поисковик: <title>, meta description и ТЕКСТ страницы без разметки. Правка стилей сигнатуру
+// не двигает, правка шаблона мета или контента — двигает.
+//
+// Использование:
+//   node scripts/indexnow_manifest.mjs --out .indexnow/manifest.json
+//   node scripts/indexnow_manifest.mjs --out new.json --prev old.json --changed changed.txt
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { dirname, resolve, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const DIST = resolve(here, '../dist');
+const ORIGIN = 'https://rules.omnisgm.com';
+
+const arg = (name, fallback = null) => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i > -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+};
+
+function* htmlFiles(dir) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = resolve(dir, e.name);
+    if (e.isDirectory()) yield* htmlFiles(p);
+    else if (e.name.endsWith('.html')) yield p;
+  }
+}
+
+// Файл dist → канонический URL страницы (index.html → директория со слэшем).
+const urlFor = (file) => {
+  const rel = relative(DIST, file).split(sep).join('/');
+  return `${ORIGIN}/${rel === 'index.html' ? '' : rel.replace(/index\.html$/, '')}`;
+};
+
+// Видимый поисковику текст: снимаем script/style целиком, затем теги, схлопываем пробелы.
+const textOf = (html) =>
+  html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const signature = (html) => {
+  const head = html.slice(0, html.indexOf('</head>'));
+  const body = html.slice(html.indexOf('</head>'));
+  const title = (head.match(/<title>([^<]*)<\/title>/) || [, ''])[1];
+  const desc = (head.match(/<meta\s+name="description"\s+content="([^"]*)"/) || [, ''])[1];
+  return createHash('sha1').update(`${title}\n${desc}\n${textOf(body)}`).digest('hex').slice(0, 16);
+};
+
+// Индексируемый набор — ровно то, что в sitemap: там уже нет noindex-страниц (#37) и нет
+// служебных вроде 404.html. Пинговать что-то помимо него — тратить квоту и слать поисковику
+// то, что мы сами закрыли. Если sitemap не нашёлся, страхуемся и не фильтруем (кроме 404).
+const sitemapUrls = new Set();
+for (const f of readdirSync(DIST)) {
+  if (!/^sitemap-\d+\.xml$/.test(f)) continue;
+  for (const m of readFileSync(resolve(DIST, f), 'utf8').matchAll(/<loc>([^<]+)<\/loc>/g)) {
+    sitemapUrls.add(m[1].trim());
+  }
+}
+const indexable = (url) =>
+  sitemapUrls.size ? sitemapUrls.has(url) : !url.endsWith('/404.html');
+
+const manifest = {};
+let skipped = 0;
+for (const file of htmlFiles(DIST)) {
+  const url = urlFor(file);
+  if (!indexable(url)) { skipped++; continue; }
+  manifest[url] = signature(readFileSync(file, 'utf8'));
+}
+
+const outPath = arg('out');
+if (!outPath) {
+  console.error('Не задан --out');
+  process.exit(2);
+}
+mkdirSync(dirname(resolve(outPath)), { recursive: true });
+writeFileSync(resolve(outPath), JSON.stringify(manifest));
+console.log(
+  `Манифест: ${Object.keys(manifest).length} страниц → ${outPath}` +
+    (skipped ? ` (вне sitemap пропущено ${skipped})` : ''),
+);
+
+const prevPath = arg('prev');
+const changedPath = arg('changed');
+if (!prevPath || !changedPath) process.exit(0);
+
+if (!existsSync(resolve(prevPath))) {
+  // Первый запуск или кэш истёк. Пинговать всё — значит вернуться ровно в тот batch-режим,
+  // от которого уходим, поэтому не пингуем: страницы всё равно найдутся через sitemap и
+  // Cloudflare Crawler Hints, а следующий деплой уже посчитает нормальный дифф.
+  writeFileSync(resolve(changedPath), '');
+  console.log(`::notice::Прошлого манифеста нет (${prevPath}) — пинг пропущен, база записана.`);
+  process.exit(0);
+}
+
+const prev = JSON.parse(readFileSync(resolve(prevPath), 'utf8'));
+const changed = Object.keys(manifest).filter((url) => prev[url] !== manifest[url]);
+const added = changed.filter((url) => !(url in prev));
+
+// Порядок отправки: сначала короткие пути. Хабы и страницы классов лежат выше по дереву и
+// стоят дороже длинного хвоста сущностей — если сработает верхний предел, отрежется хвост.
+changed.sort((a, b) => a.length - b.length || a.localeCompare(b));
+
+writeFileSync(resolve(changedPath), changed.join('\n') + (changed.length ? '\n' : ''));
+console.log(
+  `Изменилось: ${changed.length} из ${Object.keys(manifest).length} страниц ` +
+    `(новых ${added.length}, было в прошлом манифесте ${Object.keys(prev).length})`,
+);


### PR DESCRIPTION
Bing показывает рекомендацию «IndexNow is in batch mode»: `deploy.yml` слал **весь** sitemap на каждом деплое — 5975 URL, независимо от того, что менялось. Сегодня их ушло три подряд (14:36, 15:06, 15:16 UTC), то есть это не разовая июльская история, а штатное поведение каждого релиза.

## Проблема, которую пришлось решить первой

Чтобы слать «только изменённые», их надо уметь **считать** — а сравнивать не с чем: прошлой сборки на раннере нет. Диффа по git-файлам мало: правка одного `.md` меняет не только свою страницу, а правка шаблона — вообще все.

Решение: манифест «URL → сигнатура содержимого», который переносится между деплоями через кэш GitHub Actions. Разница двух манифестов и есть список изменённых URL.

## Сигнатура — не хеш файла

Astro штампует хеши в имена ассетов и классов, поэтому побайтовое сравнение показывало бы «изменилось всё» на каждой сборке. Берём то, что видит поисковик: `<title>` + `description` + текст страницы **без разметки**.

Проверено локально на реальном `dist` (6010 страниц):

| сценарий | изменённых URL |
|---|---|
| пересборка без единой правки | **0** |
| правка CSS (`letter-spacing` в крошке) | **0** |
| правка одного файла контента (`09_Rogue.md`) | **1** — `/ru/dnd/srd-5.2/classes/rogue/` |
| подложенный манифест с 250 расхождениями | 250 URL, 3 порции по 100 |
| прошлого манифеста нет | пустой список + `::notice::` |

## Что ещё внутри

- **Набор страниц берём из sitemap**, а не обходом `dist`: там уже нет noindex-страниц (#37) и служебных вроде `404.html` — незачем тратить квоту на то, что сами закрыли. Число сошлось со старым пингом: 5975.
- **Порции по 100 URL на POST с паузой 2 с** — «streaming» в терминах рекомендации Bing.
- **Верхний предел 1000 URL на прогон.** Массовая правка шаблона (как #187) двигает сигнатуру у всех страниц, и слать 6000 — ровно то, от чего уходим. Отсечённое **не замалчивается**: `::warning::` с числом, а изменённые отсортированы по длине пути, поэтому хабы и классы уходят первыми, а обрезается длинный хвост сущностей.
- **Нет прошлого манифеста** (первый запуск, истёк кэш) — не пингуем ничего и пишем notice. Слать всё в этом случае значило бы вернуться в batch-режим; страницы найдутся обходом sitemap, а следующий деплой посчитает нормальный дифф.
- **Аварийный полный пинг остался**, но теперь только руками: `workflow_dispatch` с флагом `full_ping` — для смены домена или структуры URL.
- Манифест кладётся в кэш только после успешного пинга: иначе следующий деплой сравнил бы свежий манифест сам с собой и молча потерял изменения.

## Чего этот PR не делает

- **Cloudflare Crawler Hints** (пункт 3 ишью) не трогаю: он работает на edge независимо, а наш пинг теперь не рутинный шум, а именно события изменения — дублирования нет.
- **Проверка, что рекомендация в Bing ушла** (пункт 4) — только после пары релизов, руками в Webmaster Tools.

## Что будет на первом деплое после мержа

Кэша ещё нет → пинг пропускается, пишется notice, манифест сохраняется как база. Первый настоящий стриминговый пинг уйдёт со следующего деплоя. Это ожидаемо и лучше альтернативы (ещё один пинг на 5975 URL).

Refs #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP