### PR TITLE
H1 на глоссарных хабах: заголовок раздела из nav-подписи (#228)

### DIFF
--- a/web/e2e/seo-glossary.spec.ts
+++ b/web/e2e/seo-glossary.spec.ts
@@ -47,3 +47,22 @@ test('sitemap: содержит справочники без хаба (#106), �
   expect(xml).not.toContain('/glossary/glossary/');
   expect(xml).not.toContain('/dnd/srd-5.2/glossary/');
 });
+
+test('индексируемый справочник имеет ровно один H1 с названием раздела (#228)', async ({ page }) => {
+  // Их markdown начинается сразу с таблицы: заголовок раздела в исходном SRD стоит в
+  // оглавлении документа, а не в теле файла. H1 дорисовывает шаблон nav-подписью — той же,
+  // что идёт в <title>, поэтому проверяем не текст-константу, а согласованность с <title>.
+  await page.goto(GLOSSARY_INDEXED);
+  const h1 = page.locator('h1');
+  await expect(h1).toHaveCount(1);
+  const heading = (await h1.textContent())!.trim();
+  expect(heading).toBe('Weapons (Reference)');
+  expect(await page.title()).toContain(heading);
+});
+
+test('страница с собственным H1 второго не получает', async ({ page }) => {
+  // Иначе фолбэк дорисовывал бы заголовок всем подряд, и на обычных главах стало бы два H1 —
+  // это размывает тему не меньше, чем отсутствие заголовка.
+  await page.goto(CONTENT);
+  await expect(page.locator('h1')).toHaveCount(1);
+});

--- a/web/scripts/verify_dist_meta_budget.mjs
+++ b/web/scripts/verify_dist_meta_budget.mjs
@@ -10,6 +10,10 @@
 //      разделителем (· против —), то есть были дублями по существу.
 //   4) КОРОТКИЕ description — Bing (правило 118 «Meta descriptions too short», #213) ругался
 //      на сниппеты 95–102 символа; нижняя граница комфорта — 110.
+//   7) СТРАНИЦА БЕЗ <h1> (#228) — глоссарные хабы начинались сразу с таблицы, потому что
+//      заголовок раздела в исходном SRD живёт в оглавлении, а не в теле файла. Страница без
+//      H1 теряет главный он-пейдж-сигнал темы. Гейт нулевой: заголовок дорисовывает шаблон,
+//      так что «ноль» — это работающий фолбэк, а не удача.
 //   6) БИТЫЙ BreadcrumbList (#220) — уровни строятся из NAV-дерева, и раньше группе без
 //      собственной страницы подставлялась «первая страница-лист внутри»: игра и её первая
 //      редакция давали ОДИН URL (дубль позиций 2–3), «Классы» вели на варвара. Гейт нулевой:
@@ -89,6 +93,8 @@ const modifiedDates = new Set();
 // Крошки (#220): собираем трейлы, проверяем после обхода — «ведёт ли URL на страницу» можно
 // сказать, только когда известен полный список собранных страниц.
 const crumbTrails = []; // { page, urls }
+const noHeading = []; // страницы без <h1> (#228)
+const manyHeadings = []; // и с несколькими — второй H1 размывает тему не меньше, чем его отсутствие
 const pagePaths = new Set(); // '/ru/dnd/...' → страница существует в dist
 const byTitle = new Map(); // title → [страницы]
 const longTitles = []; // { page, len }
@@ -141,6 +147,11 @@ for (const file of htmlFiles(DIST)) {
     }
   }
 
+  // <h1> ищем по всему документу, а не по <head>: он в теле страницы.
+  const h1count = (html.match(/<h1[\s>]/g) ?? []).length;
+  if (h1count === 0) noHeading.push(page);
+  else if (h1count > 1) manyHeadings.push({ page, n: h1count });
+
   const title = head.match(/<title>([^<]*)<\/title>/);
   if (title) {
     const text = decode(title[1]).trim();
@@ -183,6 +194,7 @@ console.log(`  <title> > ${TITLE_LIMIT} символов: ${longTitles.length} �
 console.log(`  дубли <title>: ${dupTitlePages} страниц в ${dupTitleGroups.length} группах (бюджет ${BUDGET.dupTitlePages})`);
 console.log(`  description < ${DESCRIPTION_MIN} символов: ${shortDescriptions.length} страниц (бюджет ${BUDGET.shortDescriptionPages})`);
 console.log(`  Article в JSON-LD: ${withArticle} страниц, неполных ${brokenArticles.length} (бюджет 0); различных dateModified: ${modifiedDates.size}`);
+console.log(`  <h1>: без заголовка ${noHeading.length}, с несколькими ${manyHeadings.length} (бюджет 0/0)`);
 console.log(`  BreadcrumbList: ${crumbTrails.length} страниц, дублей URL в трейле ${crumbDup.length}, ссылок в никуда ${crumbDead.length} (бюджет 0/0)`);
 
 const errors = [];
@@ -273,6 +285,18 @@ if (withArticle > 100 && modifiedDates.size < 2) {
     `dateModified одинаковый на всех ${withArticle} страницах (${[...modifiedDates][0]}) — ` +
       `похоже, даты приехали из сборки, а не из истории контента`,
   );
+}
+
+// H1 — гейт нулевой: заголовок дорисовывается шаблоном, когда его нет в markdown (#228),
+// поэтому «ноль без заголовка» держится само. Ненулевое значение = фолбэк отвалился.
+if (noHeading.length) {
+  errors.push(`страниц без <h1>: ${noHeading.length}`);
+  console.error('\n  Примеры:');
+  for (const p of noHeading.slice(0, 10)) console.error(`    ${p}`);
+}
+if (manyHeadings.length) {
+  errors.push(`страниц с несколькими <h1>: ${manyHeadings.length}`);
+  for (const { page, n } of manyHeadings.slice(0, 10)) console.error(`    ${n}×h1 — ${page}`);
 }
 
 // Крошки — гейт нулевой: дубль URL и ссылка в никуда это всегда баг генерации трейла, а не

--- a/web/src/pages/[lang]/[...slug].astro
+++ b/web/src/pages/[lang]/[...slug].astro
@@ -63,6 +63,15 @@ const title = pageTitle({
 // Фолбэк для всех прочих глав (issue #213): вместо бойлерплейта «… Tabletop RPG System
 // Reference Document in the OmnisGM ecosystem.» (95–102 символа, уникальны только первые
 // три слова) собираем сниппет из содержимого страницы — вводной прозы или её структуры.
+// Заголовок раздела, если его нет в самом markdown (issue #228). Глоссарные хабы —
+// единственный шаблон сайта без H1: их .md начинается сразу с таблицы, потому что заголовок
+// раздела в исходном SRD стоит в оглавлении документа, а не в теле. Для поисковика страница
+// без H1 теряет главный он-пейдж-сигнал темы, поэтому дорисовываем его сами — той же
+// nav-подписью, что идёт в <title>, а не выдумывая второе название.
+// Правим в шаблоне, а не в 30 markdown-файлах: контент — импорт SRD, и своя правка в нём
+// пережила бы переимпорт только до следующего раза.
+const needsHeading = !headings.some((h) => h.depth === 1);
+
 const description =
   (isClass
     ? classDescription({ name: searchTitle, body: entry.body, lang: ref.lang, version: ref.version, verLabel: docLabel })
@@ -78,5 +87,6 @@ const description =
   headings={headings}
   sourceId={entry.id}
 >
+  {needsHeading && <h1>{searchTitle}</h1>}
   <Content />
 </ReaderShell>


### PR DESCRIPTION
Closes #228.

## Почему H1 не было

Не забыли — его нет в исходнике. У глоссарных хабов markdown начинается сразу с таблицы: в SRD заголовок такого раздела стоит в оглавлении документа, а не в теле файла, и конверсия честно это перенесла. Отсюда единственный шаблон сайта без H1.

## Решение: дорисовывает шаблон, а не правка контента

```astro
const needsHeading = !headings.some((h) => h.depth === 1);
...
{needsHeading && <h1>{searchTitle}</h1>}
```

Два решения внутри:
- **`searchTitle`, а не новое название.** Это nav-подпись — ровно то, что уже идёт в `<title>`. Заголовок и title обязаны говорить одно и то же, иначе получается второе имя страницы.
- **Шаблон, а не 30 markdown-файлов.** Контент — импорт SRD; своя правка в нём живёт до следующего переимпорта. В шаблоне фолбэк работает и для будущих файлов, у которых заголовка не окажется.

## Охват

Было 30 страниц без H1, стало 0. В sitemap из них 12 (справочники Daggerheart и BRP), остальные 18 — глоссарные списки D&D, которые 301-редиректятся на `/all/`-хабы; им заголовок не вредит, а исключать их значило бы городить условие ради страниц, которых пользователь не видит.

Страницы с собственным H1 второго не получают — иначе фолбэк размывал бы тему не меньше, чем его отсутствие.

## Проверки

**Гейт по dist** (седьмой в `verify_dist_meta_budget.mjs`), оба нулевые:
```
<h1>: без заголовка 0, с несколькими 0 (бюджет 0/0)
```
Чувствительность проверена сломом в обе стороны: вырезал H1 у одной страницы → `страниц без <h1>: 1` с путём; дописал второй H1 в главу → `страниц с несколькими <h1>: 1`.

**e2e** (`seo-glossary.spec.ts`): у справочника ровно один H1, и его текст **входит в `<title>`** — проверяется согласованность, а не текст-константа; обычная глава остаётся с одним заголовком.

**Вёрстка** — посмотрел страницу в браузере: заголовок в том же стиле, что на остальных страницах, таблица под ним не поехала.

`astro check` 0 ошибок, полный e2e **215 passed**.
