### PR TITLE
[e2e] Паритет автолинка по HTTP вместо браузера + снятый перехват в csp

### DIFF
--- a/web/e2e/autolink.spec.ts
+++ b/web/e2e/autolink.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { fromHtml } from 'hast-util-from-html';
+import type { Element, Nodes } from 'hast';
 
 // Автоссылки на программные страницы сущностей (issue #20, rehype-entity-autolink):
 // имена состояний в контенте становятся ссылками .ent-link на страницу состояния.
@@ -196,16 +198,52 @@ const EXCEPTIONS: Record<string, string[]> = {
   //  использует канонические состояния, расхождение исчезло.)
 };
 
-async function linkedConditions(page: import('@playwright/test').Page, path: string): Promise<Set<string>> {
-  await page.goto(path);
-  const hrefs = await page
-    .locator('.rd-doc a.ent-link')
-    .evaluateAll((els) => els.map((e) => e.getAttribute('href') || ''));
-  const slugs = hrefs.map((h) => h.match(/\/conditions\/([a-z-]+)\//)?.[1]).filter(Boolean) as string[];
-  return new Set(slugs);
+/**
+ * Слаги состояний, на которые ссылается контент страницы.
+ *
+ * Разбираем ГОТОВЫЙ HTML, а не открываем страницу браузером (#248). Проверяется атрибут
+ * `href` в статической разметке — рендер, стили и скрипты для этого не нужны, а обход всех
+ * глав через `page.goto` стоил теста: 165 глав × 2 языка = 330 навигаций в одном тесте при
+ * бюджете 30 с, то есть ~90 мс на страницу. Тест жил на грани по построению и краснел в
+ * полном прогоне при исправном коде.
+ *
+ * Парсер, а не регулярка: разметка приходит из markdown-конвейера, и «ссылка внутри rd-doc»
+ * — это структура дерева, которую регулярка отличает от ссылки в шапке лишь по совпадению.
+ */
+function linkedConditionsIn(html: string): Set<string> {
+  const tree = fromHtml(html);
+
+  const classesOf = (node: Element): string[] => {
+    const className = node.properties?.className;
+    return Array.isArray(className) ? className.map(String) : [];
+  };
+
+  const collect = (node: Nodes, inDoc: boolean, out: Set<string>): void => {
+    const element = node.type === 'element' ? (node as Element) : null;
+    const insideDoc = inDoc || (element ? classesOf(element).includes('rd-doc') : false);
+
+    if (element && insideDoc && element.tagName === 'a' && classesOf(element).includes('ent-link')) {
+      const slug = String(element.properties?.href ?? '').match(/\/conditions\/([a-z-]+)\//)?.[1];
+      if (slug) out.add(slug);
+    }
+
+    for (const child of ('children' in node ? node.children : []) as Nodes[]) {
+      collect(child, insideDoc, out);
+    }
+  };
+
+  const slugs = new Set<string>();
+  collect(tree, false, slugs);
+  return slugs;
 }
 
-test('EN/RU: набор слинкованных состояний совпадает по всем главам (кроме allowlist)', async ({ page, request }) => {
+async function linkedConditions(request: APIRequestContext, path: string): Promise<Set<string>> {
+  const response = await request.get(path);
+  expect(response.ok(), `${path} отдал ${response.status()}`).toBeTruthy();
+  return linkedConditionsIn(await response.text());
+}
+
+test('EN/RU: набор слинкованных состояний совпадает по всем главам (кроме allowlist)', async ({ request }) => {
   const sitemap = await (await request.get('/sitemap-0.xml')).text();
   const chapters = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)]
     .map((m) => new URL(m[1]).pathname)
@@ -231,8 +269,10 @@ test('EN/RU: набор слинкованных состояний совпад
   const failures: string[] = [];
   for (const en of chapters) {
     const ru = en.replace('/en/', '/ru/');
-    const enSet = await linkedConditions(page, en);
-    const ruSet = await linkedConditions(page, ru);
+    const [enSet, ruSet] = await Promise.all([
+      linkedConditions(request, en),
+      linkedConditions(request, ru),
+    ]);
     const diff = [...new Set([...enSet, ...ruSet])].filter((s) => enSet.has(s) !== ruSet.has(s));
     const allow = new Set(EXCEPTIONS[en] || []);
     for (const s of diff) {

--- a/web/e2e/autolink.spec.ts
+++ b/web/e2e/autolink.spec.ts
@@ -267,12 +267,18 @@ test('EN/RU: набор слинкованных состояний совпад
 
   const usedExceptions = new Set<string>();
   const failures: string[] = [];
+  // Страниц, где ссылки на состояния реально нашлись. Тест сравнивает EN и RU между собой,
+  // поэтому вырождение парсера (пустые множества везде) выглядело бы как «расхождений нет» —
+  // зелёный тест, не проверивший ничего. Порог ниже ловит именно это.
+  let pagesWithLinks = 0;
   for (const en of chapters) {
     const ru = en.replace('/en/', '/ru/');
     const [enSet, ruSet] = await Promise.all([
       linkedConditions(request, en),
       linkedConditions(request, ru),
     ]);
+    if (enSet.size) pagesWithLinks++;
+    if (ruSet.size) pagesWithLinks++;
     const diff = [...new Set([...enSet, ...ruSet])].filter((s) => enSet.has(s) !== ruSet.has(s));
     const allow = new Set(EXCEPTIONS[en] || []);
     for (const s of diff) {
@@ -280,6 +286,10 @@ test('EN/RU: набор слинкованных состояний совпад
       else failures.push(`${en}: '${s}' (EN=${enSet.has(s)} RU=${ruSet.has(s)}) — вне allowlist`);
     }
   }
+  // Фактических страниц со слинкованными состояниями — 50 (замер по всему корпусу); порог
+  // взят с запасом вниз, чтобы не ломаться от правок контента, но ловить обнуление.
+  expect(pagesWithLinks, 'ссылки на состояния не найдены нигде — парсер вырожден').toBeGreaterThan(30);
+
   expect(failures, `новые EN/RU-расхождения:\n${failures.join('\n')}`).toEqual([]);
 
   // Протухшие исключения: каждая запись allowlist должна реально срабатывать (иначе — убрать).

--- a/web/e2e/csp.spec.ts
+++ b/web/e2e/csp.spec.ts
@@ -19,6 +19,19 @@ const csp = (() => {
   return h as { key: string; value: string };
 })();
 
+/**
+ * Снять перехват до конца теста (#249).
+ *
+ * `arm` вешает route на ВЕСЬ трафик, а страница продолжает грузить ассеты и после проверок:
+ * service worker дотягивает css/js в фоне (в логе видно `referer: /sw.js`). Когда тест
+ * заканчивается раньше этих запросов, колбэк route падает уже вне теста — «route.fetch: Test
+ * ended», и Playwright засчитывает прогону ошибку вне теста, а один тест остаётся
+ * незапущенным. Гонка тайминговая: проявляется тем чаще, чем быстрее идут соседние тесты.
+ */
+const disarm = async (context: BrowserContext) => {
+  await context.unrouteAll({ behavior: 'ignoreErrors' });
+};
+
 const arm = async (context: BrowserContext) => {
   await context.addInitScript(() => {
     (window as any).__csp = [];
@@ -47,6 +60,7 @@ test('политика не ломает главу, сущность и пои�
   await expect(page.locator('mark').first()).toBeVisible({ timeout: 10_000 });
 
   expect(await page.evaluate(() => (window as any).__csp)).toEqual([]);
+  await disarm(context);
 });
 
 test('политика запрещает чужие источники (иначе гейт выше ничего не значит)', async ({ context }) => {
@@ -64,4 +78,5 @@ test('политика запрещает чужие источники (ина�
   expect(await page.evaluate(() => (window as any).__csp)).toContain(
     'script-src-elem ← https://cdn.example.com/evil.js',
   );
+  await disarm(context);
 });

--- a/web/e2e/csp.spec.ts
+++ b/web/e2e/csp.spec.ts
@@ -27,10 +27,16 @@ const csp = (() => {
  * заканчивается раньше этих запросов, колбэк route падает уже вне теста — «route.fetch: Test
  * ended», и Playwright засчитывает прогону ошибку вне теста, а один тест остаётся
  * незапущенным. Гонка тайминговая: проявляется тем чаще, чем быстрее идут соседние тесты.
+ *
+ * Именно ХУК, а не строка в конце каждого теста: первый упавший `expect` обрывает тело, и
+ * перехват остался бы висеть ровно в том случае, ради которого этот файл написан, — при
+ * настоящей регрессии CSP. Тогда поверх честного падения легла бы ещё и «route.fetch: Test
+ * ended» с незапущенным тестом. `afterEach` выполняется и после упавшего тела, и после
+ * таймаута, и покрывает будущие тесты файла даром.
  */
-const disarm = async (context: BrowserContext) => {
+test.afterEach(async ({ context }) => {
   await context.unrouteAll({ behavior: 'ignoreErrors' });
-};
+});
 
 const arm = async (context: BrowserContext) => {
   await context.addInitScript(() => {
@@ -60,7 +66,6 @@ test('политика не ломает главу, сущность и пои�
   await expect(page.locator('mark').first()).toBeVisible({ timeout: 10_000 });
 
   expect(await page.evaluate(() => (window as any).__csp)).toEqual([]);
-  await disarm(context);
 });
 
 test('политика запрещает чужие источники (иначе гейт выше ничего не значит)', async ({ context }) => {
@@ -78,5 +83,4 @@ test('политика запрещает чужие источники (ина�
   expect(await page.evaluate(() => (window as any).__csp)).toContain(
     'script-src-elem ← https://cdn.example.com/evil.js',
   );
-  await disarm(context);
 });

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.10",
         "@playwright/test": "^1.62.1",
+        "@types/hast": "^3.0.4",
         "@vite-pwa/astro": "^1.2.0",
         "astro-pagefind": "^1.8.0",
         "typescript": "^6.0.3"

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
     "@playwright/test": "^1.62.1",
+    "@types/hast": "^3.0.4",
     "@vite-pwa/astro": "^1.2.0",
     "astro-pagefind": "^1.8.0",
     "typescript": "^6.0.3"


### PR DESCRIPTION
Closes #248, closes #249.

## Зачем

`autolink.spec.ts` («EN/RU: набор слинкованных состояний совпадает по всем главам») падал по таймауту в полном прогоне и проходил в одиночном. Причина не в конкретной главе, а в объёме: тест обходит **165 глав**, для каждой открывает EN и RU — **330 навигаций браузера внутри одного теста** при бюджете 30 с. Это ~90 мс на страницу; тест жил на грани по построению, а `retries: 0` красил прогон с первого превышения.

| | до | после |
|---|---|---|
| одиночный прогон | 17,2 с | **2,0 с** |
| в полном прогоне | 22,1 / 27,4 / **31,1 (красный)** | **5,1 / 8,0 / 7,2 с** |

## Что сделано

**Браузер убран из горячего цикла.** Проверяется атрибут `href` в статической разметке — рендер, стили и скрипты для этого не нужны. Берём HTML через `request.get` и разбираем `hast-util-from-html` (пакет уже в зависимостях). Парсер, а не регулярка: «ссылка внутри `.rd-doc`» — это структура дерева, регулярка отличила бы её от ссылки в шапке лишь по совпадению.

**Эквивалентность доказана, а не предположена.** Разовым контролем сверил оба способа по **всему** корпусу: 330 страниц, 50 из них со слинкованными состояниями, **283 пары (страница, слаг)** — парсер и браузер совпали полностью. Без этой сверки зелёный тест ничего не значил бы: молча опустевшие множества дали бы «расхождений нет».

**Соседей с тем же риском нет.** После правки самый долгий тест набора — 3,5 с (CLS с троттлингом, медленный по природе), то есть восьмикратный запас до бюджета.

## Второй коммит — гонка в `csp.spec` (#249)

Ускорение изменило тайминг набора и вскрыло чужую гонку: `csp.spec` вешает `route` на весь трафик и не снимает его, а service worker дотягивает ассеты в фоне уже после последней проверки. Колбэк падает вне теста (`route.fetch: Test ended`), прогон получает ошибку «вне теста», один тест остаётся `did not run`, **exit 1 при 246 зелёных из 247**.

До ускорения этого не было ни в одном из четырёх прогонов, сразу после — в трёх из трёх. Починил здесь же, отдельным коммитом: без этого приёмка самого #248 («трижды зелёный полный прогон») недостижима. Ишья #249 заведена, чтобы находка осталась в истории, а не растворилась в чужом PR.

## Проверено

- Полный прогон **трижды подряд: 247 passed, exit 0**, ошибок «вне теста» — ноль.
- `npm run check` — 0 ошибок.
