### PR TITLE
[SEO] Фавикон: ico первой строкой + cache-bust ?v=2 (#199)

### DIFF
--- a/web/scripts/cf_purge_urls.mjs
+++ b/web/scripts/cf_purge_urls.mjs
@@ -50,6 +50,12 @@ const FIXED = [
 
 const urls = new Set();
 
+// Корень сбрасываем всегда: сигнатурный дифф считает контент страницы, а правки в <head>
+// (фавикон, мета, скрипты) его не меняют — и главная зависла бы на эдже со старым <head>
+// до конца TTL. Именно с главной Google берёт фавикон (#199).
+urls.add(`${ORIGIN}/`);
+urls.add(`${ORIGIN}/index.html`);
+
 for (const name of FIXED) {
   if (existsSync(resolve(DIST, name))) urls.add(`${ORIGIN}/${name}`);
 }

--- a/web/src/layouts/Reader.astro
+++ b/web/src/layouts/Reader.astro
@@ -75,10 +75,12 @@ const ogAltLocale = lang === 'ru' ? 'en_US' : 'ru_RU';
     <link rel="preload" href="/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin />
 
     <meta name="theme-color" content="#0F1016" />
+    <!-- Растровый ICO ПЕРВЫМ (#199): Google в выдаче SVG-фавиконы не берёт, а первым в <head>
+         должен стоять формат, который он умеет (48×48, квадрат кратный 48). ?v=2 — cache-bust,
+         чтобы краулер сходил за иконкой сразу, а не по своему расписанию. Браузеры при наличии
+         type="image/svg+xml" всё равно предпочтут SVG ниже. -->
+    <link rel="icon" href="/favicon.ico?v=2" sizes="48x48" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <!-- Растровый ICO для краулеров, плохо понимающих SVG-favicon (Яндекс брал иконку
-         только у Table, где /favicon.ico есть; здесь его не было → /favicon.ico давал 404). -->
-    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <script is:inline>

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -14,8 +14,8 @@ import '@omnisgm-app/brand/fonts.css'; // self-host @font-face (Spectral/Inter/J
     <meta name="robots" content="noindex" />
     <meta name="theme-color" content="#0F1117" />
     <link rel="preload" href="/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="icon" href="/favicon.ico?v=2" sizes="48x48" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <style is:global>
       :root {


### PR DESCRIPTION
Закрывает #199.

## Что сделано

- `web/src/layouts/Reader.astro`, `web/src/pages/404.astro` — растровый `.ico` первым в `<head>` с новым URL:
  `<link rel="icon" href="/favicon.ico?v=2" sizes="48x48">`, SVG вторым. Google в выдаче SVG-фавиконы не берёт: своей иконки хоста у него нет вовсе, и он подставляет старый доменный фолбэк omnisgm.com. Браузеры по-прежнему предпочтут SVG — у него есть `type="image/svg+xml"`.
- `web/scripts/cf_purge_urls.mjs` — корень (`/` и `/index.html`) всегда попадает в точечный purge Cloudflare. Сигнатурный дифф (#175) считает контент страницы и правок в `<head>` не видит, так что главная осталась бы на эдже со старым `<head>` до конца TTL — и Google увидел бы кэшированную разметку.

## Проверка

- `npx astro check` — 0 ошибок.

## После мёржа и деплоя (ручное, из чек-листа ишью)

- GSC → URL-инспекция главной → «Запросить индексирование».
- Через 1–2 недели: `https://www.google.com/s2/favicons?domain=rules.omnisgm.com&sz=128` и выдача по `site:rules.omnisgm.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXFYy3P6ZjZi7k5nTdNnWp