### PR TITLE
Убрать мёртвые роуты Google Fonts из service worker (#224)

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -97,16 +97,11 @@ export default defineConfig({
         skipWaiting: true,
         clientsClaim: true,
         runtimeCaching: [
-          {
-            urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
-            handler: 'CacheFirst',
-            options: { cacheName: 'google-fonts-stylesheets', expiration: { maxEntries: 10, maxAgeSeconds: 31536000 }, cacheableResponse: { statuses: [0, 200] } },
-          },
-          {
-            urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*/i,
-            handler: 'CacheFirst',
-            options: { cacheName: 'google-fonts-webfonts', expiration: { maxEntries: 30, maxAgeSeconds: 31536000 }, cacheableResponse: { statuses: [0, 200] } },
-          },
+          // Правил для Google Fonts здесь нет и быть не должно (#224): шрифты self-hosted
+          // (public/fonts/*.woff2, они же в precache), ни одна страница к Google не ходит.
+          // Дефолтные роуты шаблона vite-pwa стояли тут мёртвым кодом и читались как рабочая
+          // политика — будущий читатель искал бы несуществующую зависимость. С #225 они ещё и
+          // заведомо нерабочие: CSP не разрешает fonts.googleapis.com / fonts.gstatic.com.
           {
             urlPattern: ({ request }) => request.destination === 'document',
             handler: 'NetworkFirst',

--- a/web/e2e/pwa-sw.spec.ts
+++ b/web/e2e/pwa-sw.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+import fs from 'node:fs';
+
+// Service worker: что в нём должно быть и, главное, чего быть не должно (issue #224).
+// Собранный sw.js читаем файлом, а не через браузер: рантайм-роуты внутри него — код, который
+// на живой странице никак не проявляется, пока не совпадёт URL. Мёртвое правило и работающее
+// выглядят в браузере одинаково — никак.
+
+const sw = () => fs.readFileSync('dist/sw.js', 'utf-8');
+
+test('шрифты self-hosted: ни одного роута к Google Fonts', () => {
+  // Дефолтные роуты шаблона vite-pwa кэшировали fonts.googleapis.com / fonts.gstatic.com.
+  // Наши шрифты лежат в public/fonts и уезжают в precache — правила не срабатывали никогда,
+  // но читались как рабочая политика. С enforce-CSP (#225) они ещё и заведомо нерабочие.
+  expect(sw()).not.toMatch(/googleapis|gstatic|google-fonts/);
+});
+
+test('шрифты precache-ятся из своей папки', () => {
+  const fonts = [...sw().matchAll(/fonts\/[^"']+\.woff2/g)].map((m) => m[0]);
+  // Не «больше нуля»: набор начертаний фиксирован, и молчаливая потеря половины из них —
+  // это ровно тот случай, который порогом «>0» не ловится.
+  expect(new Set(fonts).size).toBe(18);
+});
+
+test('рантайм-кэши — только те, что нам нужны', () => {
+  const names = [...sw().matchAll(/cacheName:"([a-z-]+)"/g)].map((m) => m[1]).sort();
+  expect([...new Set(names)]).toEqual(['entity-images', 'pagefind', 'pages']);
+});


### PR DESCRIPTION
Closes #224.

## Что убрано

Два правила `runtimeCaching` из дефолтного шаблона `@vite-pwa/astro`, кэшировавшие `fonts.googleapis.com` и `fonts.gstatic.com`. Шрифты у нас self-hosted (`public/fonts/*.woff2`, они же в precache) — правила не срабатывали никогда.

Вместо них в конфиге стоит комментарий, объясняющий, почему тут ничего нет: **удалённый мёртвый код возвращается**, если не написать, что он мёртв, а следующий читатель искал бы несуществующую зависимость от Google Fonts.

## Проверено на собранном `sw.js`

| | до (прод) | после |
|---|---|---|
| упоминаний `googleapis` | 1 | **0** |
| `cacheName` для шрифтов | `google-fonts-stylesheets`, `google-fonts-webfonts` | **нет** |
| `.woff2` в precache | 18 | **18** |
| рантайм-кэши | `pages`, `pagefind`, `entity-images` | те же три |

Отдельно: сравнивать надо было именно так, а не `grep fonts.googleapis` — в минифицированном `sw.js` это регексп с экранированием (`fonts\.googleapis`), и наивный grep даёт ложный ноль. На этом чуть не поймался.

**Оффлайн не изменился**: `check_csp.mjs` по локальной сборке — страница отдаётся из Cache Storage, нарушений нет.

## e2e

Новый `pwa-sw.spec.ts` читает собранный `sw.js` файлом, а не через браузер — сознательно: рантайм-роут внутри SW на живой странице никак не проявляется, пока не совпадёт URL, поэтому мёртвое правило и рабочее в браузере выглядят одинаково (никак). Три утверждения:
- роутов к Google Fonts нет;
- шрифтов в precache ровно **18**, а не «больше нуля» — молчаливая потеря половины начертаний порогом «>0» не ловится;
- список рантайм-кэшей фиксирован (`entity-images`, `pagefind`, `pages`).

`astro check` 0 ошибок, полный e2e **218 passed**.
