### PR TITLE
Security-заголовки на все ответы, CSP пока Report-Only (#218)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,15 @@ Markdown, справа TOC «На этой странице» → prev/next, с�
 - **Деплой:** заменить `pages.yml` (GitHub Pages) на `astro build` + `firebase deploy --only hosting`
   (проект `omnisgm-rules`). JSON API (`generate_api.py`) и release-воркфлоу — решить отдельно при сборке.
 
+### Security-заголовки (#218)
+`X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`, HSTS и CSP (пока Report-Only)
+ставятся в `firebase.json` — правило `hosting.headers` с `source: "**"`, первым в списке, а НЕ
+в Cloudflare Transform Rules: конфиг в репозитории виден в ревью и едет вместе с деплоем.
+Firebase мержит правила по ключам, поэтому точечные `Cache-Control` (`/img/**`, `sw.js`) живы —
+это и проверяет `bash web/scripts/check_security_headers.sh` (без аргумента — прод, с URL —
+эмулятор). HSTS без `preload`: список принимает апекс `omnisgm.com` и накрывает ВСЕ поддомены,
+так что preload — отдельное решение владельца на лендинге, не отсюда.
+
 ### Картинки сущностей и генератор (#201, #202)
 Портреты существ и иконки заклинаний/магпредметов лежат в репо статикой (`web/public/img/{game}/{kind}/`),
 показываются на странице сущности и уходят в поле `image` JSON API. Формат и раскладка —

--- a/firebase.json
+++ b/firebase.json
@@ -84,6 +84,19 @@
     ],
     "headers": [
       {
+        "source": "**",
+        "headers": [
+          { "key": "X-Content-Type-Options", "value": "nosniff" },
+          { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+          { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+          { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
+          {
+            "key": "Content-Security-Policy-Report-Only",
+            "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://www.googletagmanager.com https://mc.yandex.ru; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://mc.yandex.ru https://*.google-analytics.com https://www.googletagmanager.com; font-src 'self'; connect-src 'self' https://mc.yandex.ru https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com; worker-src 'self'; manifest-src 'self'; frame-src https://mc.yandex.ru"
+          }
+        ]
+      },
+      {
         "source": "/.well-known/web-app-origin-association",
         "headers": [{ "key": "Content-Type", "value": "application/json" }]
       },

--- a/web/scripts/check_security_headers.sh
+++ b/web/scripts/check_security_headers.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Проверка security-заголовков на rules.omnisgm.com — issue #218.
+#
+#   bash web/scripts/check_security_headers.sh                 # прод
+#   bash web/scripts/check_security_headers.sh http://127.0.0.1:5002   # эмулятор Firebase
+#
+# ── Где заголовки настроены
+# В `firebase.json` (`hosting.headers`, правило `source: "**"`), а НЕ в Cloudflare Transform
+# Rules: конфиг в репозитории виден в ревью, едет вместе с деплоем и не требует токена зоны.
+# Правило `**` стоит ПЕРВЫМ, дальше идут точечные правила Cache-Control (/img/**, /_astro/**,
+# sw.js). Firebase применяет все подходящие правила и мержит их по ключам — проверено на
+# эмуляторе: /img/ отдаёт и security-заголовки, и свой `Cache-Control: no-cache`. Порядок
+# именно такой на случай, если поведение когда-нибудь станет «последнее правило побеждает
+# целиком»: тогда пострадают security-заголовки на статике, а не кэш-политика (её ломать
+# нельзя — на no-cache для /img/ и sw.js завязаны обновления картинок и PWA, см. #202/#175).
+#
+# ── Про HSTS
+# `max-age=31536000; includeSubDomains`, БЕЗ preload. includeSubDomains здесь накрывает только
+# поддомены rules.omnisgm.com (их нет) — соседние news/table это НЕ трогает, они сиблинги.
+# А preload — решение уровня апекса: список принимает домен omnisgm.com, и он накроет ВСЕ
+# поддомены разом и откатывается месяцами. Ставить его нужно на лендинге и отдельным решением
+# владельца, отсюда это сделать нельзя (см. #218).
+#
+# ── Про CSP
+# Сейчас Report-Only: политика собрана из того, что страницы реально грузят (свои бандлы и
+# инлайновые модули Astro, шрифты, Pagefind с воркером и wasm, GA4 и Метрика). Инлайн-скриптов
+# у Astro много и хэши менялись бы каждый билд — поэтому `'unsafe-inline'`; смысл политики в
+# том, чтобы запретить ЧУЖИЕ источники, а не инлайн. Перевод в enforce — отдельным шагом,
+# после того как прод в Report-Only отмолчится (проверять в devtools на страницах разных
+# типов: глава, сущность, поиск, оффлайн-PWA).
+set -u
+BASE="${1:-https://rules.omnisgm.com}"
+
+# Ожидаемые заголовки: имя → регексп значения.
+EXPECT_NAMES=(
+  "x-content-type-options"
+  "referrer-policy"
+  "x-frame-options"
+  "strict-transport-security"
+  "content-security-policy-report-only"
+)
+EXPECT_VALUES=(
+  "^nosniff$"
+  "^strict-origin-when-cross-origin$"
+  "^SAMEORIGIN$"
+  "max-age=31536000; includeSubDomains"
+  "default-src 'self'"
+)
+
+header() {  # $1 — путь, $2 — имя заголовка
+  curl -sSI "$BASE$1" | tr -d '\r' | awk -F': ' -v n="$2" 'tolower($1)==n{sub(/^[^:]*: /,""); print; exit}'
+}
+
+fail=0
+check_page() {  # $1 — путь
+  local path="$1"
+  echo "  $path"
+  for i in "${!EXPECT_NAMES[@]}"; do
+    local name="${EXPECT_NAMES[$i]}" want="${EXPECT_VALUES[$i]}"
+    local got=""
+    got="$(header "$path" "$name")"
+    if [ -z "$got" ]; then
+      echo "    ✘ $name — отсутствует"; fail=1
+    elif ! printf '%s' "$got" | grep -qE "$want"; then
+      echo "    ✘ $name — «${got}» (ожидали /$want/)"; fail=1
+    else
+      echo "    ✔ $name"
+    fi
+  done
+}
+
+echo "Security-заголовки $BASE"
+check_page "/ru/"
+check_page "/en/dnd/srd-5.2/spells/fireball/"
+
+# Точечные правила Cache-Control обязаны пережить глобальное правило: если мерж когда-нибудь
+# сломается, картинки и sw.js залипнут в кэше, а это дороже самих заголовков.
+echo "  кэш-политика не потерялась:"
+for p in "/img/dnd/creatures/aboleth.webp" "/sw.js"; do
+  cc="$(header "$p" "cache-control")"
+  nosniff="$(header "$p" "x-content-type-options")"
+  if printf '%s' "$cc" | grep -q "no-cache"; then echo "    ✔ $p — Cache-Control: $cc"
+  else echo "    ✘ $p — Cache-Control «${cc}», ожидали no-cache"; fail=1; fi
+  [ -n "$nosniff" ] || echo "    ⚠ $p — без security-заголовков (мерж правил не сработал; кэш при этом цел)"
+done
+
+[ "$fail" -eq 0 ] && echo "Итог: заголовки на месте." || echo "Итог: есть расхождения — см. ✘ выше."
+exit "$fail"


### PR DESCRIPTION
Часть #218: четыре заголовка ставятся окончательно, CSP уезжает в Report-Only. Ишью НЕ
закрывается этим PR — в ней остаются перевод CSP в enforce (после наблюдения) и решение по
HSTS preload на апексе.

## Что было
Сэмпл из SEO-аудита подтверждён вживую: `curl -sI https://rules.omnisgm.com/ru/` отдаёт только
дефолтный HSTS от Firebase (`max-age=31556926`) — ни `X-Content-Type-Options`, ни
`Referrer-Policy`, ни `X-Frame-Options`, ни CSP.

## Где ставим и почему там
`firebase.json`, `hosting.headers`, правило `source: "**"` — а не Cloudflare Transform Rules:
конфиг лежит в репозитории, виден в ревью, едет вместе с деплоем и не требует токена зоны
(правило кэша #175 уже показало, что click-ops в дашборде приходится описывать в шапке скрипта,
чтобы его можно было восстановить).

| заголовок | значение |
|---|---|
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `X-Frame-Options` | `SAMEORIGIN` (плюс `frame-ancestors 'self'` в CSP) |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` — **без preload**, см. ниже |
| `Content-Security-Policy-Report-Only` | политика ниже |

## Порядок правил — не косметика
Глобальное правило стоит **первым**, точечные `Cache-Control` (`/img/**`, `/_astro/**`, `sw.js`,
шрифты) — после. Firebase применяет все подходящие правила и мержит их по ключам: проверено на
локальном эмуляторе хостинга — `/img/dnd/creatures/aboleth.webp` отдаёт и security-заголовки, и
свой `Cache-Control: no-cache`.

Порядок выбран на случай, если поведение когда-нибудь окажется «последнее правило побеждает
целиком»: тогда пострадают security-заголовки на статике, а не кэш-политика. Ломать её нельзя —
на `no-cache` для `/img/` и `sw.js` завязаны обновления картинок (#202) и PWA (#175, шрам новостей
с годовалым `sw.js`). Скрипт проверки следит за обоими исходами.

## HSTS: почему без preload
`includeSubDomains` на хосте `rules.omnisgm.com` накрывает только его поддомены — их нет, а
`news`/`table` это сиблинги апекса, их не трогает. А `preload` — решение уровня апекса: список
принимает `omnisgm.com`, накрывает ВСЕ поддомены разом и откатывается месяцами. Ставить его надо
на лендинге и отдельным решением, отсюда сделать нельзя. Пункт чеклиста оставляю владельцу.

## CSP: пока Report-Only
Политика собрана из того, что страницы реально грузят (инвентаризация по dist и по коду):
свои бандлы и инлайновые модули Astro, шрифты с своего домена, Pagefind (воркер + wasm), GA4
через `googletagmanager.com`, Метрика через `mc.yandex.ru`.

```
default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self';
script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://www.googletagmanager.com https://mc.yandex.ru;
style-src 'self' 'unsafe-inline'; img-src 'self' data: https://mc.yandex.ru https://*.google-analytics.com https://www.googletagmanager.com;
font-src 'self'; connect-src 'self' https://mc.yandex.ru https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com;
worker-src 'self'; manifest-src 'self'; frame-src https://mc.yandex.ru
```

`'unsafe-inline'` для скриптов — осознанно: инлайн-модулей Astro на странице девять, хэши менялись
бы каждый билд, а смысл политики здесь в том, чтобы запретить ЧУЖИЕ источники. `'wasm-unsafe-eval'`
нужен Pagefind. Перевод в enforce — отдельным шагом, после того как прод отмолчится в Report-Only.

## Проверено
- Локальный эмулятор хостинга Firebase на этом конфиге: `bash web/scripts/check_security_headers.sh
  http://127.0.0.1:5002` — все пять заголовков на HTML-страницах, `Cache-Control: no-cache` жив
  у `/img/` и `sw.js`.
- Тот же скрипт против ТЕКУЩЕГО прода краснеет по всем пяти пунктам и возвращает код 1 — проверка
  не холостая.
- Страницы прогнаны в браузере против эмулятора (глава, сущность с портретом, поиск с Pagefind,
  зарегистрированный service worker, RU и EN): нарушений CSP в консоли нет, политика парсится без
  «Unrecognized directive».
- Скрипт по образцу `check_edge_cache.sh` — ручной, как и он: в CI прода нет, а в deploy.yml
  проверка была бы флаки из-за эджа.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpZFAJnWNgkswDmHd5KVhF

