### PR TITLE
[CI] Авто-ревью PR плагином omnisgm (claude-code-action)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,67 @@
+name: Claude auto-review
+
+# Авто-ревью каждого коммита PR (#443-процесс, скилл omnisgm-review из плагина omnisgm).
+# Новый пуш в PR отменяет незаконченное ревью и запускает свежее (concurrency ниже).
+# Работает на личной подписке владельца: CLAUDE_CODE_OAUTH_TOKEN из `claude setup-token`.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  # Один прогон на PR: прилетел новый коммит — текущее ревью стопается и стартует заново.
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          # Полная история: ревью сверяет опоры по базовой ветке (git diff base...head).
+          fetch-depth: 0
+
+      - name: Claude review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ github.token }}
+          track_progress: false
+          # Маркетплейс приватный — клонится fine-grained PAT-ом (contents: read
+          # на OmnisGM-App/claude-plugins); секрет в URL маскируется логами Actions.
+          plugin_marketplaces: |
+            https://x-access-token:${{ secrets.CLAUDE_PLUGINS_TOKEN }}@github.com/OmnisGM-App/claude-plugins.git
+          plugins: |
+            omnisgm@omnisgm
+          claude_args: |
+            --max-turns 60
+          prompt: |
+            Ты — CI-ревьюер PR #${{ github.event.pull_request.number }} в ${{ github.repository }}.
+            Прочитай SKILL.md скилла omnisgm-review из установленного плагина omnisgm и проведи
+            ОДИНОЧНОЕ ревью по его §§1–5 с поправками на CI:
+
+            - Рабочая копия — уже вычекнутая ветка PR в $GITHUB_WORKSPACE (не локальные клоны
+              из скилла). Дифф: `git diff origin/${{ github.base_ref }}...HEAD`. Опоры (контракты,
+              полноту замены) проверяй грепом по рабочей копии.
+            - НИЧЕГО не собирать и не запускать: ни тестов, ни эмуляторов, ни песочниц —
+              только чтение кода и диффа. Мутационные проверки пропускай, честно помечая
+              «не проверялось в CI».
+            - Каждая находка — с доказательством (файл:строка, вывод грепа) и тяжестью
+              (❗ существенное / среднее / ремарка). Пре-существующее, вкусовое и «потенциальное»
+              без конкретного входа — не находки.
+            - Публикация: ОДИН review-объект (body + inline-комменты к строкам диффа) через
+              `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews`
+              с event=COMMENT. Тело — шапка-вердикт в одну-две строки (голова, итог, «+N инлайнов»);
+              находка на строку диффа — ТОЛЬКО инлайном с полным текстом, из тела целиком убирается.
+              Если находок нет — короткий коммент «CI-ревью: находок нет» с головой коммита.
+            - НЕ одобрять (no APPROVE), НЕ давать финальный LGTM, НЕ мёржить, НЕ править код:
+              финальный вердикт и гейт прогонов остаются за живой сессией ревью владельца.
+            - Пиши по-русски, тон и формат — как в предыдущих ревью в треде PR.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,8 +1,7 @@
 name: Claude auto-review
 
-# Авто-ревью каждого коммита PR (#443-процесс, скилл omnisgm-review из плагина omnisgm).
-# Новый пуш в PR отменяет незаконченное ревью и запускает свежее (concurrency ниже).
-# Работает на личной подписке владельца: CLAUDE_CODE_OAUTH_TOKEN из `claude setup-token`.
+# Тонкий вызов ЕДИНОГО воркера авто-ревью из репы плагинов — сам процесс ревью и его
+# промт живут одним экземпляром в OmnisGM-App/claude-plugins/.github/workflows/claude-review.yml.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -15,61 +14,11 @@ concurrency:
 jobs:
   review:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    uses: OmnisGM-App/claude-plugins/.github/workflows/claude-review.yml@master
+    secrets: inherit
     permissions:
       contents: read
       pull-requests: write
       issues: read
       id-token: write
       actions: read
-    steps:
-      - name: Checkout PR
-        uses: actions/checkout@v4
-        with:
-          # Полная история: ревью сверяет опоры по базовой ветке (git diff base...head).
-          fetch-depth: 0
-
-      - name: Claude review
-        uses: anthropics/claude-code-action@v1
-        env:
-          GH_PLUGINS_TOKEN: ${{ secrets.CLAUDE_PLUGINS_TOKEN }}
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ github.token }}
-          track_progress: false
-          # Маркетплейс приватный — клонится fine-grained PAT-ом (contents: read
-          # на OmnisGM-App/claude-plugins); секрет в URL маскируется логами Actions.
-          plugin_marketplaces: |
-            https://x-access-token:${{ secrets.CLAUDE_PLUGINS_TOKEN }}@github.com/OmnisGM-App/claude-plugins.git
-          plugins: |
-            omnisgm@omnisgm
-          claude_args: |
-            --max-turns 60
-          prompt: |
-            Ты — CI-ревьюер PR #${{ github.event.pull_request.number }} в ${{ github.repository }}.
-            Прочитай SKILL.md скилла omnisgm-review из установленного плагина omnisgm и проведи
-            ОДИНОЧНОЕ ревью по его §§1–5 с поправками на CI:
-
-            - Рабочая копия — уже вычекнутая ветка PR в $GITHUB_WORKSPACE (не локальные клоны
-              из скилла). Дифф: `git diff origin/${{ github.base_ref }}...HEAD`. Опоры (контракты,
-              полноту замены) проверяй грепом по рабочей копии.
-            - НИЧЕГО не собирать и не запускать: ни тестов, ни эмуляторов, ни песочниц —
-              только чтение кода и диффа. Мутационные проверки пропускай, честно помечая
-              «не проверялось в CI».
-            - Каждая находка — с доказательством (файл:строка, вывод грепа) и тяжестью
-              (❗ существенное / среднее / ремарка). Пре-существующее, вкусовое и «потенциальное»
-              без конкретного входа — не находки.
-            - Публикация: ОДИН review-объект (body + inline-комменты к строкам диффа) через
-              `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews`
-              с event=COMMENT. Тело — шапка-вердикт в одну-две строки (голова, итог, «+N инлайнов»);
-              находка на строку диффа — ТОЛЬКО инлайном с полным текстом, из тела целиком убирается.
-              Если находок нет — короткий коммент «CI-ревью: находок нет» с головой коммита.
-            - НЕ одобрять (no APPROVE), НЕ давать финальный LGTM, НЕ мёржить, НЕ править код:
-              финальный вердикт и гейт прогонов остаются за живой сессией ревью владельца.
-            - Пиши по-русски, тон и формат — как в предыдущих ревью в треде PR.
-            - ПОСЛЕ публикации ревью — цикл улучшения: если по ходу что-то мешало
-              (скилл требовал недоступного в CI, промту не хватило правила, находка оказалась
-              ложной по понятной причине), добавь ОДИН коммент в журнал
-              `gh issue comment 1 --repo OmnisGM-App/claude-plugins` по формату из тела той
-              ишьи (PR/голова, наблюдение, класс). Токен для этого — в env GH_PLUGINS_TOKEN
-              (`GH_TOKEN=$GH_PLUGINS_TOKEN gh issue comment …`). Нечего сказать — не пиши.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Claude review
         uses: anthropics/claude-code-action@v1
+        env:
+          GH_PLUGINS_TOKEN: ${{ secrets.CLAUDE_PLUGINS_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ github.token }}
@@ -65,3 +67,9 @@ jobs:
             - НЕ одобрять (no APPROVE), НЕ давать финальный LGTM, НЕ мёржить, НЕ править код:
               финальный вердикт и гейт прогонов остаются за живой сессией ревью владельца.
             - Пиши по-русски, тон и формат — как в предыдущих ревью в треде PR.
+            - ПОСЛЕ публикации ревью — цикл улучшения: если по ходу что-то мешало
+              (скилл требовал недоступного в CI, промту не хватило правила, находка оказалась
+              ложной по понятной причине), добавь ОДИН коммент в журнал
+              `gh issue comment 1 --repo OmnisGM-App/claude-plugins` по формату из тела той
+              ишьи (PR/голова, наблюдение, класс). Токен для этого — в env GH_PLUGINS_TOKEN
+              (`GH_TOKEN=$GH_PLUGINS_TOKEN gh issue comment …`). Нечего сказать — не пиши.


### PR DESCRIPTION
Авто-ревью каждого коммита PR силами нашего плагина `omnisgm` (скилл `omnisgm-review`) на `anthropics/claude-code-action@v1` — по образцу AllTrip.Backend, но в автоматическом режиме (`prompt` вместо @claude-упоминаний).

**Обновление:** воркер вынесен ОДНИМ экземпляром в `OmnisGM-App/claude-plugins/.github/workflows/claude-review.yml` (reusable, `workflow_call`); в этой репе остаётся тонкий вызов `uses: …@master` + `secrets: inherit` — триггеры, draft-фильтр и cancel-in-progress живут у вызывающего. Правка промта ревью делается в одном месте и подхватывается всеми репами без PR-волны. У репы плагинов включён доступ Actions уровня организации (иначе private reusable не резолвится).

## Как работает

- Триггер: `pull_request` (opened / synchronize / reopened / ready_for_review), драфты пропускаются.
- **Новый коммит стопает текущее ревью и запускает свежее**: `concurrency.group = claude-review-<PR>` + `cancel-in-progress: true`.
- Модель работает на **личной подписке** владельца: `claude_code_oauth_token` (Pro/Max, генерится `claude setup-token`).
- Плагин ставится из приватного маркетплейса `OmnisGM-App/claude-plugins` — клонится fine-grained PAT-ом в URL (секрет маскируется в логах Actions).
- Режим ревью — одиночный, §§1–5 скилла с CI-поправками: без прогонов/эмуляторов/песочниц, только дифф + опоры грепом; публикация одним review-объектом (тело-вердикт + полные инлайны); **без APPROVE/LGTM/мёржа** — финальный гейт остаётся за живой сессией.
- `runs-on: ubuntu-latest` намеренно (не self-hosted): ревью ничего не запускает, а на GitHub-раннере есть `gh` из коробки.

## Что нужно до мёржа (секреты, руками владельца)

- [ ] `CLAUDE_CODE_OAUTH_TOKEN` — локально `claude setup-token`, положить в секреты репы.
- [ ] `CLAUDE_PLUGINS_TOKEN` — fine-grained PAT с `contents: read` + `issues: write` только на `OmnisGM-App/claude-plugins`, положить в секреты репы.

## Цикл улучшения

После каждого ревью CI-ревьюер пишет наблюдение (что мешало, ложные срабатывания, недостающий класс проверки) комментом в журнал OmnisGM-App/claude-plugins#1 — если есть что сказать. Раз в неделю воркер `improve.yml` в репе плагинов сводит журнал в классы, правит SKILL.md/промты и открывает PR. Для записи в журнал PAT `CLAUDE_PLUGINS_TOKEN` нужен с правами `contents: read` + `issues: write` на claude-plugins.

Без секретов джоб честно упадёт на установке плагина/аутентификации — тихого зелёного не будет.
