### PR TITLE
Ранбук токена: держателей двое — Table больше не в списке (#403)

### DIFF
--- a/.github/workflows/gen-images.yml
+++ b/.github/workflows/gen-images.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Explain auth failure
         if: ${{ failure() && steps.gen.outcome == 'failure' }}
         run: |
-          echo "::error::Если в summary «codex auth протух» — перелогинься (codex login) и обнови секрет во всех трёх репо: for r in OmnisGM-App/OmnisGM-News OmnisGM-App/OmnisGM-Table OmnisGM-App/OmnisGM-Rules; do gh secret set CODEX_AUTH_JSON --repo \$r < ~/.codex/auth.json; done"
+          echo "::error::Если в summary «codex auth протух» — перелогинься (codex login) и обнови секрет в обоих репо: for r in OmnisGM-App/OmnisGM-News OmnisGM-App/OmnisGM-Rules; do gh secret set CODEX_AUTH_JSON --repo \$r < ~/.codex/auth.json; done"
 
       # Пуш в images-queue — главное; PR лишь удобная обёртка. По умолчанию Actions не имеет
       # права создавать PR (org-настройка) → шаг некритичный.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,12 +63,14 @@ Markdown, справа TOC «На этой странице» → prev/next, с�
 + `.github/workflows/gen-images.yml` (codex на подписке, очередь от данных Rules, ветка `images-queue`
 → draft-PR без автомёржа).
 
-**Ранбук токена codex.** Токен один на три репо-держателя (локальный `~/.codex/auth.json` → CI News
-→ CI Table → CI Rules). Прогон падает с `refresh_token_reused` / `token_revoked` / `401` — значит
-локальный перелогин обесценил токен в CI. Починка: `codex login` локально, затем обновить секрет ВЕЗДЕ:
+**Ранбук токена codex.** Держателей токена **двое** — CI News и CI Rules, оба от одного
+локального `~/.codex/auth.json`. (Третьим был CI Table, пока там жил свой генератор портретов;
+он снесён вместе с ним — Table#403.) Прогон падает с `refresh_token_reused` / `token_revoked` /
+`401` — значит локальный перелогин обесценил токен в CI. Починка: `codex login` локально,
+затем обновить секрет в ОБОИХ репозиториях:
 
 ```bash
-for r in OmnisGM-App/OmnisGM-News OmnisGM-App/OmnisGM-Table OmnisGM-App/OmnisGM-Rules; do
+for r in OmnisGM-App/OmnisGM-News OmnisGM-App/OmnisGM-Rules; do
   gh secret set CODEX_AUTH_JSON --repo $r < ~/.codex/auth.json
 done
 ```

--- a/scripts/gen-images.mjs
+++ b/scripts/gen-images.mjs
@@ -111,13 +111,14 @@ function summary(md) {
   console.log(md);
 }
 
-// Держателей три: News-CI, Table-CI (до Table#403) и Rules-CI, все от одного локального
-// ~/.codex/auth.json — перелогин обесценивает токен во всех, синкать разом.
+// Держателей двое: News-CI и Rules-CI, оба от одного локального ~/.codex/auth.json —
+// перелогин обесценивает токен в обоих, синкать разом. (Table был третьим, пока там жил
+// свой генератор портретов; снесён вместе с ним — Table#403.)
 const AUTH_FIX = [
   '### ❌ codex auth протух (`refresh_token_reused` / `token_revoked`)',
   'Перелогинься локально (`codex login`) и обнови секрет во ВСЕХ репозиториях-держателях:',
   '```',
-  'for r in OmnisGM-App/OmnisGM-News OmnisGM-App/OmnisGM-Table OmnisGM-App/OmnisGM-Rules; do',
+  'for r in OmnisGM-App/OmnisGM-News OmnisGM-App/OmnisGM-Rules; do',
   '  gh secret set CODEX_AUTH_JSON --repo $r < ~/.codex/auth.json',
   'done',
   '```',


### PR DESCRIPTION
Хвост к Table#403: секрет `CODEX_AUTH_JSON` удалён из Table вместе с генератором портретов, который им пользовался. Команда синка после этого перечисляла репозиторий, где секрета уже нет.

Поправлено в трёх местах, где команда дублировалась:

* `CLAUDE.md` — ранбук токена;
* `scripts/gen-images.mjs` — `AUTH_FIX`, который печатается в summary при протухшем токене;
* `.github/workflows/gen-images.yml` — `::error` в шаге объяснения сбоя.

Везде теперь двое — **News-CI и Rules-CI**. Почему Table выпал, написано рядом со ссылкой на ишью: иначе через полгода это выглядело бы как пропущенный репозиторий, и кто-нибудь «починил» бы список обратно.

Проверки: yaml валиден, очередь генератора строится (`KIND=spells CHECK_ONLY=1` — 336 в очереди), правка только текстовая.

Refs #403