### PR TITLE
[SEO] Хабы документов: числительное в RU-description через pluralRu (#245)

### DIFF
--- a/web/scripts/test_plural.mjs
+++ b/web/scripts/test_plural.mjs
@@ -31,6 +31,15 @@ eq(countPhrase(2, 'ru', ANIMAL, ['animal', 'animals']), 'Все 2 животны
 eq(countPhrase(24, 'ru', MONSTER, ['monster', 'monsters']), 'Все 24 монстра', 'countPhrase(24)');
 eq(countPhrase(5, 'ru', MONSTER, ['monster', 'monsters']), 'Все 5 монстров', 'countPhrase(5)');
 
+// Хабы документов (#245): числа там произвольные и крупные — «884 страниц» вместо «страницы»
+// висело на проде, потому что форма была захардкожена. Реальные значения четырёх хабов.
+const PAGE = ['страница', 'страницы', 'страниц'];
+eq(pluralRu(884, PAGE), 'страницы', 'pluralRu(884) — D&D 5.1');
+eq(pluralRu(1042, PAGE), 'страницы', 'pluralRu(1042) — D&D 5.2');
+eq(pluralRu(364, PAGE), 'страницы', 'pluralRu(364) — Daggerheart');
+eq(pluralRu(78, PAGE), 'страниц', 'pluralRu(78) — BRP');
+eq(pluralRu(25, ['раздел', 'раздела', 'разделов']), 'разделов', 'pluralRu(25) — разделы хаба');
+
 // Английский: форм две, «All» уходит при единице.
 eq(countPhrase(1, 'en', ANIMAL, ['animal', 'animals']), '1 animal', 'countPhrase(1, en)');
 eq(countPhrase(3, 'en', ANIMAL, ['animal', 'animals']), 'All 3 animals', 'countPhrase(3, en)');

--- a/web/src/components/DocHub.astro
+++ b/web/src/components/DocHub.astro
@@ -18,6 +18,7 @@ import {
 import { pageTitle } from '../lib/page-title';
 import { resourceTotal } from '../lib/entity-counts.mjs';
 import { isIndexableGlossary } from '../lib/glossary-seo.mjs';
+import { pluralRu } from '../lib/plural.mjs';
 
 interface Props {
   lang: Lang;
@@ -81,8 +82,12 @@ const title = pageTitle({ name: t('Правила и справочники', 'R
 
 const chapterCount = chapters.reduce((n, c) => n + (isGroup(c) ? c.kids.length : 1), 0);
 const entityCount = compendiums.reduce((n, c) => n + (totalOf(c) ?? 0), 0);
+// Числа тут произвольные (884 страницы, 1042 страницы, 25 разделов) — форму существительного
+// без pluralRu не угадать: захардкоженное «страниц» давало «884 страниц» в сниппете выдачи.
+const sections = pluralRu(chapterCount, ['раздел', 'раздела', 'разделов']);
+const pages = pluralRu(entityCount, ['страница', 'страницы', 'страниц']);
 const description = t(
-  `${sysLabel} ${verLabel} на русском: ${chapterCount} разделов правил и справочники — ${entityCount} страниц заклинаний, монстров, предметов и других сущностей со ссылками на каждую.`,
+  `${sysLabel} ${verLabel} на русском: ${chapterCount} ${sections} правил и справочники — ${entityCount} ${pages} заклинаний, монстров, предметов и других сущностей со ссылками на каждую.`,
   `${sysLabel} ${verLabel} in full: ${chapterCount} rules sections plus reference compendiums — ${entityCount} pages of spells, monsters, items and other entities, each linked.`,
 );
 


### PR DESCRIPTION
Закрывает #245 (кроме последнего пункта — проверка по origin после релиза).

## Что было
RU-description хабов документов собирался с захардкоженной формой: на проде «884 страниц» (D&D 5.1), «1042 страниц» (5.2), «364 страниц» (Daggerheart) — при mod10 = 4/2/4 нужна паукальная «страницы». BRP «78 страниц» был верен случайно.

`plural.mjs` (#240) закрывал 26 числовых хабов и фасетов, а хаб документа (#230, PR #241) выехал тем же днём параллельно и с ним разминулся.

## Что сделано
- `DocHub.astro`: `${entityCount} страниц` и `${chapterCount} разделов` — через `pluralRu`. Разделы переведены заодно: 25/27/9 дают верную форму случайно, но «21 раздел»/«22 раздела» сломались бы так же.
- EN-ветка не тронута («N pages» инвариантен).
- `test_plural.mjs`: кейсы 884 / 1042 / 364 / 78 + 25 разделов — реальные значения четырёх хабов.

Видимый текст хаба чисел со словами не печатает (у ссылки на компендиум только «— 339»), проверять там нечего.

## Прогон
- `astro check` — 0 ошибок, 0 предупреждений.
- `node scripts/test_plural.mjs` — зелёный; `verify_dist_seo` / `verify_dist_meta_budget` / `test_page_description` — в норме (дубли description 0, бюджеты не сдвинулись).
- `playwright test` — 247/247.

Проверено по `dist` (сборка с правкой):

| хаб | description |
|---|---|
| `ru/dnd/srd-5.1` | 27 разделов … **884 страницы** |
| `ru/dnd/srd-5.2` | 25 разделов … **1042 страницы** |
| `ru/daggerheart/srd-1.0` | 25 разделов … **364 страницы** |
| `ru/brp/srd-1.0` | 9 разделов … **78 страниц** |
| `en/dnd/srd-5.2` | 25 rules sections … 1042 pages (не изменилось) |

После релиза остаётся проверить те же 4 RU-хаба по origin `omnisgm-rules.web.app` (не через rules.omnisgm.com — застрявшая CF-копия даёт ложные минусы).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpZFAJnWNgkswDmHd5KVhF
