### PR TITLE
[Assets] Раскладка ассетов — из кита (Core#1)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/sitemap": "^3.7.4",
-        "@omnisgm-app/brand": "^0.10.0",
+        "@omnisgm-app/brand": "^0.11.1",
         "@omnisgm-app/core": "^0.4.0",
         "astro": "^5.7.0",
         "hast-util-from-html": "^2.0.3",
@@ -2873,9 +2873,9 @@
       }
     },
     "node_modules/@omnisgm-app/brand": {
-      "version": "0.10.0",
-      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.10.0/8cf894b03f159d73c41a2dec8ebd7f958959619a",
-      "integrity": "sha512-akKqTUzAHCqQF2scBaYU3UGmDi903iVUNm/0RY1DH0Ylbv/+b/45MGLP2EeEVWk3CVJsyfw2oDpnVALN/ubjHw=="
+      "version": "0.11.1",
+      "resolved": "https://npm.pkg.github.com/download/@omnisgm-app/brand/0.11.1/75c0dd1c1ce44a704ef36a0115237fe8757ed53b",
+      "integrity": "sha512-iMfwaIkQrPSknkUxZzQKoxD3NLJcoUcgudcK9Y9XZcxYFy2ov/c0HM0w1zCRR5dXtRUWqfUxJ0p2nEyc33rbGQ=="
     },
     "node_modules/@omnisgm-app/core": {
       "version": "0.4.0",

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.4",
-    "@omnisgm-app/brand": "^0.10.0",
+    "@omnisgm-app/brand": "^0.11.1",
     "@omnisgm-app/core": "^0.4.0",
     "astro": "^5.7.0",
     "hast-util-from-html": "^2.0.3",

--- a/web/scripts/copy-brand-assets.mjs
+++ b/web/scripts/copy-brand-assets.mjs
@@ -8,6 +8,12 @@
 //
 // ОСТАЛОСЬ ЗДЕСЬ: карта имён и решение про 404. Имена у нас канонические — переименований нет,
 // в отличие от Table с его `pwa-512x512.png`.
+//
+// ОТДАНО КИТУ: шрифты self-host (#10) — все `*.woff2` уезжают в `public/fonts/`, на них
+// ссылается `@omnisgm-app/brand/fonts.css` (импортируется в `Reader.astro`), а число начертаний
+// пришпилено `e2e/pwa-sw.spec.ts` («ровно 18», не «больше нуля»). Раньше это была строка здесь;
+// теперь список ведёт кит, и здесь о нём только этот абзац — указатели из `Reader.astro` и
+// `web/.gitignore` приводят сюда.
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { copyBrandAssets } from '@omnisgm-app/brand/copy-assets';
@@ -19,7 +25,9 @@ copyBrandAssets({
     'favicon.svg', 'favicon.ico', 'icon.svg', 'maskable.svg',
     'icon-192.png', 'icon-512.png', 'maskable-192.png', 'maskable-512.png', 'apple-touch-icon.png',
   ],
-  // 404 кита НЕ берём: у нас своя `src/pages/404.astro` с навигацией сайта, а самодостаточный
-  // HTML кита рассчитан на продукт без своей вёрстки.
+  // 404 кита НЕ берём, и причина не в дизайне: `src/pages/404.astro` — ТОТ ЖЕ дизайн кита, но с
+  // Rules-спецификой (язык в home-ссылке `/en/` · `/ru/`, свои favicon/manifest). Причина
+  // механическая: `public/404.html` кита столкнулся бы с `dist/404.html`, который Astro генерит
+  // из этой страницы, — в `dist/` победил бы один из двух, и какой именно, зависело бы от порядка.
   notFound: false,
 });

--- a/web/scripts/copy-brand-assets.mjs
+++ b/web/scripts/copy-brand-assets.mjs
@@ -1,25 +1,25 @@
-// Копирует бренд-иконки из @omnisgm-app/brand в public/ — единый источник (кит).
-// Запускается на predev/prebuild. og.png остаётся per-app (свой текст), не трогаем.
-import { copyFileSync, mkdirSync, readdirSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+// Раскладка ассетов кита в public/ — обёртка над @omnisgm-app/brand/copy-assets (Core#1).
+//
+// Копирование жило тремя копиями (Table, News, здесь) и разошлось не только картой имён, но и
+// механикой: Table резолвил ассеты через `require.resolve` (в workspaces кит hoist'ится в
+// корневой node_modules), а здесь путь `node_modules/@omnisgm-app/brand/assets` складывался
+// руками — то есть работало ровно до первого переезда в workspace. Теперь копирует кит, и
+// резолва у потребителя нет вовсе: файлы считаются от модуля изнутри пакета.
+//
+// ОСТАЛОСЬ ЗДЕСЬ: карта имён и решение про 404. Имена у нас канонические — переименований нет,
+// в отличие от Table с его `pwa-512x512.png`.
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { copyBrandAssets } from '@omnisgm-app/brand/copy-assets';
 
-const root = join(dirname(fileURLToPath(import.meta.url)), '..');
-const src = join(root, 'node_modules', '@omnisgm-app', 'brand', 'assets');
-const pub = join(root, 'public');
-mkdirSync(pub, { recursive: true });
-
-const FILES = [
-  'favicon.svg', 'favicon.ico', 'icon.svg', 'maskable.svg',
-  'icon-192.png', 'icon-512.png', 'maskable-192.png', 'maskable-512.png', 'apple-touch-icon.png',
-];
-for (const f of FILES) copyFileSync(join(src, f), join(pub, f));
-console.log(`✓ бренд-иконки скопированы из @omnisgm-app/brand (${FILES.length} файлов)`);
-
-// Шрифты (self-host, #10): assets/fonts/*.woff2 → public/fonts/ (fonts.css ссылается на /fonts/*).
-const fontsSrc = join(src, 'fonts');
-const fontsDest = join(pub, 'fonts');
-mkdirSync(fontsDest, { recursive: true });
-const woff2 = readdirSync(fontsSrc).filter((f) => f.endsWith('.woff2'));
-for (const f of woff2) copyFileSync(join(fontsSrc, f), join(fontsDest, f));
-console.log(`✓ шрифты скопированы из @omnisgm-app/brand (${woff2.length} woff2) → public/fonts/`);
+copyBrandAssets({
+  publicDir: join(dirname(fileURLToPath(import.meta.url)), '..', 'public'),
+  // og.png остаётся per-app (свой текст), поэтому кит его не отдаёт и здесь его нет.
+  icons: [
+    'favicon.svg', 'favicon.ico', 'icon.svg', 'maskable.svg',
+    'icon-192.png', 'icon-512.png', 'maskable-192.png', 'maskable-512.png', 'apple-touch-icon.png',
+  ],
+  // 404 кита НЕ берём: у нас своя `src/pages/404.astro` с навигацией сайта, а самодостаточный
+  // HTML кита рассчитан на продукт без своей вёрстки.
+  notFound: false,
+});


### PR DESCRIPTION
## Что меняем и почему

`scripts/copy-brand-assets.mjs` был одной из **трёх копий** (здесь, Table, News), и копии разошлись не только картой имён — она и обязана быть разной, — но и механикой:

| | здесь | Table | News |
|---|---|---|---|
| резолв ассетов | путь руками | `require.resolve` | путь руками |
| 404 из кита | нет | да | да |

Резолв — не вкусовщина: в workspaces кит hoist'ится в **корневой** `node_modules`, и путь «мой каталог плюс `node_modules/@omnisgm-app/brand`» там не существует. Table это знал, мы — нет; наша форма сломалась бы при первом переезде в workspace.

Теперь копирует сам кит ([Brand#34](https://github.com/OmnisGM-App/OmnisGM-Brand/pull/34)), и **задача резолва у потребителя исчезла как класс**: файлы считаются от `import.meta.url` изнутри пакета.

У нас остаётся карта имён (канонические, переименований нет) и решение про 404: **не берём** — есть своя `src/pages/404.astro` с навигацией сайта, а самодостаточный HTML кита рассчитан на продукт без своей вёрстки. Раньше это различие выражалось отсутствием строки в одной из трёх копий; теперь это параметр `notFound: false` с объяснением по месту.

Кит берём **0.11.1**, а не 0.11.0: на 0.11.0 `lint:tools` падал `TS7016` — TypeScript не читает JSDoc внутри `node_modules` даже при `allowJs`+`checkJs`, и декларация приехала отдельным ПР ([Brand#35](https://github.com/OmnisGM-App/OmnisGM-Brand/pull/35)); эта обёртка её и поймала.

## Проверки

- **`public/` байт-в-байт как до правки**: снял копию каталога, снёс все файлы кита, разложил заново — `diff -r` пуст (9 иконок + 18 woff2).
- `npm run lint:tools` чист (на 0.11.0 краснел — см. выше), сборка **6020 страниц** зелёная, `postbuild` проставил lastmod 5982 URL.

Часть Core#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpZFAJnWNgkswDmHd5KVhF
