### PR TITLE
Cloudflare: точечный purge изменённых URL после деплоя (#175)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,16 @@ jobs:
       - name: Мета-бюджет по dist (дубли description, длина title)
         working-directory: web
         run: node scripts/verify_dist_meta_budget.mjs
+
+      # Смоук скриптов деплоя (#175/#186): они гоняются только в deploy.yml, где поломка
+      # обнаружилась бы уже после выката. Здесь проверяем, что оба отрабатывают на свежем dist
+      # и находят непустой набор URL. /api/ в CI нет (его делает firebase predeploy) — скрипт
+      # это переживает, поэтому список короче боевого.
+      - name: Смоук скриптов деплоя (манифест IndexNow, purge-список Cloudflare)
+        working-directory: web
+        run: |
+          set -euo pipefail
+          node scripts/indexnow_manifest.mjs --out /tmp/manifest.json
+          node scripts/cf_purge_urls.mjs --out /tmp/purge.txt
+          grep -q 'sitemap-index.xml' /tmp/purge.txt || { echo "❌ purge-список без sitemap — сломан сбор фикс-имён"; exit 1; }
+          test "$(grep -c . /tmp/purge.txt)" -ge 10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,7 +98,6 @@ jobs:
           restore-keys: indexnow-manifest-
 
       - name: Дифф сборки (изменённые и исчезнувшие URL)
-        id: diff
         if: success()
         env:
           FULL: ${{ inputs.full_ping }}
@@ -124,9 +123,6 @@ jobs:
               --changed /tmp/urls.txt \
               --removed /tmp/removed.txt
           fi
-
-          echo "changed=$(grep -c . /tmp/urls.txt || true)" >> "$GITHUB_OUTPUT"
-          echo "removed=$(grep -c . /tmp/removed.txt || true)" >> "$GITHUB_OUTPUT"
 
       # Сброс edge-кэша Cloudflare после деплоя (#175). Точечно по URL, а не «purge everything»:
       # зона одна на весь omnisgm.com, полный сброс выносит заодно кэш News и Table. Purge по
@@ -156,8 +152,12 @@ jobs:
               -H "Content-Type: application/json" --data "$1"
           }
 
+          # Шаг сознательно без `set -e` (ошибки порций разбираем сами), поэтому падение
+          # скрипта проверяем явно: иначе дальше насчитается ok=0 и шаг умрёт с сообщением
+          # «не сброшено ничего» — красный, но с неверным диагнозом (ревью #192).
           node web/scripts/cf_purge_urls.mjs \
-            --out /tmp/purge.txt --changed /tmp/urls.txt --removed /tmp/removed.txt
+            --out /tmp/purge.txt --changed /tmp/urls.txt --removed /tmp/removed.txt \
+            || { echo "❌ cf_purge_urls.mjs не отработал — purge-список не собран"; exit 1; }
 
           PURGE_MAX_BATCHES=40   # 40 × 30 URL = 1200 адресов, дальше выгоднее сбросить зону
           total=$(grep -c . /tmp/purge.txt || true)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,41 +80,10 @@ jobs:
           # Без переменной блок Метрики тихо не грузится (gated в analytics-client.ts).
           PUBLIC_METRIKA_ID: ${{ vars.PUBLIC_METRIKA_ID }}
 
-      # Сброс edge-кэша Cloudflare после деплоя — точечно, фикс-имена на rules.omnisgm.com
-      # (иконки/favicon/manifest/sw/og кэшируются на edge; HTML/хэш-ассеты не трогаем).
-      # Без секретов CLOUDFLARE_* шаг тихо пропускается.
-      - name: Purge Cloudflare cache
-        if: success()
-        env:
-          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-        run: |
-          if [ -z "$CF_API_TOKEN" ] || [ -z "$CF_ZONE_ID" ]; then
-            echo "Cloudflare-секреты не заданы — purge пропущен."
-            exit 0
-          fi
-          base="https://rules.omnisgm.com"
-          files=$(printf '"%s",' \
-            "$base/favicon.svg" "$base/favicon.ico" "$base/icon.svg" "$base/maskable.svg" \
-            "$base/robots.txt" "$base/sitemap-index.xml" "$base/sitemap-0.xml" "$base/llms.txt" \
-            "$base/icon-192.png" "$base/icon-512.png" \
-            "$base/maskable-192.png" "$base/maskable-512.png" \
-            "$base/apple-touch-icon.png" "$base/og.png" \
-            "$base/manifest.webmanifest" "$base/sw.js")
-          resp=$(curl -s -X POST \
-            "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/purge_cache" \
-            -H "Authorization: Bearer $CF_API_TOKEN" \
-            -H "Content-Type: application/json" \
-            --data "{\"files\":[${files%,}]}")
-          echo "$resp"
-          echo "$resp" | grep -q '"success":true' || { echo "❌ Cloudflare purge не удался"; exit 1; }
-          echo "✔ Cloudflare: edge-кэш фикс-файлов rules.omnisgm.com сброшен"
-
-      # IndexNow — стриминг ТОЛЬКО изменённых URL (#186; заведён в #17).
-      #
-      # Раньше слали весь sitemap на каждом деплое (5975 URL), из-за чего Bing показывал
-      # рекомендацию «IndexNow is in batch mode». Теперь: манифест «URL → сигнатура содержимого»
-      # кладётся в кэш, следующий деплой берёт прошлый манифест и шлёт разницу.
+      # Диффом сборки пользуются ДВА шага ниже — purge Cloudflare (#175) и пинг IndexNow (#186),
+      # поэтому он считается один раз здесь, до них обоих. Порядок именно такой: сначала выбить
+      # старое из edge-кэша, потом звать поисковик — иначе краулер придёт на закэшированную
+      # прошлую версию страницы.
       #
       # Сигнатура — <title> + description + текст страницы без разметки, а не хеш файла: Astro
       # штампует хеши в имена ассетов и классов, побайтовое сравнение показывало бы «изменилось
@@ -128,6 +97,104 @@ jobs:
           key: indexnow-manifest-${{ github.sha }}
           restore-keys: indexnow-manifest-
 
+      - name: Дифф сборки (изменённые и исчезнувшие URL)
+        id: diff
+        if: success()
+        env:
+          FULL: ${{ inputs.full_ping }}
+        run: |
+          set -euo pipefail
+          cd web
+          # Кэш кладёт файл по тому же пути, под которым его сохранили, поэтому прошлый
+          # манифест приезжает как manifest.json — переименовываем, чтобы не перезаписать.
+          mkdir -p .indexnow
+          [ -f .indexnow/manifest.json ] && mv .indexnow/manifest.json .indexnow/prev.json || true
+          # Файлы должны существовать даже когда прошлого манифеста нет: скрипт в этом случае
+          # выходит раньше, а читают их шаги ниже.
+          : > /tmp/urls.txt
+          : > /tmp/removed.txt
+
+          if [ "${FULL:-false}" = "true" ]; then
+            grep -ohE '<loc>[^<]+</loc>' dist/sitemap-[0-9]*.xml | sed -E 's#</?loc>##g' > /tmp/urls.txt
+            echo "::warning::Аварийный режим: шлём ВЕСЬ sitemap ($(wc -l < /tmp/urls.txt) URL)."
+          else
+            node scripts/indexnow_manifest.mjs \
+              --out .indexnow/manifest.json \
+              --prev .indexnow/prev.json \
+              --changed /tmp/urls.txt \
+              --removed /tmp/removed.txt
+          fi
+
+          echo "changed=$(grep -c . /tmp/urls.txt || true)" >> "$GITHUB_OUTPUT"
+          echo "removed=$(grep -c . /tmp/removed.txt || true)" >> "$GITHUB_OUTPUT"
+
+      # Сброс edge-кэша Cloudflare после деплоя (#175). Точечно по URL, а не «purge everything»:
+      # зона одна на весь omnisgm.com, полный сброс выносит заодно кэш News и Table. Purge по
+      # префиксу/хосту в Cloudflare — только на Enterprise, поэтому список URL собираем сами:
+      # изменённые и исчезнувшие страницы + фикс-имена (sitemap/robots/иконки/sw) + JSON API.
+      # Хэш-ассеты не нужны — новая сборка даёт новые имена.
+      #
+      # Порог: purge по URL идёт порциями по 30 (лимит API вне Enterprise). Когда правка задела
+      # столько страниц, что порций стало бы больше PURGE_MAX_BATCHES, дешевле один раз сбросить
+      # зону целиком — соседи прогреются заново, зато не ждём сотню запросов.
+      # Без секретов CLOUDFLARE_* шаг тихо пропускается.
+      - name: Purge Cloudflare cache
+        if: success()
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        run: |
+          set -uo pipefail
+          if [ -z "${CF_API_TOKEN:-}" ] || [ -z "${CF_ZONE_ID:-}" ]; then
+            echo "Cloudflare-секреты не заданы — purge пропущен."
+            exit 0
+          fi
+          api="https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/purge_cache"
+          call() {  # $1 — тело запроса
+            curl -s -X POST "$api" \
+              -H "Authorization: Bearer $CF_API_TOKEN" \
+              -H "Content-Type: application/json" --data "$1"
+          }
+
+          node web/scripts/cf_purge_urls.mjs \
+            --out /tmp/purge.txt --changed /tmp/urls.txt --removed /tmp/removed.txt
+
+          PURGE_MAX_BATCHES=40   # 40 × 30 URL = 1200 адресов, дальше выгоднее сбросить зону
+          total=$(grep -c . /tmp/purge.txt || true)
+          batches=$(( (total + 29) / 30 ))
+
+          if [ "$batches" -gt "$PURGE_MAX_BATCHES" ]; then
+            echo "::warning::Cloudflare: $total URL к сбросу — это $batches порций, сбрасываем зону целиком (заденет кэш News/Table, они прогреются)."
+            resp=$(call '{"purge_everything":true}')
+            echo "$resp" | grep -q '"success":true' \
+              || { echo "❌ Cloudflare purge_everything не удался: $resp"; exit 1; }
+            echo "✔ Cloudflare: зона сброшена целиком"
+            exit 0
+          fi
+
+          rm -f /tmp/cf-purge-batch-*
+          split -l 30 /tmp/purge.txt /tmp/cf-purge-batch-
+          ok=0; bad=0
+          for batch in /tmp/cf-purge-batch-*; do
+            body=$(jq -R . < "$batch" | jq -sc '{files: .}')
+            resp=$(call "$body")
+            if echo "$resp" | grep -q '"success":true'; then
+              ok=$((ok + $(grep -c . "$batch")))
+            else
+              bad=$((bad + 1)); echo "::warning::порция не сброшена: $resp"
+            fi
+          done
+          # Неуспешные порции сами по себе деплой не роняют: страница доживёт до конца TTL (час).
+          # А вот полный отказ — это несвежий сайт на эдже, о нём надо знать сразу.
+          [ "$ok" -gt 0 ] || { echo "❌ Cloudflare: не сброшено ничего ($bad порций с ошибкой)"; exit 1; }
+          echo "✔ Cloudflare: сброшено $ok из $total URL (неуспешных порций: $bad)"
+
+      # IndexNow — стриминг ТОЛЬКО изменённых URL (#186; заведён в #17).
+      #
+      # Раньше слали весь sitemap на каждом деплое (5975 URL), из-за чего Bing показывал
+      # рекомендацию «IndexNow is in batch mode». Теперь: манифест «URL → сигнатура содержимого»
+      # кладётся в кэш, следующий деплой берёт прошлый манифест и шлёт разницу. Сам дифф
+      # посчитан шагом «Дифф сборки» выше, здесь только отправка.
       - name: IndexNow ping
         id: indexnow
         if: success()
@@ -137,25 +204,10 @@ jobs:
         run: |
           set -euo pipefail
           host="rules.omnisgm.com"
-          cd web
-          # Кэш кладёт файл по тому же пути, под которым его сохранили, поэтому прошлый
-          # манифест приезжает как manifest.json — переименовываем, чтобы не перезаписать.
-          mkdir -p .indexnow
-          [ -f .indexnow/manifest.json ] && mv .indexnow/manifest.json .indexnow/prev.json || true
           # Верхний предел на один прогон: массовая правка шаблона меняет сигнатуру у всех
           # страниц, и слать 6000 URL — это ровно тот batch-режим, от которого уходим.
           # Скрипт сортирует изменённые по длине пути, поэтому первыми идут хабы и классы.
           MAX=1000
-
-          if [ "${FULL:-false}" = "true" ]; then
-            grep -ohE '<loc>[^<]+</loc>' dist/sitemap-[0-9]*.xml | sed -E 's#</?loc>##g' > /tmp/urls.txt
-            echo "::warning::Аварийный режим: шлём ВЕСЬ sitemap ($(wc -l < /tmp/urls.txt) URL)."
-          else
-            node scripts/indexnow_manifest.mjs \
-              --out .indexnow/manifest.json \
-              --prev .indexnow/prev.json \
-              --changed /tmp/urls.txt
-          fi
 
           n=$(grep -c . /tmp/urls.txt || true)
           if [ "$n" -eq 0 ]; then

--- a/web/scripts/cf_purge_urls.mjs
+++ b/web/scripts/cf_purge_urls.mjs
@@ -1,0 +1,90 @@
+// Список URL для точечного purge edge-кэша Cloudflare после деплоя — issue #175.
+//
+// Зачем не «purge everything»: зона в Cloudflare одна на весь omnisgm.com, и полный сброс
+// выносит заодно кэш News и Table. Раз в квартал это не жалко, а на каждом деплое Rules —
+// соседи постоянно ходят с холодным кэшем. Purge по префиксу/хосту в Cloudflare доступен
+// только на Enterprise, поэтому точечный список URL — единственный способ сбросить своё,
+// не трогая чужое.
+//
+// Что попадает в список:
+//   • страницы, чьё содержимое изменилось (--changed, считает indexnow_manifest.mjs);
+//   • страницы, которые исчезли (--removed) — иначе удалённый URL живёт на эдже до конца TTL;
+//   • файлы с ФИКСИРОВАННЫМИ именами: sitemap, robots, llms.txt, иконки, манифест, sw.js —
+//     их имена не меняются от сборки к сборке, поэтому сигнатурный дифф их не видит;
+//   • JSON API (/api/**) целиком — он пересобирается predeploy'ем на каждом деплое, в sitemap
+//     не входит и в манифест не попадает, а Cloudflare его кэширует наравне с остальным.
+//
+// Хэш-ассеты (/_astro/*.js|css) в список НЕ идут: их имена содержат хеш содержимого, новая
+// сборка = новые имена = промах кэша по определению. Сбрасывать старые бессмысленно.
+//
+// Использование:
+//   node scripts/cf_purge_urls.mjs --out /tmp/purge.txt [--changed changed.txt] [--removed removed.txt]
+import { readdirSync, readFileSync, writeFileSync, existsSync, statSync } from 'node:fs';
+import { dirname, resolve, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const DIST = resolve(here, '../dist');
+const ORIGIN = 'https://rules.omnisgm.com';
+
+const arg = (name, fallback = null) => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i > -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+};
+
+const lines = (path) =>
+  path && existsSync(resolve(path))
+    ? readFileSync(resolve(path), 'utf8').split('\n').map((s) => s.trim()).filter(Boolean)
+    : [];
+
+// Фикс-имена в корне dist. Перечислены явно, а не собраны по маске: список должен ломаться
+// заметно (файл исчез — его просто не будет в purge), а не молча разрастаться от случайных
+// файлов, попавших в корень сборки.
+const FIXED = [
+  'favicon.svg', 'favicon.ico', 'icon.svg', 'maskable.svg',
+  'icon-192.png', 'icon-512.png', 'maskable-192.png', 'maskable-512.png',
+  'apple-touch-icon.png', 'og.png',
+  'robots.txt', 'llms.txt', 'manifest.webmanifest', 'sw.js',
+  'sitemap-index.xml',
+];
+
+const urls = new Set();
+
+for (const name of FIXED) {
+  if (existsSync(resolve(DIST, name))) urls.add(`${ORIGIN}/${name}`);
+}
+// Пронумерованные sitemap-0.xml, -1.xml… — их количество растёт вместе с сайтом.
+for (const f of readdirSync(DIST)) {
+  if (/^sitemap-\d+\.xml$/.test(f)) urls.add(`${ORIGIN}/${f}`);
+}
+
+// JSON API целиком (обычно ~230 файлов) — вместе с его index.html-навигацией.
+const apiDir = resolve(DIST, 'api');
+function* walk(dir) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = resolve(dir, e.name);
+    if (e.isDirectory()) yield* walk(p);
+    else yield p;
+  }
+}
+if (existsSync(apiDir) && statSync(apiDir).isDirectory()) {
+  for (const file of walk(apiDir)) {
+    const rel = relative(DIST, file).split(sep).join('/');
+    // index.html отдаётся и как /api/dnd/, и как /api/dnd/index.html — кэшируются они
+    // отдельными записями, поэтому сбрасываем оба адреса.
+    urls.add(`${ORIGIN}/${rel}`);
+    if (rel.endsWith('/index.html')) urls.add(`${ORIGIN}/${rel.replace(/index\.html$/, '')}`);
+  }
+}
+
+for (const u of lines(arg('changed'))) urls.add(u);
+for (const u of lines(arg('removed'))) urls.add(u);
+
+const out = arg('out');
+if (!out) {
+  console.error('Не задан --out');
+  process.exit(2);
+}
+const list = [...urls];
+writeFileSync(resolve(out), list.join('\n') + (list.length ? '\n' : ''));
+console.log(`Purge-список: ${list.length} URL → ${out}`);

--- a/web/scripts/cf_purge_urls.mjs
+++ b/web/scripts/cf_purge_urls.mjs
@@ -77,8 +77,14 @@ if (existsSync(apiDir) && statSync(apiDir).isDirectory()) {
   }
 }
 
-for (const u of lines(arg('changed'))) urls.add(u);
-for (const u of lines(arg('removed'))) urls.add(u);
+// Страницы отдаются по двум адресам: канонический со слэшем и прямой /…/index.html. Firebase
+// второй НЕ редиректит (отдаёт 200 — проверено на проде), значит в кэше это две независимые
+// записи, и purge одной не трогает другую. Ссылок на index.html у нас нет, но краулер мог его
+// однажды дёрнуть — и тогда именно эта версия зависла бы до конца TTL (ревью #192).
+const withIndexHtml = (url) => (url.endsWith('/') ? [url, `${url}index.html`] : [url]);
+
+for (const u of lines(arg('changed'))) withIndexHtml(u).forEach((x) => urls.add(x));
+for (const u of lines(arg('removed'))) withIndexHtml(u).forEach((x) => urls.add(x));
 
 const out = arg('out');
 if (!out) {

--- a/web/scripts/check_edge_cache.sh
+++ b/web/scripts/check_edge_cache.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Проверка edge-кэша Cloudflare на rules.omnisgm.com — issue #175.
+#
+# Cache Rule включается руками в дашборде Cloudflare (API-токен деплоя умеет только purge),
+# поэтому проверка отдельная и ручная: запусти после включения правила и после деплоя.
+#
+#   bash web/scripts/check_edge_cache.sh
+#
+# Что должно получиться:
+#   • HTML-страницы и JSON API — HIT со второго запроса (кэшируются на эдже, egress не тратится);
+#   • sw.js и manifest.webmanifest — НЕ HIT никогда: origin отдаёт им no-cache, и правило обязано
+#     это уважать. Ровно на этом обжигались новости: CF закэшировал sw.js, и PWA-обновления
+#     переставали доходить до пользователей (см. omnisgm-news, Cloudflare-кэш).
+set -u
+BASE="${1:-https://rules.omnisgm.com}"
+
+status() {  # $1 — путь; печатает cf-cache-status
+  curl -sSI "$BASE$1" | tr -d '\r' | awk -F': ' 'tolower($1)=="cf-cache-status"{print $2}'
+}
+
+fail=0
+check() {  # $1 — путь, $2 — «cacheable» | «bypass»
+  local path="$1" want="$2"
+  status "$path" > /dev/null          # первый запрос — прогрев (MISS)
+  local st; st=$(status "$path")
+  case "$want" in
+    cacheable)
+      if [ "$st" = "HIT" ]; then echo "  ✔ $path — $st"
+      else echo "  ✘ $path — $st (ожидался HIT: правило не кэширует этот тип)"; fail=1; fi ;;
+    bypass)
+      if [ "$st" = "HIT" ]; then echo "  ✘ $path — HIT (origin отдаёт no-cache, кэшировать нельзя)"; fail=1
+      else echo "  ✔ $path — $st"; fi ;;
+  esac
+}
+
+echo "Edge-кэш $BASE"
+echo "Должны кэшироваться:"
+check "/ru/" cacheable
+check "/ru/dnd/srd-5.2/classes/rogue/" cacheable
+check "/api/" cacheable
+echo "Не должны кэшироваться (no-cache от origin):"
+check "/sw.js" bypass
+check "/manifest.webmanifest" bypass
+
+[ "$fail" -eq 0 ] && echo "Итог: edge-кэш настроен верно." || echo "Итог: есть расхождения — см. ✘ выше."
+exit "$fail"

--- a/web/scripts/indexnow_manifest.mjs
+++ b/web/scripts/indexnow_manifest.mjs
@@ -16,6 +16,7 @@
 // Использование:
 //   node scripts/indexnow_manifest.mjs --out .indexnow/manifest.json
 //   node scripts/indexnow_manifest.mjs --out new.json --prev old.json --changed changed.txt
+//   … --removed removed.txt   — URL, исчезнувшие с прошлой сборки (для purge Cloudflare, #175)
 import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { dirname, resolve, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -110,6 +111,17 @@ if (!existsSync(resolve(prevPath))) {
 const prev = JSON.parse(readFileSync(resolve(prevPath), 'utf8'));
 const changed = Object.keys(manifest).filter((url) => prev[url] !== manifest[url]);
 const added = changed.filter((url) => !(url in prev));
+
+// Исчезнувшие URL (были в прошлом манифесте, в новом их нет: переименован слаг, удалён раздел).
+// В IndexNow они не идут — там пингуют существующие адреса, а не «сходите посмотрите на 404».
+// А вот из edge-кэша Cloudflare их надо выбить, иначе удалённая страница живёт на эдже до
+// истечения TTL (#175). Поэтому список отдаётся отдельным файлом.
+const removed = Object.keys(prev).filter((url) => !(url in manifest));
+const removedPath = arg('removed');
+if (removedPath) {
+  writeFileSync(resolve(removedPath), removed.join('\n') + (removed.length ? '\n' : ''));
+  if (removed.length) console.log(`Исчезло: ${removed.length} URL → ${removedPath}`);
+}
 
 // Порядок отправки: сначала короткие пути. Хабы и страницы классов лежат выше по дереву и
 // стоят дороже длинного хвоста сущностей — если сработает верхний предел, отрежется хвост.


### PR DESCRIPTION
Код-часть #175. Готовит деплой к тому, что HTML начнёт кэшироваться на эдже; сама Cache Rule — ручной шаг владельца (инструкция в комментарии к ишью).

## Зачем

Сейчас purge сбрасывает только фикс-имена — иконки, sitemap, `sw.js`. HTML не кэшируется (`cf-cache-status: DYNAMIC`, проверил сегодня), поэтому этого хватало. После включения правила не хватит: страницы и JSON API висели бы на эдже до конца TTL, то есть до часа после выката.

## Почему не «purge everything»

Зона в Cloudflare одна на весь `omnisgm.com` — полный сброс выносит заодно кэш News и Table. Purge по префиксу или хосту доступен только на Enterprise, так что список URL собираем сами.

**Что в списке:**
- изменённые страницы — дифф сигнатур, он уже считался для IndexNow (#186);
- **исчезнувшие** страницы (`--removed`) — иначе удалённый или переименованный URL живёт на эдже до конца TTL. В IndexNow они не идут: там пингуют существующие адреса, а не «сходите посмотрите на 404»;
- фикс-имена: sitemap, robots, llms.txt, иконки, манифест, `sw.js`;
- JSON API целиком (~310 адресов) — он пересобирается predeploy'ем каждый раз, в sitemap не входит и в манифест не попадает, а Cloudflare кэширует его наравне с остальным.

Хэш-ассеты (`/_astro/*`) не нужны: новая сборка даёт новые имена, промах кэша по определению.

## Устройство

- **Дифф вынесен в отдельный шаг** «Дифф сборки» — им пользуются оба потребителя, и порядок теперь строгий: сначала выбить старое из кэша, потом звать поисковик. Наоборот было бы хуже, чем не звать вовсе: краулер приходит на закэшированную прошлую версию.
- Порции по 30 URL (лимит API вне Enterprise). Если порций стало бы больше 40 — случай массовой правки шаблона — дешевле один раз сбросить зону целиком; в лог уходит `::warning::` с объяснением, что задет кэш соседей.
- Полный отказ purge роняет шаг: несвежий сайт на эдже — не то, о чём стоит молчать. Отдельные неуспешные порции не роняют: страница доживёт до конца TTL.

## Проверено

Локальный стенд с подменённым `curl` (тот же приём, что для #186), пять сценариев:

| Сценарий | Результат |
|---|---|
| без секретов CLOUDFLARE_* | шаг тихо пропущен |
| типичный деплой (1 изменённая + 1 удалённая) | 330 URL → 11 порций, все успешны |
| массовая правка (все 5975 страниц) | 6303 URL → 211 порций → один `purge_everything` |
| 3 порции упали | сброшено 239 из 329, шаг зелёный |
| упало всё | `exit 1`, «не сброшено ничего» |

Плюс скрипты прогнаны на реальном `dist` с сгенерированным `/api` (226 файлов): дифф ловит ровно одну изменённую и одну исчезнувшую страницу.

## Ещё в PR

- `web/scripts/check_edge_cache.sh` — ручная проверка после включения правила: HTML и `/api/` должны отдавать HIT, а `sw.js` и `manifest.webmanifest` — никогда. Это не педантизм: на закэшированном `sw.js` обжигались новости, там PWA-обновления перестали доходить до пользователей. Сейчас скрипт честно показывает три ✘ (правило не включено) и два ✔.
- Смоук обоих скриптов деплоя в `ci.yml` — раньше они гонялись только в `deploy.yml`, где поломка вскрылась бы уже после выката.

Refs #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFxzDRctTNcMvQKEbnajmP