### PR TITLE
[Deps] core 0.2.0 → 0.4.0, brand 0.9.0 → 0.10.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/sitemap": "^3.7.4",
-        "@omnisgm-app/brand": "^0.9.0",
-        "@omnisgm-app/core": "^0.2.0",
+        "@omnisgm-app/brand": "^0.10.0",
+        "@omnisgm-app/core": "^0.4.0",
         "astro": "^5.7.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-html": "^9.0.5",
@@ -2873,14 +2873,14 @@
       }
     },
     "node_modules/@omnisgm-app/brand": {
-      "version": "0.9.0",
-      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.9.0/15ff6bab6ace3e1d5058ed5ce7cbf86629bdecec",
-      "integrity": "sha512-2g1ehtCeSkVVxN5XmUEFcYAplXryOWSHLetpFCrIGk8NANzRXtrlwOaWEbfC5b+te9ONT/hRF9wxye/lhTW0+w=="
+      "version": "0.10.0",
+      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.10.0/8cf894b03f159d73c41a2dec8ebd7f958959619a",
+      "integrity": "sha512-akKqTUzAHCqQF2scBaYU3UGmDi903iVUNm/0RY1DH0Ylbv/+b/45MGLP2EeEVWk3CVJsyfw2oDpnVALN/ubjHw=="
     },
     "node_modules/@omnisgm-app/core": {
-      "version": "0.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/core/0.2.0/97a3824bb3be460fd251f98c677e8ef9a3aa685b",
-      "integrity": "sha512-64PT+MiFlcjFRUdYR+tFrpRrSu+UP6xknQkG0L8c2lu1BFuFNtSkIKl+82fONRSRmTLVZDEG9JpAyIwuKpjjpA=="
+      "version": "0.4.0",
+      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/core/0.4.0/39302ee1002f87c45015346a4dc782aaa8c58db5",
+      "integrity": "sha512-pvEUwp/YUuUDNOWMwryH9tP64dI5sttnJatXW3JnUuLn0YlDKtdiWIoEu2XKsLp/2DLKt/VypLrshM1HoC6wCg=="
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -22,8 +22,8 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.4",
-    "@omnisgm-app/brand": "^0.9.0",
-    "@omnisgm-app/core": "^0.2.0",
+    "@omnisgm-app/brand": "^0.10.0",
+    "@omnisgm-app/core": "^0.4.0",
     "astro": "^5.7.0",
     "hast-util-from-html": "^2.0.3",
     "hast-util-to-html": "^9.0.5",


### PR DESCRIPTION
## Что меняем и почему

Обе наших зависимости отстали на минорные версии, и сами бы не подтянулись: у пакетов `0.x` каретка минор не пускает — `^0.9.0` разрешает только `0.9.x`. То есть «обновится при следующем `npm ci`» здесь не работает в принципе, бамп нужен руками.

**`@omnisgm-app/core` 0.2.0 → 0.4.0.** В 0.3.0 в карту портов заехал блок `news-rules` (прогон `firestore.rules` у News держал шесть портов числами в самом продукте), в 0.4.0 — модуль `emulator-tools`. Rules берёт из пакета разбор слота и карту баз, так что на 0.2.0 гейт литеральных адресов сверялся с картой, в которой блоков четыре вместо пяти: занять порт, уже занятый соседним продуктом, можно было молча. Сам `emulator-tools` Rules не использует — своих эмуляторов у него нет.

**`@omnisgm-app/brand` 0.9.0 → 0.10.0.** Палитра бумаги `--og-print-*` плюс генератор SVG-принта; изменение аддитивное, существующие токены не тронуты. Table уже на 0.10.0 — этим бампом Rules и News к нему подтягиваются.

Вердикт: `astro check` — 0 ошибок, сборка 6020 страниц, гейт литеральных адресов и тайпчек инструментов зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpZFAJnWNgkswDmHd5KVhF
