### PR TITLE
Article в JSON-LD: image, даты из git, author + Organization.sameAs (#219)

### DIFF
--- a/.github/scripts/generate_api.py
+++ b/.github/scripts/generate_api.py
@@ -505,6 +505,11 @@ def main():
                         help="Root of entity images (web/public/img) — presence decides the `image` field")
     parser.add_argument("--site-origin", default=DEFAULT_SITE_ORIGIN,
                         help="Origin for absolute image URLs")
+    # Карта «ресурс → исходные markdown-файлы» (#219): из неё сборка сайта берёт даты
+    # изменения контента для JSON-LD (и дальше для lastmod в sitemap). Знание о том, из
+    # какого файла собрана коллекция, живёт здесь, в SOURCES, — дублировать его в JS нельзя.
+    parser.add_argument("--emit-sources", default=None,
+                        help="Path to write {ver/lang/resource: [source .md paths]} JSON")
     args = parser.parse_args()
 
     src_root = Path(args.src_root)
@@ -528,6 +533,9 @@ def main():
 
     # Parse all sources
     all_data: dict[tuple[str, str, str], list[dict]] = {}
+    # (ver, lang, resource) → исходные файлы; у ресурса их может быть несколько
+    # (оружие и доспехи собираются из той же главы «Снаряжение»).
+    sources_map: dict[tuple[str, str, str], list[str]] = {}
     total_entities = 0
 
     for source in SOURCES:
@@ -621,6 +629,9 @@ def main():
             continue
 
         key = (ver, lang, resource)
+        rel = str(Path(src_root.name) / source["file"])  # dnd/srd-5.2/ru/07_Spells.md
+        if rel not in sources_map.setdefault(key, []):
+            sources_map[key].append(rel)
         if key in all_data:
             all_data[key].extend(entities)
         else:
@@ -821,6 +832,23 @@ def main():
             sys_links.append({"href": f"{d.name}/", "label": system_labels.get(d.name, d.name)})
     write_index_html(output_dir / "index.html", "TTRPG SRD API", sys_links)
     file_count += 1
+
+    # Карта исходников (#219). Ключ — «ver/lang/resource», значение — пути от src/.
+    # Мультиигровой билд зовёт генератор несколько раз в один файл, поэтому дописываем
+    # к уже существующему содержимому, а не перезаписываем его.
+    if args.emit_sources:
+        out = Path(args.emit_sources)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        existing = {}
+        if out.is_file():
+            try:
+                existing = json.loads(out.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                existing = {}
+        for (ver, lang, resource), files in sources_map.items():
+            existing[f"{SYSTEM}/{ver}/{lang}/{resource}"] = files
+        out.write_text(json.dumps(existing, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+        print(f"  sources map: {len(sources_map)} resources → {out}")
 
     print(f"\nDone: {file_count} files written ({total_entities} entities)")
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,14 @@ jobs:
     name: Check & Build
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth: 0 — сборке нужны даты коммитов по контентным .md (#219): из них
+      # datePublished/dateModified в JSON-LD. На мелком клоне истории нет, и страницы
+      # остались бы без дат (дату билда вместо настоящей мы намеренно не подставляем).
+      # filter: blob:none — история приезжает без старых блобов, клон остаётся быстрым.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          filter: blob:none
 
       # Валидация JSON API по схеме — тем же generate_api.py, что гоняет firebase predeploy
       # при деплое (schemas.py, additionalProperties:False). Локальный prebuild зовёт генератор

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth: 0 — сборке нужны даты коммитов по контентным .md (#219): из них
+      # datePublished/dateModified в JSON-LD. На мелком клоне истории нет, и страницы
+      # остались бы без дат (дату билда вместо настоящей мы намеренно не подставляем).
+      # filter: blob:none — история приезжает без старых блобов, клон остаётся быстрым.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          filter: blob:none
 
       - uses: actions/setup-node@v7
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,19 @@ Markdown, справа TOC «На этой странице» → prev/next, с�
 - **Деплой:** заменить `pages.yml` (GitHub Pages) на `astro build` + `firebase deploy --only hosting`
   (проект `omnisgm-rules`). JSON API (`generate_api.py`) и release-воркфлоу — решить отдельно при сборке.
 
+### Даты контента для JSON-LD (#219)
+`datePublished`/`dateModified` у `Article` берутся из **истории git** по исходному markdown:
+`web/scripts/gen-content-dates.mjs` (prebuild) делает один проход `git log --name-only` по `src/`
+и пишет карту в `web/src/data/content-dates.json` (gitignored), а `web/src/lib/content-dates.mjs`
+отдаёт даты странице. Сущностная страница знает свой ресурс и передаёт `contentSource` в
+`ReaderShell`; какие `.md` стоят за ресурсом — говорит `_sources.json` от парсера
+(`generate_api.py --emit-sources`), чтобы это знание не дублировалось в JS.
+
+**Мелкий клон дат не даёт.** `actions/checkout` без `fetch-depth: 0` не привозит историю, и
+страницы остаются БЕЗ дат — намеренно: дата билда на 6000 страницах означала бы «всё обновилось
+разом». Поэтому в `ci.yml` и `deploy.yml` стоит `fetch-depth: 0` + `filter: blob:none`, а гейт
+`verify_dist_meta_budget.mjs` валит сборку, если Article остался без обязательных полей.
+
 ### Security-заголовки (#218)
 `X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`, HSTS и CSP (пока Report-Only)
 ставятся в `firebase.json` — правило `hosting.headers` с `source: "**"`, первым в списке, а НЕ

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -23,4 +23,6 @@ public/fonts/
 
 # Сгенерированные данные сущностей для programmatic-страниц (prebuild)
 src/data/api/
+# Даты контента из git для JSON-LD (#219) — генерятся в prebuild, как и src/data/api/.
+src/data/content-dates.json
 .indexnow/

--- a/web/e2e/entity-images.spec.ts
+++ b/web/e2e/entity-images.spec.ts
@@ -66,9 +66,13 @@ test('JSON API: image есть у существ с файлом и отсутс
   const aboleth = monsters.find((m: { slug: string }) => m.slug === 'aboleth');
   expect(aboleth.image).toBe('https://rules.omnisgm.com/img/dnd/creatures/aboleth.webp');
   // Поля нет вовсе, а не пустая строка/null — потребитель проверяет наличие ключа.
-  // Берём заклинание, которого генератор ещё не касался (первое по алфавиту уже с иконкой).
+  // Заклинание без иконки выбираем ПО ФАКТУ, а не по имени: очередь генератора доливает
+  // картинки порциями, и любой зафиксированный слаг рано или поздно её получает (на fireball
+  // так и вышло — тест покраснел от мёржа очереди, а не от поломки).
   const spells = api('dnd/srd52/ru/spells/all.json');
-  expect(spells.find((s: { slug: string }) => s.slug === 'fireball')).not.toHaveProperty('image');
+  const pending = spells.find((s: { image?: string }) => !s.image);
+  expect(pending, 'все заклинания уже с иконками — возьми другой раздел для этой проверки').toBeTruthy();
+  expect(pending).not.toHaveProperty('image');
   // Окружения Daggerheart делят схему с противниками, но картинок у них нет.
   expect(api('daggerheart/srd10/ru/environments/all.json')[0]).not.toHaveProperty('image');
   expect(api('daggerheart/srd10/ru/adversaries/all.json')[0].image).toContain('/img/daggerheart/creatures/');
@@ -118,8 +122,11 @@ test('заклинание и магпредмет с иконкой — тот 
 });
 
 test('сущность без картинки: страница как раньше', async ({ page }) => {
-  // Огненный шар в очереди генератора — иконки пока нет.
-  await page.goto('/ru/dnd/srd-5.2/spells/fireball/');
+  // Слаг берём из данных, а не из головы: очередь генератора доливает иконки порциями,
+  // и захардкоженное заклинание однажды перестаёт быть «без картинки».
+  const pending = api('dnd/srd52/ru/spells/all.json').find((s: { image?: string }) => !s.image);
+  expect(pending, 'все заклинания уже с иконками — возьми другой раздел для этой проверки').toBeTruthy();
+  await page.goto(`/ru/dnd/srd-5.2/spells/${pending.slug}/`);
   await expect(page.locator('img.ent-portrait')).toHaveCount(0);
   await expect(page.locator('head meta[property="og:image"]')).toHaveAttribute(
     'content', 'https://rules.omnisgm.com/og.png',

--- a/web/e2e/seo-jsonld.spec.ts
+++ b/web/e2e/seo-jsonld.spec.ts
@@ -40,18 +40,15 @@ test('страница без портрета: image — общий og.png, а 
   expect(article.datePublished).toMatch(ISO);
 });
 
-test('даты берутся из контента, а не из даты сборки', async ({ page }) => {
-  // Две страницы из разных SRD обязаны иметь разные даты изменения: одинаковые означали бы,
-  // что источник дат — момент билда, а не история правок контента.
+test('дата изменения — из контента, а не из даты сборки', async ({ page }) => {
   await page.goto('/en/dnd/srd-5.2/spells/fireball/');
-  const spells = node(await graphOf(page), 'Article');
-  await page.goto('/en/daggerheart/srd-1.0/classes/druid/');
-  const druid = node(await graphOf(page), 'Article');
-
-  expect(spells.dateModified).not.toBe(druid.dateModified);
-  // И ни одна из дат не «сегодня»: контент правился раньше сборки.
+  const article = node(await graphOf(page), 'Article');
+  // Дата не «сегодня»: контент правился раньше сборки. Сравнивать даты ДВУХ конкретных глав
+  // здесь нельзя — один общий коммит по обеим (прогон форматера, массовая правка терминов)
+  // сделал бы их равными при полностью исправном механизме. Инвариант «дат в сборке больше
+  // одной» проверяется по всему dist в scripts/verify_dist_meta_budget.mjs.
   const today = new Date().toISOString().slice(0, 10);
-  expect(spells.dateModified.slice(0, 10)).not.toBe(today);
+  expect(article.dateModified.slice(0, 10)).not.toBe(today);
 });
 
 test('Organization.sameAs связывает ресурсы экосистемы и репозиторий', async ({ page }) => {

--- a/web/e2e/seo-jsonld.spec.ts
+++ b/web/e2e/seo-jsonld.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// JSON-LD контентных страниц (issue #219). Сплошной счёт по dist делает
+// verify_dist_meta_budget.mjs (гейт «Article без обязательных полей» = 0); здесь — смысловые
+// проверки на живой странице: что именно лежит в полях и что граф связан ссылками @id.
+//
+// Почему это важно ровно так: без image и дат Google не выдаёт Article-rich-result вовсе,
+// а даты у нас приезжают из git по исходному markdown — на сборке без истории они молча
+// исчезают, и подмены датой билда мы не делаем (это шум для поисковика, а не свежесть).
+
+const graphOf = async (page: Page) => {
+  const raw = await page.locator('head script[type="application/ld+json"]').first().textContent();
+  return JSON.parse(raw!)['@graph'] as any[];
+};
+const node = (graph: any[], type: string) => graph.find((n) => n['@type'] === type);
+const ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/;
+
+test('сущность с портретом: image = портрет, даты ISO, автор — Organization', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/monsters-a-z/aboleth/');
+  const graph = await graphOf(page);
+  const article = node(graph, 'Article');
+
+  expect(article.image).toBe('https://rules.omnisgm.com/img/dnd/creatures/aboleth.webp');
+  expect(article.datePublished).toMatch(ISO);
+  expect(article.dateModified).toMatch(ISO);
+  expect(new Date(article.dateModified).getTime()).toBeGreaterThanOrEqual(
+    new Date(article.datePublished).getTime(),
+  );
+  // author/publisher — ссылки на узел Organization в том же графе, а не строки.
+  expect(article.author).toEqual({ '@id': 'https://rules.omnisgm.com/#org' });
+  expect(article.publisher).toEqual({ '@id': 'https://rules.omnisgm.com/#org' });
+  expect(node(graph, 'Organization')['@id']).toBe('https://rules.omnisgm.com/#org');
+  expect(article.mainEntityOfPage['@id']).toBe(article.url);
+});
+
+test('страница без портрета: image — общий og.png, а не пустое поле', async ({ page }) => {
+  await page.goto('/en/daggerheart/srd-1.0/classes/druid/');
+  const article = node(await graphOf(page), 'Article');
+  expect(article.image).toBe('https://rules.omnisgm.com/og.png');
+  expect(article.datePublished).toMatch(ISO);
+});
+
+test('даты берутся из контента, а не из даты сборки', async ({ page }) => {
+  // Две страницы из разных SRD обязаны иметь разные даты изменения: одинаковые означали бы,
+  // что источник дат — момент билда, а не история правок контента.
+  await page.goto('/en/dnd/srd-5.2/spells/fireball/');
+  const spells = node(await graphOf(page), 'Article');
+  await page.goto('/en/daggerheart/srd-1.0/classes/druid/');
+  const druid = node(await graphOf(page), 'Article');
+
+  expect(spells.dateModified).not.toBe(druid.dateModified);
+  // И ни одна из дат не «сегодня»: контент правился раньше сборки.
+  const today = new Date().toISOString().slice(0, 10);
+  expect(spells.dateModified.slice(0, 10)).not.toBe(today);
+});
+
+test('Organization.sameAs связывает ресурсы экосистемы и репозиторий', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/fireball/');
+  const org = node(await graphOf(page), 'Organization');
+  expect(org.sameAs).toEqual(
+    expect.arrayContaining([
+      'https://omnisgm.com/',
+      'https://news.omnisgm.com/',
+      'https://rules.omnisgm.com/',
+      'https://github.com/OmnisGM-App/OmnisGM-Rules',
+    ]),
+  );
+});
+
+test('хаб раздела тоже получает даты (контент тот же файл главы)', async ({ page }) => {
+  await page.goto('/ru/dnd/srd-5.2/spells/all/');
+  const article = node(await graphOf(page), 'Article');
+  expect(article.datePublished).toMatch(ISO);
+  expect(article.dateModified).toMatch(ISO);
+});

--- a/web/package.json
+++ b/web/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "description": "rules.omnisgm.com — Astro (SSG) SRD reader for the OmnisGM ecosystem",
   "scripts": {
-    "predev": "node scripts/copy-brand-assets.mjs && node scripts/gen-entity-data.mjs",
+    "predev": "node scripts/copy-brand-assets.mjs && node scripts/gen-entity-data.mjs && node scripts/gen-content-dates.mjs",
     "dev": "astro dev",
-    "prebuild": "node scripts/copy-brand-assets.mjs && node scripts/gen-entity-data.mjs",
+    "prebuild": "node scripts/copy-brand-assets.mjs && node scripts/gen-entity-data.mjs && node scripts/gen-content-dates.mjs",
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",

--- a/web/scripts/gen-content-dates.mjs
+++ b/web/scripts/gen-content-dates.mjs
@@ -1,0 +1,71 @@
+// Даты изменения контента для JSON-LD (issue #219) — и, дальше, для lastmod в sitemap (#221).
+//
+// Astro при сборке знает только «сейчас», поэтому datePublished/dateModified неоткуда взять
+// иначе как из истории git: дата коммита, тронувшего исходный markdown. Мы НЕ берём mtime
+// файла — в CI это время checkout'а, то есть у всех страниц разом дата билда; ровно эту
+// ловушку и просили обойти.
+//
+// Один проход `git log --name-only` по src/ строит карту: путь .md → { published, modified }.
+// Лог идёт от новых к старым, поэтому первая встреча файла — последнее изменение, последняя —
+// появление. Переименования не отслеживаем (`--follow` пришлось бы звать на каждый файл):
+// у переименованного файла published станет датой переименования — редкий случай, а цена
+// точности здесь несоразмерна.
+//
+// НА МЕЛКОМ КЛОНЕ (fetch-depth: 1) истории нет, и честного ответа тоже: тогда пишем пустую
+// карту с пометкой shallow, а страницы просто не получают дат. Пустая дата лучше, чем
+// одинаковая дата билда на 6000 страниц — Google такую «свежесть» считает шумом.
+//
+// Запуск: node web/scripts/gen-content-dates.mjs (в prebuild, до astro build).
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..');
+const outFile = resolve(here, '../src/data/content-dates.json');
+
+const git = (...args) =>
+  execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+
+let shallow = false;
+let files = {};
+
+try {
+  shallow = git('rev-parse', '--is-shallow-repository').trim() === 'true';
+  if (shallow) {
+    console.warn(
+      '[gen-content-dates] мелкий клон (fetch-depth: 1) — истории нет, даты не проставляем.\n' +
+        '  Для полных дат в CI нужен actions/checkout с fetch-depth: 0 (и filter: blob:none, чтобы не тащить блобы).',
+    );
+  } else {
+    // %x00 — разделитель записей, дальше ISO-дата коммита и его файлы.
+    const log = git('log', '--format=%x00%aI', '--name-only', '--', 'src');
+    for (const block of log.split('\0')) {
+      const lines = block.split('\n').filter(Boolean);
+      if (!lines.length) continue;
+      const date = lines[0];
+      for (const file of lines.slice(1)) {
+        if (!file.endsWith('.md') || !file.startsWith('src/')) continue;
+        const key = file.slice('src/'.length);
+        const rec = files[key];
+        // Лог идёт от новых к старым: первая встреча — modified, каждая следующая — published.
+        if (rec) rec.published = date;
+        else files[key] = { published: date, modified: date };
+      }
+    }
+  }
+} catch (err) {
+  // Сборка без git (архив исходников, чужая песочница) — не повод валить билд.
+  console.warn(`[gen-content-dates] git недоступен (${err.message.split('\n')[0]}) — даты не проставляем.`);
+  files = {};
+  shallow = true;
+}
+
+mkdirSync(dirname(outFile), { recursive: true });
+writeFileSync(outFile, JSON.stringify({ shallow, files }, null, 0));
+console.log(
+  shallow
+    ? `[gen-content-dates] дат нет (shallow) → ${outFile}`
+    : `[gen-content-dates] ${Object.keys(files).length} файлов → ${outFile}`,
+);

--- a/web/scripts/gen-entity-data.mjs
+++ b/web/scripts/gen-entity-data.mjs
@@ -14,6 +14,9 @@ const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '../..'); // .../OmnisGM-Rules
 const script = resolve(repoRoot, '.github/scripts/generate_api.py');
 const outDir = resolve(here, '../src/data/api');
+// Карта «ресурс → исходные .md» (#219): нужна сборке, чтобы проставить сущностным страницам
+// datePublished/dateModified. Знание живёт в SOURCES генератора, здесь его не дублируем.
+const sourcesFile = resolve(outDir, '_sources.json');
 const python = process.env.PYTHON || 'python3';
 
 // Каждая игра — свой конфиг (config.py / config_{game}.py) и src-root; общий output-dir
@@ -33,7 +36,8 @@ for (const { game, srcRoot } of GAMES) {
   try {
     execFileSync(
       python,
-      [script, '--game', game, '--src-root', srcRoot, '--output-dir', outDir, '--no-validate'],
+      [script, '--game', game, '--src-root', srcRoot, '--output-dir', outDir, '--no-validate',
+       '--emit-sources', sourcesFile],
       { stdio: 'inherit' },
     );
   } catch (err) {

--- a/web/scripts/verify_dist_meta_budget.mjs
+++ b/web/scripts/verify_dist_meta_budget.mjs
@@ -79,6 +79,9 @@ const shortDescriptions = []; // { page, len }
 const ARTICLE_REQUIRED = ['image', 'datePublished', 'dateModified', 'author', 'publisher'];
 const brokenArticles = []; // { page, why }
 let withArticle = 0;
+// Инвариант «даты из контента, а не из сборки»: у 6000 страниц не может быть одной даты
+// изменения. Ровно один dateModified на весь dist = источником дат стал момент билда.
+const modifiedDates = new Set();
 const byTitle = new Map(); // title → [страницы]
 const longTitles = []; // { page, len }
 let pages = 0;
@@ -121,6 +124,7 @@ for (const file of htmlFiles(DIST)) {
       withArticle++;
       const missing = ARTICLE_REQUIRED.filter((k) => !article[k]);
       if (missing.length) brokenArticles.push({ page, why: `Article без ${missing.join(', ')}` });
+      if (article.dateModified) modifiedDates.add(article.dateModified);
     }
   }
 
@@ -154,7 +158,7 @@ console.log(`  дубли description: ${dupPages} страниц в ${dupGroups
 console.log(`  <title> > ${TITLE_LIMIT} символов: ${longTitles.length} страниц (бюджет ${BUDGET.longTitlePages})`);
 console.log(`  дубли <title>: ${dupTitlePages} страниц в ${dupTitleGroups.length} группах (бюджет ${BUDGET.dupTitlePages})`);
 console.log(`  description < ${DESCRIPTION_MIN} символов: ${shortDescriptions.length} страниц (бюджет ${BUDGET.shortDescriptionPages})`);
-console.log(`  Article в JSON-LD: ${withArticle} страниц, неполных ${brokenArticles.length} (бюджет 0)`);
+console.log(`  Article в JSON-LD: ${withArticle} страниц, неполных ${brokenArticles.length} (бюджет 0); различных dateModified: ${modifiedDates.size}`);
 
 const errors = [];
 
@@ -230,11 +234,22 @@ if (brokenArticles.length) {
   const noDates = brokenArticles.filter((b) => b.why.includes('datePublished')).length;
   if (noDates) {
     console.error(
-      '\n  Похоже на сборку без git-истории: даты берутся из коммитов по контентным .md ' +
-        '(scripts/gen-content-dates.mjs). В CI нужен actions/checkout с fetch-depth: 0.',
+      '\n  Даты берутся из коммитов по контентным .md (scripts/gen-content-dates.mjs). Две причины:\n' +
+        '   • сборка без git-истории — в CI нужен actions/checkout с fetch-depth: 0;\n' +
+        '   • разъехались ключи _sources.json (от generate_api.py --emit-sources) и content-dates.json —\n' +
+        '     оба считают путь от src/, и src-root игры обязан лежать прямо в src/{game}.',
     );
   }
 }
+// Одна-единственная дата изменения на весь dist означала бы, что источником стал момент
+// сборки, а не история контента (см. #219). Порог мягкий: важно «не одна», а не «сколько».
+if (withArticle > 100 && modifiedDates.size < 2) {
+  errors.push(
+    `dateModified одинаковый на всех ${withArticle} страницах (${[...modifiedDates][0]}) — ` +
+      `похоже, даты приехали из сборки, а не из истории контента`,
+  );
+}
+
 // Покрытие Article: если он вдруг исчез со всех страниц, гейт выше промолчит (нечего ломать).
 if (withArticle < pages * 0.9) {
   errors.push(`Article найден только на ${withArticle} из ${pages} страниц — шаблон JSON-LD сломан`);

--- a/web/scripts/verify_dist_meta_budget.mjs
+++ b/web/scripts/verify_dist_meta_budget.mjs
@@ -10,6 +10,8 @@
 //      разделителем (· против —), то есть были дублями по существу.
 //   4) КОРОТКИЕ description — Bing (правило 118 «Meta descriptions too short», #213) ругался
 //      на сниппеты 95–102 символа; нижняя граница комфорта — 110.
+//   5) НЕПОЛНЫЙ Article в JSON-LD (#219) — без image и дат Google не выдаёт rich-результат
+//      вовсе, а даты у нас приезжают из git и на мелком клоне молча исчезают. Гейт нулевой.
 //
 // Гейт — БЮДЖЕТНЫЙ, а не нулевой: чиним разделы волнами (монстры/животные → заклинания →
 // магпредметы → …), и до конца волн нули недостижимы. Скрипт валит CI, если стало ХУЖЕ
@@ -73,6 +75,10 @@ const decode = (s) =>
 
 const byDescription = new Map(); // description → [страницы]
 const shortDescriptions = []; // { page, len }
+// Article без обязательных полей (#219) и страницы, где JSON-LD вовсе не разобрался.
+const ARTICLE_REQUIRED = ['image', 'datePublished', 'dateModified', 'author', 'publisher'];
+const brokenArticles = []; // { page, why }
+let withArticle = 0;
 const byTitle = new Map(); // title → [страницы]
 const longTitles = []; // { page, len }
 let pages = 0;
@@ -93,6 +99,28 @@ for (const file of htmlFiles(DIST)) {
       if (key.length < DESCRIPTION_MIN) shortDescriptions.push({ page, len: key.length });
       if (!byDescription.has(key)) byDescription.set(key, []);
       byDescription.get(key).push(page);
+    }
+  }
+
+  // JSON-LD: сам граф — в <head>, но регексп по нему целиком дешевле, чем резать скрипты.
+  const ld = head.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/);
+  if (ld) {
+    let graph = null;
+    try {
+      graph = JSON.parse(ld[1]);
+    } catch {
+      brokenArticles.push({ page, why: 'JSON-LD не парсится' });
+    }
+    const nodes = graph?.['@graph'] ?? [];
+    const article = nodes.find((n) => n['@type'] === 'Article');
+    const org = nodes.find((n) => n['@type'] === 'Organization');
+    if (org && !(Array.isArray(org.sameAs) && org.sameAs.length)) {
+      brokenArticles.push({ page, why: 'Organization без sameAs' });
+    }
+    if (article) {
+      withArticle++;
+      const missing = ARTICLE_REQUIRED.filter((k) => !article[k]);
+      if (missing.length) brokenArticles.push({ page, why: `Article без ${missing.join(', ')}` });
     }
   }
 
@@ -126,6 +154,7 @@ console.log(`  дубли description: ${dupPages} страниц в ${dupGroups
 console.log(`  <title> > ${TITLE_LIMIT} символов: ${longTitles.length} страниц (бюджет ${BUDGET.longTitlePages})`);
 console.log(`  дубли <title>: ${dupTitlePages} страниц в ${dupTitleGroups.length} группах (бюджет ${BUDGET.dupTitlePages})`);
 console.log(`  description < ${DESCRIPTION_MIN} символов: ${shortDescriptions.length} страниц (бюджет ${BUDGET.shortDescriptionPages})`);
+console.log(`  Article в JSON-LD: ${withArticle} страниц, неполных ${brokenArticles.length} (бюджет 0)`);
 
 const errors = [];
 
@@ -190,6 +219,25 @@ if (shortDescriptions.length > BUDGET.shortDescriptionPages) {
   errors.push(
     `коротких description стало ${shortDescriptions.length} при бюджете ${BUDGET.shortDescriptionPages} — опусти BUDGET.shortDescriptionPages`,
   );
+}
+
+// Article — гейт нулевой: поля либо есть у всех, либо сломался источник (напр. мелкий клон
+// без git-истории → нет дат). Половинчатого состояния здесь не бывает.
+if (brokenArticles.length) {
+  errors.push(`неполный JSON-LD: ${brokenArticles.length} страниц`);
+  console.error('\n  Примеры:');
+  for (const { page, why } of brokenArticles.slice(0, 10)) console.error(`    ${why} — ${page}`);
+  const noDates = brokenArticles.filter((b) => b.why.includes('datePublished')).length;
+  if (noDates) {
+    console.error(
+      '\n  Похоже на сборку без git-истории: даты берутся из коммитов по контентным .md ' +
+        '(scripts/gen-content-dates.mjs). В CI нужен actions/checkout с fetch-depth: 0.',
+    );
+  }
+}
+// Покрытие Article: если он вдруг исчез со всех страниц, гейт выше промолчит (нечего ломать).
+if (withArticle < pages * 0.9) {
+  errors.push(`Article найден только на ${withArticle} из ${pages} страниц — шаблон JSON-LD сломан`);
 }
 
 if (errors.length) {

--- a/web/src/components/ReaderShell.astro
+++ b/web/src/components/ReaderShell.astro
@@ -10,6 +10,7 @@ import {
   NAV, SYSTEMS, FLAT_PAGES, findPath, systemOf, isGroup, flattenPages,
   label, routeOf, systemRoute, homeRoute, type Lang, type NavGroup, type NavNode,
 } from '../lib/nav';
+import { pageDates } from '../lib/content-dates.mjs';
 
 export interface Props {
   lang: Lang;
@@ -25,8 +26,11 @@ export interface Props {
   image?: string;        // og:image страницы (портрет существа, #201); по умолчанию общий og.png
   imageWidth?: number;
   imageHeight?: number;
+  // Откуда собран контент сущностной страницы (#219) — чтобы взять даты изменения из git.
+  // У markdown-глав источник известен из sourceId, здесь его передавать не надо.
+  contentSource?: { game: string; ver: string; lang: string; resource: string };
 }
-const { lang, currentId, title, description, headings = [], sourceId, searchTitle, bilingual = false, titleRu, upLink, image, imageWidth, imageHeight } = Astro.props;
+const { lang, currentId, title, description, headings = [], sourceId, searchTitle, bilingual = false, titleRu, upLink, image, imageWidth, imageHeight, contentSource } = Astro.props;
 const REPO = 'https://github.com/OmnisGM-App/OmnisGM-Rules';
 const REPO_BRANCH = 'main'; // дефолтная ветка репо — для ссылок «Источник»
 const MAIN = 'https://omnisgm.com';
@@ -121,9 +125,13 @@ const pageUrl = SITE + currentPath; // currentPath с trailing slash (trailingSl
 const nodeRoute = (n: NavNode): string =>
   isGroup(n) ? (flattenPages(n.kids)[0] ? routeOf(flattenPages(n.kids)[0].slug, lang) : homeRoute(lang))
              : routeOf(n.slug, lang);
+// sameAs — брендовый сигнал: связывает три наших ресурса и репозиторий в одну сущность.
+// Практический смысл именно здесь: в выдаче по «OmnisGM» соседствует научная статья
+// «OmniSGM», и без явных связей поисковику не за что зацепиться (#219).
 const org = {
   '@type': 'Organization', '@id': SITE + '/#org', name: 'OmnisGM', url: MAIN,
   logo: { '@type': 'ImageObject', url: SITE + '/icon-512.png', width: 512, height: 512 },
+  sameAs: [MAIN + '/', 'https://news.omnisgm.com/', SITE + '/', REPO],
 };
 const webSite = {
   '@type': 'WebSite', '@id': SITE + '/#website', url: SITE + '/',
@@ -136,11 +144,20 @@ if (currentId !== 'home' && trail.length) {
     '@type': 'BreadcrumbList',
     itemListElement: crumbs.map((c, i) => ({ '@type': 'ListItem', position: i + 1, name: c.name, item: SITE + c.url })),
   });
+  // Article без image и без дат Google не показывает rich-результатом вовсе (#219).
+  // image — портрет сущности, если он есть, иначе общий og.png (у обоих абсолютный URL).
+  // Даты — из git по исходному markdown; на сборке без истории их не будет, и это лучше,
+  // чем дата билда у всех 6000 страниц разом (см. lib/content-dates.mjs).
+  const dates = pageDates({ sourceId, contentSource });
   graph.push({
     '@type': 'Article', '@id': pageUrl + '#article',
     headline: searchTitle ?? title, url: pageUrl, inLanguage: lang,
     ...(description ? { description } : {}),
+    image: SITE + (image ?? '/og.png'),
+    ...(dates ? { datePublished: dates.published, dateModified: dates.modified } : {}),
+    author: { '@id': SITE + '/#org' },
     isPartOf: { '@id': SITE + '/#website' }, publisher: { '@id': SITE + '/#org' },
+    mainEntityOfPage: { '@type': 'WebPage', '@id': pageUrl },
   });
 }
 const jsonLd = { '@context': 'https://schema.org', '@graph': graph };

--- a/web/src/lib/content-dates.mjs
+++ b/web/src/lib/content-dates.mjs
@@ -1,0 +1,71 @@
+// Даты контента страницы для JSON-LD (issue #219).
+//
+// Источник — карта из git (scripts/gen-content-dates.mjs, путь .md → published/modified) плюс
+// карта «ресурс → исходные .md» из парсера (scripts/gen-entity-data.mjs → _sources.json).
+// Обе генерятся в prebuild и лежат в gitignored src/data/.
+//
+// Страница бывает двух видов:
+//   • markdown-глава — один исходный файл, известен как sourceId («dnd/srd-5.2/ru/07_Spells»);
+//   • сущностная (заклинание, монстр, навык) — собрана парсером из одного-двух файлов главы;
+//     ресурс знает страница, файлы — карта _sources.json.
+//
+// Дат может не быть вовсе (мелкий клон в CI, сборка без git) — тогда возвращаем null, и
+// вызывающий просто не кладёт поля в JSON-LD. Дата билда вместо настоящей — хуже, чем ничего:
+// на 6000 страниц она означала бы «всё обновилось разом», а это шум для поисковика.
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DATA_ROOT = path.resolve(process.cwd(), 'src/data');
+
+const readJson = (file, fallback) => {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf-8'));
+  } catch {
+    return fallback;
+  }
+};
+
+const dates = readJson(path.join(DATA_ROOT, 'content-dates.json'), { shallow: true, files: {} });
+const sources = readJson(path.join(DATA_ROOT, 'api', '_sources.json'), {});
+
+/** Есть ли вообще даты в этой сборке (false на мелком клоне / без git). */
+export const hasContentDates = () => Object.keys(dates.files ?? {}).length > 0;
+
+/** Даты одного .md (путь от src/, с расширением или без). null, если файла нет в карте. */
+export function datesForFile(mdPath) {
+  if (!mdPath) return null;
+  const key = mdPath.endsWith('.md') ? mdPath : `${mdPath}.md`;
+  return dates.files?.[key] ?? null;
+}
+
+/**
+ * Даты набора файлов: published — самая ранняя, modified — самая поздняя. Ресурс может
+ * собираться из нескольких глав (оружие и доспехи — из одной «Снаряжение»), и «страница
+ * появилась» тогда = когда появился первый из источников.
+ */
+export function datesForFiles(mdPaths) {
+  const found = (mdPaths ?? []).map(datesForFile).filter(Boolean);
+  if (!found.length) return null;
+  return {
+    published: found.map((d) => d.published).sort()[0],
+    modified: found.map((d) => d.modified).sort().at(-1),
+  };
+}
+
+/** Даты сущностной страницы по её коллекции API: game/ver/lang/resource. */
+export function datesForResource(game, ver, lang, resource) {
+  return datesForFiles(sources[`${game}/${ver}/${lang}/${resource}`]);
+}
+
+/**
+ * Единая точка для шаблона: что бы страница ни знала о себе — sourceId (глава) или
+ * контентный ресурс (сущность), — отсюда выходит одна пара дат или null.
+ */
+export function pageDates({ sourceId, contentSource } = {}) {
+  if (sourceId) return datesForFile(sourceId);
+  if (contentSource) {
+    const { game, ver, lang, resource } = contentSource;
+    return datesForResource(game, ver, lang, resource);
+  }
+  return null;
+}

--- a/web/src/pages/[lang]/brp/[version]/professions/[slug].astro
+++ b/web/src/pages/[lang]/brp/[version]/professions/[slug].astro
@@ -53,6 +53,7 @@ const title = pageTitle({ name: entity.name, kind, lang, game: 'brp', version: v
 ---
 
 <ReaderShell
+  contentSource={{ game: 'brp', ver, lang, resource: 'professions' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/brp/[version]/professions/all.astro
+++ b/web/src/pages/[lang]/brp/[version]/professions/all.astro
@@ -42,6 +42,7 @@ const upLink = { href: `/${lang}/${GAME}/${verSlug}/09_Glossary/04_Professions/`
 ---
 
 <ReaderShell
+  contentSource={{ game: 'brp', ver, lang, resource: 'professions' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/brp/[version]/skills/[slug].astro
+++ b/web/src/pages/[lang]/brp/[version]/skills/[slug].astro
@@ -59,6 +59,7 @@ const title = pageTitle({ name: entity.name, kind, lang, game: 'brp', version: v
 ---
 
 <ReaderShell
+  contentSource={{ game: 'brp', ver, lang, resource: 'skills' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/brp/[version]/skills/all.astro
+++ b/web/src/pages/[lang]/brp/[version]/skills/all.astro
@@ -53,6 +53,7 @@ const upLink = { href: `/${lang}/${GAME}/${verSlug}/09_Glossary/01_Skills/`, ru:
 ---
 
 <ReaderShell
+  contentSource={{ game: 'brp', ver, lang, resource: 'skills' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/brp/[version]/skills/category/[category].astro
+++ b/web/src/pages/[lang]/brp/[version]/skills/category/[category].astro
@@ -51,6 +51,7 @@ const description = t(
 ---
 
 <ReaderShell
+  contentSource={{ game: 'brp', ver, lang, resource: 'skills' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/brp/[version]/spot-rules/[slug].astro
+++ b/web/src/pages/[lang]/brp/[version]/spot-rules/[slug].astro
@@ -53,6 +53,7 @@ const title = pageTitle({ name: entity.name, kind, lang, game: 'brp', version: v
 ---
 
 <ReaderShell
+  contentSource={{ game: 'brp', ver, lang, resource: 'spot-rules' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/brp/[version]/spot-rules/all.astro
+++ b/web/src/pages/[lang]/brp/[version]/spot-rules/all.astro
@@ -42,6 +42,7 @@ const upLink = { href: `/${lang}/${GAME}/${verSlug}/06_SpotRules/`, ru: 'Точ�
 ---
 
 <ReaderShell
+  contentSource={{ game: 'brp', ver, lang, resource: 'spot-rules' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/daggerheart/[version]/adversaries/[slug].astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/adversaries/[slug].astro
@@ -62,6 +62,7 @@ const portrait = creatureImage('daggerheart', entity.slug);
 ---
 
 <ReaderShell
+  contentSource={{ game: 'daggerheart', ver, lang, resource: 'adversaries' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/daggerheart/[version]/adversaries/all.astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/adversaries/all.astro
@@ -49,6 +49,7 @@ const upLink = { href: `/${lang}/${GAME}/${verSlug}/13_Adversaries/`, ru: 'Пр�
 ---
 
 <ReaderShell
+  contentSource={{ game: 'daggerheart', ver, lang, resource: 'adversaries' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/daggerheart/[version]/adversaries/tier/[tier].astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/adversaries/tier/[tier].astro
@@ -52,6 +52,7 @@ const upLink = { href: `${base}/all/`, ru: 'Все противники', en: 'A
 ---
 
 <ReaderShell
+  contentSource={{ game: 'daggerheart', ver, lang, resource: 'adversaries' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/daggerheart/[version]/adversaries/type/[type].astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/adversaries/type/[type].astro
@@ -58,6 +58,7 @@ const tiers = [...new Set(adversaries.map((a) => a.tier))].sort((a, b) => a - b)
 ---
 
 <ReaderShell
+  contentSource={{ game: 'daggerheart', ver, lang, resource: 'adversaries' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/daggerheart/[version]/ancestries/[slug].astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/ancestries/[slug].astro
@@ -54,6 +54,7 @@ const title = pageTitle({ name: entity.name, kind, lang, game: 'daggerheart', ve
 ---
 
 <ReaderShell
+  contentSource={{ game: 'daggerheart', ver, lang, resource: 'ancestries' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/daggerheart/[version]/ancestries/all.astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/ancestries/all.astro
@@ -43,6 +43,7 @@ const upLink = { href: `/${lang}/${GAME}/${verSlug}/05_Ancestries/`, ru: 'Про
 ---
 
 <ReaderShell
+  contentSource={{ game: 'daggerheart', ver, lang, resource: 'ancestries' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/daggerheart/[version]/communities/[slug].astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/communities/[slug].astro
@@ -54,6 +54,7 @@ const title = pageTitle({ name: entity.name, kind, lang, game: 'daggerheart', ve
 ---
 
 <ReaderShell
+  contentSource={{ game: 'daggerheart', ver, lang, resource: 'communities' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/daggerheart/[version]/communities/all.astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/communities/all.astro
@@ -43,6 +43,7 @@ const upLink = { href: `/${lang}/${GAME}/${verSlug}/06_Communities/`, ru: 'Со�
 ---
 
 <ReaderShell
+  contentSource={{ game: 'daggerheart', ver, lang, resource: 'communities' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/daggerheart/[version]/domain-cards/[slug].astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/domain-cards/[slug].astro
@@ -62,6 +62,7 @@ const domainHref = `/${lang}/${GAME}/${verSlug}/domain-cards/domain/${entity.dom
 ---
 
 <ReaderShell
+  contentSource={{ game: 'daggerheart', ver, lang, resource: 'domain-cards' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/daggerheart/[version]/domain-cards/all.astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/domain-cards/all.astro
@@ -57,6 +57,7 @@ const upLink = { href: `/${lang}/${GAME}/${verSlug}/16_DomainCardReference/`, ru
 ---
 
 <ReaderShell
+  contentSource={{ game: 'daggerheart', ver, lang, resource: 'domain-cards' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/daggerheart/[version]/domain-cards/domain/[domain].astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/domain-cards/domain/[domain].astro
@@ -66,6 +66,7 @@ const upLink = { href: `${base}/all/`, ru: 'Все доменные карты',
 ---
 
 <ReaderShell
+  contentSource={{ game: 'daggerheart', ver, lang, resource: 'domain-cards' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/daggerheart/[version]/environments/[slug].astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/environments/[slug].astro
@@ -58,6 +58,7 @@ const title = pageTitle({ name: entity.name, kind, lang, game: 'daggerheart', ve
 ---
 
 <ReaderShell
+  contentSource={{ game: 'daggerheart', ver, lang, resource: 'environments' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/daggerheart/[version]/environments/all.astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/environments/all.astro
@@ -46,6 +46,7 @@ const upLink = { href: `/${lang}/${GAME}/${verSlug}/14_Environments/`, ru: 'Ок
 ---
 
 <ReaderShell
+  contentSource={{ game: 'daggerheart', ver, lang, resource: 'environments' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/daggerheart/[version]/environments/tier/[tier].astro
+++ b/web/src/pages/[lang]/daggerheart/[version]/environments/tier/[tier].astro
@@ -51,6 +51,7 @@ const upLink = { href: `${base}/all/`, ru: 'Все окружения', en: 'All
 ---
 
 <ReaderShell
+  contentSource={{ game: 'daggerheart', ver, lang, resource: 'environments' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/animals/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/animals/[slug].astro
@@ -149,6 +149,7 @@ const portrait = creatureImage('dnd', entity.slug);
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'animals' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/animals/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/animals/all.astro
@@ -37,6 +37,7 @@ const description = t(
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'animals' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/animals/cr/[cr].astro
+++ b/web/src/pages/[lang]/dnd/[version]/animals/cr/[cr].astro
@@ -58,6 +58,7 @@ const otherCr = CR_HUBS.filter((h) => h.slug !== crHubSlug && h.values.some((v) 
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'animals' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/armor/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/armor/[slug].astro
@@ -100,6 +100,7 @@ const icon = entityImage('dnd', 'gear', entity.slug);
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'armor' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/backgrounds/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/backgrounds/[slug].astro
@@ -53,6 +53,7 @@ const title = pageTitle({ name: entity.name, kind, lang, game: 'dnd', version: v
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'backgrounds' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/character-origins/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/character-origins/all.astro
@@ -48,6 +48,7 @@ const rows = [
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'species' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/equipment/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/equipment/[slug].astro
@@ -102,6 +102,7 @@ const icon = entityImage('dnd', 'gear', entity.slug);
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'equipment' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/feats/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/feats/[slug].astro
@@ -91,6 +91,7 @@ const title = pageTitle({ name: entity.name, kind, lang, game: 'dnd', version: v
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'feats' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/magic-items/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/magic-items/[slug].astro
@@ -92,6 +92,7 @@ const icon = entityImage('dnd', 'magic-items', entity.slug);
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'magic-items' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/magic-items/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/magic-items/all.astro
@@ -38,6 +38,7 @@ const description = t(
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'magic-items' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/magic-items/rarity/[rarity].astro
+++ b/web/src/pages/[lang]/dnd/[version]/magic-items/rarity/[rarity].astro
@@ -57,6 +57,7 @@ const otherRarities = RARITIES.filter((r) => r.slug !== rSlug && present.has(r.s
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'magic-items' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/[slug].astro
@@ -151,6 +151,7 @@ const portrait = creatureImage('dnd', entity.slug);
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'monsters' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/all.astro
@@ -37,6 +37,7 @@ const description = t(
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'monsters' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/cr/[cr].astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/cr/[cr].astro
@@ -56,6 +56,7 @@ const otherCr = CR_HUBS.filter((h) => h.slug !== crHubSlug);
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'monsters' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/monsters-a-z/type/[type].astro
+++ b/web/src/pages/[lang]/dnd/[version]/monsters-a-z/type/[type].astro
@@ -53,6 +53,7 @@ const otherTypes = activeMonsterTypes(ver).filter((x) => x.slug !== typeSlug);
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'monsters' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/races/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/races/[slug].astro
@@ -59,6 +59,7 @@ const title = pageTitle({ name: entity.name, kind, lang, game: 'dnd', version: v
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'races' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/races/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/races/all.astro
@@ -43,6 +43,7 @@ const upLink = { href: `${base}/`, ru: 'Расы (глава)', en: 'Races (chap
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'races' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/rules-glossary/action/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/rules-glossary/action/[slug].astro
@@ -49,6 +49,7 @@ const title = pageTitle({ name: entity.name, kind, lang, game: 'dnd', version: v
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'actions' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/rules-glossary/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/rules-glossary/all.astro
@@ -53,6 +53,7 @@ const upLink = { href: `/${lang}/dnd/${verSlug}/rules-glossary/`, ru: 'Глос�
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'rules-terms' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/rules-glossary/area-of-effect/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/rules-glossary/area-of-effect/[slug].astro
@@ -48,6 +48,7 @@ const title = pageTitle({ name: entity.name, kind, lang, game: 'dnd', version: v
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'areas-of-effect' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/rules-glossary/conditions/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/rules-glossary/conditions/[slug].astro
@@ -65,6 +65,7 @@ const title = pageTitle({ name: entity.name, kind, lang, game: 'dnd', version: v
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'conditions' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/rules-glossary/term/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/rules-glossary/term/[slug].astro
@@ -47,6 +47,7 @@ const title = pageTitle({ name: entity.name, kind, lang, game: 'dnd', version: v
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'rules-terms' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/species/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/species/[slug].astro
@@ -52,6 +52,7 @@ const title = pageTitle({ name: entity.name, kind, lang, game: 'dnd', version: v
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'species' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/[slug].astro
@@ -164,6 +164,7 @@ const icon = entityImage('dnd', 'spells', entity.slug);
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'spells' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/spells/all.astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/all.astro
@@ -40,6 +40,7 @@ const description = t(
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'spells' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/spells/class/[class].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/class/[class].astro
@@ -65,6 +65,7 @@ const otherClasses = SPELL_CLASSES.filter((c) => c.slug !== classSlug);
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'spells' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/spells/level/[level].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/level/[level].astro
@@ -55,6 +55,7 @@ const otherLevels = LEVELS.filter((n) => n !== level);
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'spells' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/spells/school/[school].astro
+++ b/web/src/pages/[lang]/dnd/[version]/spells/school/[school].astro
@@ -55,6 +55,7 @@ const otherSchools = SCHOOL_HUBS.filter((s) => s.slug !== sSlug);
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'spells' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}

--- a/web/src/pages/[lang]/dnd/[version]/weapons/[slug].astro
+++ b/web/src/pages/[lang]/dnd/[version]/weapons/[slug].astro
@@ -127,6 +127,7 @@ const icon = entityImage('dnd', 'gear', entity.slug);
 ---
 
 <ReaderShell
+  contentSource={{ game: 'dnd', ver, lang, resource: 'weapons' }}
   lang={lang}
   currentId={PARENT_NAV[ver]}
   title={title}


### PR DESCRIPTION
Часть #219: поля Article, даты и `sameAs` приезжают; открытым в ишье остаётся валидация
живых страниц в Rich Results Test — её делаю после деплоя и кидаю итог комментом.

## Что было
```json
{ "@type": "Article", "@id": "…#article", "headline": "Аболет", "url": "…",
  "inLanguage": "ru", "description": "…",
  "isPartOf": {"@id": "…#website"}, "publisher": {"@id": "…#org"} }
```
Ни `image`, ни дат, ни `author`. Без image и дат Google Article-rich-result не выдаёт вовсе.

## Что стало
```json
{ "@type": "Article", "@id": "https://rules.omnisgm.com/ru/dnd/srd-5.2/monsters-a-z/aboleth/#article",
  "headline": "Аболет", "url": "…", "inLanguage": "ru", "description": "…",
  "image": "https://rules.omnisgm.com/img/dnd/creatures/aboleth.webp",
  "datePublished": "2026-02-14T09:31:13+02:00",
  "dateModified": "2026-08-19T19:01:44+03:00",
  "author": {"@id": "https://rules.omnisgm.com/#org"},
  "isPartOf": {"@id": "…#website"}, "publisher": {"@id": "…#org"},
  "mainEntityOfPage": {"@type": "WebPage", "@id": "…"} }
```
`image` — портрет сущности, где он есть (#201/#202), иначе общий `og.png`; всегда абсолютный URL.
`Organization` получил `sameAs`: лендинг, новости, rules, репозиторий — тот самый брендовый
сигнал против соседства с научной статьёй «OmniSGM».

`author`/`publisher` — ссылки `@id` на узел `Organization` в том же `@graph`, а не строки и не
копии объекта: одна сущность, описанная один раз. Если на ревью решишь, что RRT надёжнее читает
инлайн-объект, разверну.

## Даты — из истории git, а не из времени сборки
Это главная развилка задачи, поэтому подробно:

- `web/scripts/gen-content-dates.mjs` (prebuild) одним проходом `git log --name-only` по `src/`
  строит карту «файл `.md` → published/modified». Лог идёт от новых к старым: первая встреча
  файла — последнее изменение, последняя — появление.
- Сущностная страница знает свой ресурс и передаёт `contentSource={{ game, ver, lang, resource }}`
  в `ReaderShell`. Какие `.md` стоят за ресурсом — говорит `_sources.json`, который теперь
  умеет отдавать парсер (`generate_api.py --emit-sources`). Это знание живёт в `SOURCES` и
  в JS не дублируется — тот же принцип, что со слагами в #202.
- Markdown-глава берёт дату по своему `sourceId` напрямую.

**На мелком клоне дат нет — намеренно.** `mtime` файла в CI — это время checkout'а, то есть
дата билда на всех 6000 страницах разом; «всё обновилось сегодня» поисковик читает как шум.
Поэтому в `ci.yml` и `deploy.yml` добавлен `fetch-depth: 0` + `filter: blob:none` (история без
старых блобов — клон остаётся быстрым), а без истории поля дат просто не выводятся.

Разброс дат по собранному dist — живой, а не одна дата на всё:

```
2323 "dateModified":"2026-08-19T19:01:44+03:00"   ← правка глоссария D&D 5.2
 380 "dateModified":"2026-02-20T21:29:50+02:00"
 367 "dateModified":"2026-07-09T23:48:16+03:00"
 350 "dateModified":"2026-02-21T19:07:27+02:00"
 …
```

## Проверки
- **`verify_dist_meta_budget.mjs`** — пятый гейт по ВСЕМУ dist: `Article` без
  image/datePublished/dateModified/author/publisher и `Organization` без `sameAs` = 0, плюс
  страховка покрытия (Article обязан находиться почти везде — иначе «0 нарушений» означало бы
  сломанный шаблон, а не порядок). Сейчас: `Article в JSON-LD: 5992 страниц, неполных 0`.
- **Чувствительность гейта проверена**: собрал с пустой картой дат (эмуляция мелкого клона) —
  5992 нарушения и подсказка «нужен fetch-depth: 0». То есть гейт ловит ровно тот отказ,
  который здесь наиболее вероятен.
- **`e2e/seo-jsonld.spec.ts`** — 5 тестов: портрет vs `og.png`, ISO-формат, `modified ≥ published`,
  `author`/`publisher` как `@id`-ссылки, `sameAs`, и отдельно — что даты РАЗНЫЕ у страниц из
  разных SRD и не равны сегодняшней (иначе источник дат — билд, а не контент).
- `astro check` — 0 ошибок; полный прогон Playwright — **202 passed**.

## Мимо scope, но нужно назвать
Два теста `entity-images.spec.ts` брали `fireball` как «заклинание без иконки». Мёрж очереди
картинок (#210) дал ему иконку — и оба покраснели **на main**, ещё до этой ветки. Починил здесь:
сущность без картинки выбирается из данных, а не по имени, иначе тест будет ломаться после
каждой порции генератора.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpZFAJnWNgkswDmHd5KVhF
