### PR TITLE
Спека: edge-кэш при no-cache — purge для картинок не нужен (#202)

### DIFF
--- a/documentation/entity-images.md
+++ b/documentation/entity-images.md
@@ -70,7 +70,21 @@ curl -sI https://rules.omnisgm.com/img/dnd/creatures/aboleth.webp | grep -i cach
 
 Ожидается `no-cache`. Если пришло `max-age=86400` — приоритет обратный, правило нужно поднять выше общего.
 
-Отдельно живёт edge-кэш Cloudflare (#175) — см. `web/scripts/check_edge_cache.sh`. При **замене** существующего файла (не добавлении нового) нужен точечный purge, иначе на эдже останется старый портрет.
+### Edge-кэш Cloudflare
+
+Правило #175 (`web/scripts/check_edge_cache.sh`) висит на всём хосте `rules.omnisgm.com` с `edge_ttl = respect_origin`, поэтому `no-cache` меняет и поведение эджа: копию он держит, но **ревалидирует её при каждом запросе** — новый файл подхватывается сам.
+
+Значит **точечный purge для картинок не нужен** — ни при добавлении, ни при замене. (В более раннем варианте этой спеки, когда на `/img/**` стоял месячный TTL, purge при замене был обязателен; с переходом на `no-cache` требование отпало.)
+
+Проверяется тем же способом, что и на Table, где эта схема работает с #252:
+
+```bash
+curl -sI https://omnisgm.com/monster-avatars/aboleth.webp | grep -iE 'cache-control|cf-cache-status'
+# cache-control: no-cache
+# cf-cache-status: EXPIRED   ← объект в кэше есть, но каждый раз ревалидируется
+```
+
+Purge по-прежнему нужен для HTML и прочего, что эдж кэширует по-настоящему.
 
 ## Кто это генерирует
 

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -129,8 +129,10 @@ export default defineConfig({
             handler: 'StaleWhileRevalidate',
             options: {
               cacheName: 'entity-images',
-              // Очередь генератора — около 1400 картинок на все системы; cap с запасом.
-              expiration: { maxEntries: 1500, maxAgeSeconds: 60 * 60 * 24 * 30 },
+              // Cap НЕ на весь набор (их около 1400 на все системы): 800 записей ≈ 10 МБ на
+              // устройстве, и этого с запасом хватает на реально просмотренное. Вытесненная
+              // по LRU картинка не теряется — подтянется из сети при следующем показе.
+              expiration: { maxEntries: 800, maxAgeSeconds: 60 * 60 * 24 * 30 },
               cacheableResponse: { statuses: [0, 200] },
             },
           },


### PR DESCRIPTION
Правка по ревью #207 (comment 5368281821): строка про точечный purge устарела внутри коммета `41b9b364`, когда `/img/**` перешёл с месячного TTL на `no-cache`.

Формулировку уточнил против замечания: «эдж перестанет кэшировать вовсе» — не совсем так. Правило #175 висит на всём хосте с `edge_ttl = respect_origin`, и при `no-cache` эдж копию **держит**, но ревалидирует на каждом запросе. Проверил на Table, где та же схема работает с #252:

```
curl -sI https://omnisgm.com/monster-avatars/aboleth.webp
cache-control: no-cache
cf-cache-status: EXPIRED   ← объект в кэше есть, но каждый раз ревалидируется
```

Практический вывод тот же, что в замечании: **purge для картинок не нужен** ни при добавлении, ни при замене — новый файл подхватывается сам. Для HTML и прочего, что эдж кэширует по-настоящему, purge по-прежнему нужен; это в спеке сказано отдельно.

Команда проверки записана рядом, чтобы следующий читатель убедился сам, а не верил тексту.

Refs #202